### PR TITLE
Remove MvNormalSVD Class

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -28,7 +28,6 @@ from pymc_extras.statespace.filters import (
 )
 from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
-    MvNormalSVD,
     SequenceMvNormal,
 )
 from pymc_extras.statespace.filters.utilities import stabilize
@@ -2233,7 +2232,9 @@ class PyMCStateSpace:
             if shock_trajectory is None:
                 shock_trajectory = pt.zeros((n_steps, self.k_posdef))
                 if Q is not None:
-                    init_shock = MvNormalSVD("initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM])
+                    init_shock = pm.MvNormal(
+                        "initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM], method="svd"
+                    )
                 else:
                     init_shock = pm.Deterministic(
                         "initial_shock",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ filterwarnings =[
   # Warning coming from blackjax
   'ignore:jax\.tree_map is deprecated:DeprecationWarning',
 
-  # Ignore PyMC use of numpy.core
+  # PyMC uses numpy.core functions, which emits an warning as of numpy>2.0
   'ignore:numpy\.core\.numeric is deprecated:DeprecationWarning',
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pymc>=5.21
+pymc>=5.21.1
 scikit-learn
 better-optimize


### PR DESCRIPTION
This is no longer necessary as of `pymc==5.21.1`, because `MvNormal` now has a `method="svd"` argument that can be used. This will also make sampling more robust in non-jax backends, which is also great!

Also updates the version requirement to 5.21.1 as a result