### PR TITLE
Fix bug in `fit_MAP` when shared variables are used in graph

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -6,7 +6,7 @@ dependencies:
 - pymc>=5.21
 - pytest-cov>=2.5
 - pytest>=3.0
-- dask
+- dask<2025.1.1
 - xhistogram
 - statsmodels
 - numba<=0.60.0

--- a/conda-envs/windows-environment-test.yml
+++ b/conda-envs/windows-environment-test.yml
@@ -6,7 +6,7 @@ dependencies:
 - pip
 - pytest-cov>=2.5
 - pytest>=3.0
-- dask
+- dask<2025.1.1
 - xhistogram
 - statsmodels
 - numba<=0.60.0

--- a/pymc_extras/inference/find_map.py
+++ b/pymc_extras/inference/find_map.py
@@ -15,7 +15,6 @@ from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.initial_point import make_initial_point_fn
 from pymc.model.transform.optimization import freeze_dims_and_data
 from pymc.pytensorf import join_nonshared_inputs
-from pymc.sampling.jax import _replace_shared_variables
 from pymc.util import get_default_varnames
 from pytensor.compile import Function
 from pytensor.compile.mode import Mode
@@ -306,6 +305,8 @@ def scipy_optimize_funcs_from_loss(
     # computing jax gradients, we discard the function wrapper, so we can't handle shared variables --> rewrite them
     # away.
     if use_jax_gradients:
+        from pymc.sampling.jax import _replace_shared_variables
+
         [loss] = _replace_shared_variables([loss])
 
     compute_grad = use_grad and not use_jax_gradients

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ with open(DEV_REQUIREMENTS_FILE) as f:
 
 
 extras_require = dict(
-    dask_histogram=["dask[complete]", "xhistogram"],
+    dask_histogram=["dask[complete]<2025.1.1", "xhistogram"],
     histogram=["xhistogram"],
 )
 extras_require["complete"] = sorted(set(itertools.chain.from_iterable(extras_require.values())))

--- a/tests/test_find_map.py
+++ b/tests/test_find_map.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pymc as pm
+import pytensor
 import pytensor.tensor as pt
 import pytest
 
@@ -95,6 +96,28 @@ def test_JAX_map(method, use_grad, use_hess, use_hessp, gradient_backend: Gradie
             use_hessp=use_hessp,
             progressbar=False,
             gradient_backend=gradient_backend,
+            compile_kwargs={"mode": "JAX"},
+        )
+    mu_hat, log_sigma_hat = optimized_point["mu"], optimized_point["sigma_log__"]
+
+    assert np.isclose(mu_hat, 3, atol=0.5)
+    assert np.isclose(np.exp(log_sigma_hat), 1.5, atol=0.5)
+
+
+def test_JAX_map_shared_variables():
+    with pm.Model() as m:
+        data = pytensor.shared(np.random.normal(loc=3, scale=1.5, size=100), name="shared_data")
+        mu = pm.Normal("mu")
+        sigma = pm.Exponential("sigma", 1)
+        y_hat = pm.Normal("y_hat", mu=mu, sigma=sigma, observed=data)
+
+        optimized_point = find_MAP(
+            method="L-BFGS-B",
+            use_grad=True,
+            use_hess=False,
+            use_hessp=False,
+            progressbar=False,
+            gradient_backend="jax",
             compile_kwargs={"mode": "JAX"},
         )
     mu_hat, log_sigma_hat = optimized_point["mu"], optimized_point["sigma_log__"]


### PR DESCRIPTION
Currently, `fit_MAP` fails on graphs with shared variables when `gradient_backend='jax'`. This is because we are discarding the pytensor function wrapper that helps work with them. This PR rewrites shared variables into constants using `_replace_shared_variables` in this case. This is the same approach used in `pymc.sampling.jax.get_jaxified_graph` 