### PR TITLE
Make index check on statespace data less strict

### DIFF
--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -114,9 +114,6 @@ def preprocess_pandas_data(data, n_obs, obs_coords=None, check_column_names=Fals
         if not np.issubdtype(index.dtype, np.integer):
             raise IndexError("Provided index is not an integer index.")
 
-        if not index.is_monotonic_increasing:
-            raise IndexError("Provided index is not monotonic increasing.")
-
         index_diff = index.to_series().diff().dropna().values
         if not (index_diff == 1).all():
             raise IndexError("Provided index is not monotonic increasing.")

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -87,18 +87,18 @@ def preprocess_pandas_data(data, n_obs, obs_coords=None, check_column_names=Fals
     col_names = data.columns
     _validate_data_shape(data.shape, n_obs, obs_coords, check_column_names, col_names)
 
-    if isinstance(data.index, pd.RangeIndex):
-        if obs_coords is not None:
-            warnings.warn(NO_TIME_INDEX_WARNING)
-        return preprocess_numpy_data(data.values, n_obs, obs_coords)
-
-    elif isinstance(data.index, pd.DatetimeIndex):
+    if isinstance(data.index, pd.DatetimeIndex):
         if data.index.freq is None:
             warnings.warn(NO_FREQ_INFO_WARNING)
             data.index.freq = data.index.inferred_freq
 
         index = data.index
         return data.values, index
+
+    elif isinstance(data.index, pd.Index):
+        if obs_coords is not None:
+            warnings.warn(NO_TIME_INDEX_WARNING)
+        return preprocess_numpy_data(data.values, n_obs, obs_coords)
 
     else:
         raise IndexError(


### PR DESCRIPTION
Closes #384 

I was assuming that any pandas index of integers was a `RangeIndex`; this will now accept anything. 

One issue is that if the index has holes (like the index goes 0, 1, 3, 4, ...), it will just be totally ignored, and internally we'll treat it *as though* it was continuous. I might be able to check for this, but it might also be the type of thing that you have to trust users to do the right thing with. Open to suggestions.