### PR TITLE
add python 3.13 to the list

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Apache Software License",
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering",


### PR DESCRIPTION
This was missing the pymc 5.21.0 brought in python 3.13 

Reference: 

https://github.com/pymc-devs/pymc/releases
