### PR TITLE
Add version pin on better-optimize

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pymc>=5.21.1
   - scikit-learn
-  - better-optimize
+  - better-optimize>=0.1.2
   - dask<2025.1.1
   - xhistogram
   - statsmodels

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
   "pymc>=5.21.1",
   "scikit-learn",
-  "better-optimize"
+  "better-optimize>=0.1.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
Closes #479 . I guess the issue is related to support for `basinhopping`, which requires the latest version of better-optimize.