### PR TITLE
Small typos corrections in notebooks SARMA and VARMAX examples

### DIFF
--- a/notebooks/VARMAX Example.ipynb
+++ b/notebooks/VARMAX Example.ipynb
@@ -214,10 +214,10 @@
    "source": [
     "# PyMC Statespace\n",
     "\n",
-    "To fit a VAR model with `pymc-statespace`, use the `BayesianVARMAX` model. We will recieve a message giving the names of the parameters we need to set priors for. In this case, we need:\n",
+    "To fit a VAR model with `pymc-statespace`, use the `BayesianVARMAX` model. We will receive a message giving the names of the parameters we need to set priors for. In this case, we need:\n",
     "\n",
     "- `x0`, a guess at the initial state of the system. \n",
-    "- `P0`, a guess at the initial covaraince of the system\n",
+    "- `P0`, a guess at the initial covariance of the system\n",
     "- `ar_params`, the autoregressive parameters\n",
     "- `state_cov`, the covariance matrix of the shocks to the system\n",
     "\n",
@@ -348,7 +348,7 @@
    "id": "16f65990-6343-4cff-ae14-8ba6ea91dbb7",
    "metadata": {},
    "source": [
-    "For readibility in the PyMC model block, we can unpack them into separate variables"
+    "For readability in the PyMC model block, we can unpack them into separate variables"
    ]
   },
   {
@@ -409,7 +409,7 @@
     "2. Ravel all these variables and concatenate them together into a single vector called \"theta\".\n",
     "3. One variable at a time, read \"theta\" like tape. For each chunk of variables, reshape them into the expected shape and put them in the correct location in the correct matrix.\n",
     "\n",
-    "We are worried about where the `ar_coefs` end up, so let's look at an example. We start with a 3d tensor, because PyMC makes it really easy to decalare the variables that way. It will look like a matrix of three 3-by-2 matrices:\n",
+    "We are worried about where the `ar_coefs` end up, so let's look at an example. We start with a 3d tensor, because PyMC makes it really easy to declare the variables that way. It will look like a matrix of three 3-by-2 matrices:\n",
     "\n",
     "$\\begin{bmatrix}\n",
     "\\begin{bmatrix} a_{x,1,x} & a_{x,1,y} & a_{x,1,z} \\\\ a_{x,2,x} & a_{x,2,y} & a_{x,2,z} \\end{bmatrix} \\\\\n",
@@ -951,12 +951,12 @@
    "source": [
     "# Stability Analysis\n",
     "\n",
-    "We can get posterior eigenvalues of the transition matrix to better understand the range of dynamics our model believes are possible. Unforunately we can't use `sample_posterior_predictive` to help us do that, because `pt.linalg.eig` discards the imaginary eigenvalues. Instead, we have to use `xarray.apply_ufunc`.  "
+    "We can get posterior eigenvalues of the transition matrix to better understand the range of dynamics our model believes are possible. Unfortunately we can't use `sample_posterior_predictive` to help us do that, because `pt.linalg.eig` discards the imaginary eigenvalues. Instead, we have to use `xarray.apply_ufunc`.  "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "81362229",
    "metadata": {},
    "outputs": [
@@ -993,7 +993,7 @@
     }
    ],
    "source": [
-    "# By deafult we don't store the statespace matrices in idata at sampling time, so we need to go back and sample them.\n",
+    "# By default we don't store the statespace matrices in idata at sampling time, so we need to go back and sample them.\n",
     "# The sample_statespace_matrices class is a helper to do this.\n",
     "\n",
     "matrix_idata = bvar_mod.sample_statespace_matrices(idata, [\"T\"])"
@@ -1178,7 +1178,7 @@
    "source": [
     "Another interesting thing to do is look at the dynamics of samples where the eigenvalues are maximally imaginary. First of all, it's a sanity check on the `xr.apply_ufunc`, which is non-trivial to use. But secondly, it's interesting to see periodic dynamics. Some macroeconomic models seek imaginary eigenvalues as a way to generating business cycles. \n",
     "\n",
-    "For this sample, we can see some convergant osciallating behavior in the IRFs."
+    "For this sample, we can see some convergent oscillating behavior in the IRFs."
    ]
   },
   {
@@ -1324,7 +1324,7 @@
    "id": "dd0ed7f8",
    "metadata": {},
    "source": [
-    "## Forcasting"
+    "## Forecasting"
    ]
   },
   {


### PR DESCRIPTION
This PR fixes some typographical errors in the SARMA and VARMAX example notebooks.