### PR TITLE
Fix group selection in `sample_posterior_predictive` when `predictions=True` is passed in kwargs

### DIFF
--- a/pymc_extras/model_builder.py
+++ b/pymc_extras/model_builder.py
@@ -650,8 +650,11 @@ class ModelBuilder:
             if extend_idata:
                 self.idata.extend(post_pred, join="right")
 
+        # Determine the correct group dynamically
+        group_name = "predictions" if kwargs.get("predictions", False) else "posterior_predictive"
+
         posterior_predictive_samples = az.extract(
-            post_pred, "posterior_predictive", combined=combined
+            post_pred, group_name, combined=combined
         )
 
         return posterior_predictive_samples


### PR DESCRIPTION
### Summary
Fixes hard-coded group selection in `sample_posterior_predictive` which unnecessarily restricts usage of predict functions. Previously, if `predictions=True` (ideally set in `pm.sample_posterior_predictive' when predicting out-of-sample) is passed to the predict functions the function always extracted from `"posterior_predictive"` which doesn't exist in the dataframe when `predictions = True`.

### Changes
Selects appropriate group depending if `predictions` is passed.
