### PR TITLE
Allow `method="basinhopping"` in `find_MAP` and `fit_laplace`

### DIFF
--- a/pymc_extras/inference/laplace.py
+++ b/pymc_extras/inference/laplace.py
@@ -416,7 +416,7 @@ def sample_laplace_posterior(
 
 
 def fit_laplace(
-    optimize_method: minimize_method = "BFGS",
+    optimize_method: minimize_method | Literal["basinhopping"] = "BFGS",
     *,
     model: pm.Model | None = None,
     use_grad: bool | None = None,
@@ -449,8 +449,11 @@ def fit_laplace(
     ----------
     model : pm.Model
         The PyMC model to be fit. If None, the current model context is used.
-    optimize_method : str
-        The optimization method to use. See scipy.optimize.minimize documentation for details.
+    method : str
+        The optimization method to use. Valid choices are: Nelder-Mead, Powell, CG, BFGS, L-BFGS-B, TNC, SLSQP,
+        trust-constr, dogleg, trust-ncg, trust-exact, trust-krylov, and basinhopping.
+
+        See scipy.optimize.minimize documentation for details.
     use_grad : bool | None, optional
         Whether to use gradients in the optimization. Defaults to None, which determines this automatically based on
         the ``method``.
@@ -500,10 +503,10 @@ def fit_laplace(
     diag_jitter: float | None
         A small value added to the diagonal of the inverse Hessian matrix to ensure it is positive semi-definite.
         If None, no jitter is added. Default is 1e-8.
-    optimizer_kwargs: dict, optional
-        Additional keyword arguments to pass to scipy.minimize. See the documentation for scipy.optimize.minimize for
-        details. Arguments that are typically passed via ``options`` will be automatically extracted without the need
-        to use a nested dictionary.
+    optimizer_kwargs
+        Additional keyword arguments to pass to the ``scipy.optimize`` function being used. Unless
+        ``method = "basinhopping"``, ``scipy.optimize.minimize`` will be used. For ``basinhopping``,
+        ``scipy.optimize.basinhopping`` will be used. See the documentation of these functions for details.
     compile_kwargs: dict, optional
         Additional keyword arguments to pass to pytensor.function.
 

--- a/tests/test_find_map.py
+++ b/tests/test_find_map.py
@@ -124,3 +124,35 @@ def test_JAX_map_shared_variables():
 
     assert np.isclose(mu_hat, 3, atol=0.5)
     assert np.isclose(np.exp(log_sigma_hat), 1.5, atol=0.5)
+
+
+@pytest.mark.parametrize(
+    "method, use_grad, use_hess, use_hessp",
+    [
+        ("nelder-mead", False, False, False),
+        ("L-BFGS-B", True, False, False),
+        ("trust-exact", True, True, False),
+        ("trust-ncg", True, False, True),
+    ],
+)
+def test_find_MAP_basinhopping(method, use_grad, use_hess, use_hessp, rng):
+    with pm.Model() as m:
+        mu = pm.Normal("mu")
+        sigma = pm.Exponential("sigma", 1)
+        pm.Normal("y_hat", mu=mu, sigma=sigma, observed=rng.normal(loc=3, scale=1.5, size=100))
+
+        optimized_point = find_MAP(
+            method="basinhopping",
+            use_grad=use_grad,
+            use_hess=use_hess,
+            use_hessp=use_hessp,
+            progressbar=False,
+            gradient_backend="pytensor",
+            compile_kwargs={"mode": "JAX"},
+            minimizer_kwargs=dict(method=method),
+        )
+
+    mu_hat, log_sigma_hat = optimized_point["mu"], optimized_point["sigma_log__"]
+
+    assert np.isclose(mu_hat, 3, atol=0.5)
+    assert np.isclose(np.exp(log_sigma_hat), 1.5, atol=0.5)


### PR DESCRIPTION
Closes #454 

This PR lets users use the `basinhopping` algorithm to fit PyMC models. This is in the class of simulated annealing algorithms, except that it also runs an inner optimization loop to find the nearest minimum after proposing a new starting position. 

API is pretty clean, if I do say so myself:

```py
    with pm.Model() as m:
        mu = pm.Normal("mu")
        sigma = pm.Exponential("sigma", 1)
        pm.Normal("y_hat", mu=mu, sigma=sigma, observed=rng.normal(loc=3, scale=1.5, size=100))

        optimized_point = find_MAP(
            method="basinhopping",
            use_grad=True,
            use_hess=False,
            use_hessp=True,
            progressbar=True,
            gradient_backend="pytensor",
            compile_kwargs={"mode": "JAX"},
            minimizer_kwargs=dict(method="trust-ncg"),
        )
```

Gives:
```
  Process                            Elapsed   Iteration   Step    Target   Objective     ||grad|| 
 ──────────────────────────────────────────────────────────────────────────────────────────────────
  Basinhopping   ━━━━━━━━━━━━━━━━━   0:00:02   100/100     0.617   0.500    186.98814     0.00000
  Minimize       ━━━━━━━━━━━━━━━━━   0:00:00   8/8         0.000   0.000    34964.56397   0.00000
```

The top progress bar shows the overall algorithm, the current step, the target step size, current best objective function, and the gradient at that current best. The bottom shows progress on the inner optimization loop, so it gets updated a lot. You can see here that the final inner optimization went somewhere stupid, so the objective value is very high.