### PR TITLE
Fix failed test related to PR #443 by replacing `pt.batched_dot` with `pt.vectorize(pt.dot,...)`

### DIFF
--- a/pymc_extras/inference/fit.py
+++ b/pymc_extras/inference/fit.py
@@ -11,9 +11,10 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+import arviz as az
 
 
-def fit(method, **kwargs):
+def fit(method: str, **kwargs) -> az.InferenceData:
     """
     Fit a model with an inference algorithm
 

--- a/pymc_extras/inference/pathfinder/pathfinder.py
+++ b/pymc_extras/inference/pathfinder/pathfinder.py
@@ -40,7 +40,7 @@ from pymc.initial_point import make_initial_point_fn
 from pymc.model import modelcontext
 from pymc.model.core import Point
 from pymc.pytensorf import (
-    compile_pymc,
+    compile,
     find_rng_nodes,
     reseed_rngs,
 )
@@ -77,7 +77,9 @@ from pymc_extras.inference.pathfinder.lbfgs import (
 
 logger = logging.getLogger(__name__)
 _warnings.filterwarnings(
-    "ignore", category=FutureWarning, message="compile_pymc was renamed to compile"
+    "ignore",
+    category=UserWarning,
+    message="The same einsum subscript is used for a broadcastable and non-broadcastable dimension",
 )
 
 REGULARISATION_TERM = 1e-8
@@ -142,7 +144,7 @@ def get_logp_dlogp_of_ravel_inputs(
         [model.logp(jacobian=jacobian), model.dlogp(jacobian=jacobian)],
         model.value_vars,
     )
-    logp_dlogp_fn = compile_pymc([inputs], (logP, dlogP), **compile_kwargs)
+    logp_dlogp_fn = compile([inputs], (logP, dlogP), **compile_kwargs)
     logp_dlogp_fn.trust_input = True
 
     return logp_dlogp_fn
@@ -502,7 +504,7 @@ def bfgs_sample_dense(
 
     logdet = 2.0 * pt.sum(pt.log(pt.abs(pt.diagonal(Lchol, axis1=-2, axis2=-1))), axis=-1)
 
-    mu = x - pt.batched_dot(H_inv, g)
+    mu = x - pt.einsum("ijk,ik->ij", H_inv, g)
 
     phi = pt.matrix_transpose(
         # (L, N, 1)
@@ -571,15 +573,12 @@ def bfgs_sample_sparse(
     logdet = 2.0 * pt.sum(pt.log(pt.abs(pt.diagonal(Lchol, axis1=-2, axis2=-1))), axis=-1)
     logdet += pt.sum(pt.log(alpha), axis=-1)
 
+    # inverse Hessian
+    # (L, N, N) + (L, N, 2J), (L, 2J, 2J), (L, 2J, N) -> (L, N, N)
+    H_inv = alpha_diag + (beta @ gamma @ pt.matrix_transpose(beta))
+
     # NOTE: changed the sign from "x + " to "x -" of the expression to match Stan which differs from Zhang et al., (2022). same for dense version.
-    mu = x - (
-        # (L, N), (L, N) -> (L, N)
-        pt.batched_dot(alpha_diag, g)
-        # beta @ gamma @ beta.T
-        # (L, N, 2J), (L, 2J, 2J), (L, 2J, N) -> (L, N, N)
-        # (L, N, N), (L, N) -> (L, N)
-        + pt.batched_dot((beta @ gamma @ pt.matrix_transpose(beta)), g)
-    )
+    mu = x - pt.einsum("ijk,ik->ij", H_inv, g)
 
     phi = pt.matrix_transpose(
         # (L, N, 1)
@@ -853,7 +852,7 @@ def make_pathfinder_body(
 
     # return psi, logP_psi, logQ_psi, elbo_argmax
 
-    pathfinder_body_fn = compile_pymc(
+    pathfinder_body_fn = compile(
         [x_full, g_full],
         [psi, logP_psi, logQ_psi, elbo_argmax],
         **compile_kwargs,

--- a/pymc_extras/inference/pathfinder/pathfinder.py
+++ b/pymc_extras/inference/pathfinder/pathfinder.py
@@ -21,11 +21,9 @@ from collections import Counter
 from collections.abc import Callable, Iterator
 from dataclasses import asdict, dataclass, field, replace
 from enum import Enum, auto
-from importlib.util import find_spec
 from typing import Literal, TypeAlias
 
 import arviz as az
-import blackjax
 import filelock
 import jax
 import numpy as np
@@ -1736,8 +1734,8 @@ def fit_pathfinder(
         )
         pathfinder_samples = mp_result.samples
     elif inference_backend == "blackjax":
-        if find_spec("blackjax") is None:
-            raise RuntimeError("Need BlackJAX to use `pathfinder`")
+        import blackjax
+
         if version.parse(blackjax.__version__).major < 1:
             raise ImportError("fit_pathfinder requires blackjax 1.0 or above")
 

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -18,10 +18,6 @@ import numpy as np
 import pymc as pm
 import pytest
 
-pytestmark = pytest.mark.filterwarnings(
-    "ignore:The same einsum subscript is used for a broadcastable and non-broadcastable dimension:UserWarning"
-)
-
 import pymc_extras as pmx
 
 
@@ -55,6 +51,7 @@ def reference_idata():
 
 
 @pytest.mark.parametrize("inference_backend", ["pymc", "blackjax"])
+@pytest.mark.filterwarnings("ignore:JAXopt is no longer maintained.:DeprecationWarning")
 def test_pathfinder(inference_backend, reference_idata):
     if inference_backend == "blackjax" and sys.platform == "win32":
         pytest.skip("JAX not supported on windows")

--- a/tests/test_pathfinder.py
+++ b/tests/test_pathfinder.py
@@ -18,7 +18,9 @@ import numpy as np
 import pymc as pm
 import pytest
 
-pytestmark = pytest.mark.filterwarnings("ignore:compile_pymc was renamed to compile:FutureWarning")
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:The same einsum subscript is used for a broadcastable and non-broadcastable dimension:UserWarning"
+)
 
 import pymc_extras as pmx
 


### PR DESCRIPTION
Fix failed test from PR #443 and replace `pt.batched_dot` with `pt.einsum`

* Modified the calculation of `mu` in `bfgs_sample_dense` and `bfgs_sample_sparse` to use `einsum` instead of the deprecated `batched_dot` function.
* Added calculations for `H_inv` in `bfgs_sample_sparse` to improve readability.
* Renamed `compile_pymc` to `compile` in pathfinder functions to reflect API changes.
* Updated warning filters to ignore UserWarnings related to einsum subscripts.