### PR TITLE
`as_model` wraps function arguments in `Data` if they support it.

### DIFF
--- a/tests/model/test_model_api.py
+++ b/tests/model/test_model_api.py
@@ -25,5 +25,14 @@ def test_logp():
 
     mw2 = model_wrapped2(coords=coords)
 
+    @pmx.as_model()
+    def model_wrapped3(mu):
+        pm.Normal("x", mu, 1.0, dims="obs")
+
+    mw3 = model_wrapped3(0.0, coords=coords)
+    mw4 = model_wrapped3(np.array([np.nan]), coords=coords)
+
     np.testing.assert_equal(model.point_logps(), mw.point_logps())
     np.testing.assert_equal(mw.point_logps(), mw2.point_logps())
+    assert mw3["mu"] in mw3.data_vars
+    assert "mu" not in mw4


### PR DESCRIPTION
This extends `as_model` to wrap the function arguments in `pm.Data`

The motivation for this is that often what gets resampled when running `sample_posterior_predictive` is dependent on what variables are shared. This makes lots of default behaviour less surprising. It also makes it easier to adapt models made with `as_model` into workflows which rely on `set_data`