### PR TITLE
Remove `mode` argument passed from Statespace.build_statespace_graph to scan

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1136,12 +1136,6 @@ class PyMCStateSpace:
 
         return [x0, P0, c, d, T, Z, R, H, Q], grouped_outputs
 
-    def _set_default_mode(self, compile_kwargs):
-        mode = compile_kwargs.get("mode", self.mode)
-        compile_kwargs["mode"] = mode
-
-        return compile_kwargs
-
     def _sample_conditional(
         self,
         idata: InferenceData,
@@ -1194,7 +1188,7 @@ class PyMCStateSpace:
         group_idata = getattr(idata, group)
 
         compile_kwargs = kwargs.pop("compile_kwargs", {})
-        compile_kwargs = self._set_default_mode(compile_kwargs)
+        compile_kwargs.setdefault("mode", self.mode)
 
         with pm.Model(coords=self._fit_coords) as forward_model:
             (
@@ -1330,7 +1324,7 @@ class PyMCStateSpace:
         _verify_group(group)
 
         compile_kwargs = kwargs.pop("compile_kwargs", {})
-        compile_kwargs = self._set_default_mode(compile_kwargs)
+        compile_kwargs.setdefault("mode", self.mode)
 
         group_idata = getattr(idata, group)
         dims = None
@@ -1645,7 +1639,7 @@ class PyMCStateSpace:
         _verify_group(group)
 
         compile_kwargs = kwargs.pop("compile_kwargs", {})
-        compile_kwargs = self._set_default_mode(compile_kwargs)
+        compile_kwargs.setdefault("mode", self.mode)
 
         if matrix_names is None:
             matrix_names = MATRIX_NAMES
@@ -2150,7 +2144,7 @@ class PyMCStateSpace:
         _validate_filter_arg(filter_output)
 
         compile_kwargs = kwargs.pop("compile_kwargs", {})
-        compile_kwargs = self._set_default_mode(compile_kwargs)
+        compile_kwargs.setdefault("mode", self.mode)
 
         time_index = self._get_fit_time_index()
 
@@ -2343,7 +2337,7 @@ class PyMCStateSpace:
         Q = None  # No covariance matrix needed if a trajectory is provided. Will be overwritten later if needed.
 
         compile_kwargs = kwargs.pop("compile_kwargs", {})
-        compile_kwargs = self._set_default_mode(compile_kwargs)
+        compile_kwargs.setdefault("mode", self.mode)
 
         if n_options > 1:
             raise ValueError("Specify exactly 0 or 1 of shock_size, shock_cov, or shock_trajectory")

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -69,7 +69,6 @@ class _LinearGaussianStateSpace(Continuous):
         H,
         Q,
         steps=None,
-        mode=None,
         sequence_names=None,
         append_x0=True,
         method="svd",
@@ -98,7 +97,6 @@ class _LinearGaussianStateSpace(Continuous):
             H,
             Q,
             steps=steps,
-            mode=mode,
             sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,
@@ -118,7 +116,6 @@ class _LinearGaussianStateSpace(Continuous):
         H,
         Q,
         steps=None,
-        mode=None,
         sequence_names=None,
         append_x0=True,
         method="svd",
@@ -135,7 +132,6 @@ class _LinearGaussianStateSpace(Continuous):
 
         return super().dist(
             [a0, P0, c, d, T, Z, R, H, Q, steps],
-            mode=mode,
             sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,
@@ -156,7 +152,6 @@ class _LinearGaussianStateSpace(Continuous):
         Q,
         steps,
         size=None,
-        mode=None,
         sequence_names=None,
         append_x0=True,
         method="svd",
@@ -240,7 +235,6 @@ class _LinearGaussianStateSpace(Continuous):
             sequences=None if len(sequences) == 0 else sequences,
             non_sequences=[*non_sequences, rng],
             n_steps=steps,
-            mode=mode,
             strict=True,
         )
 
@@ -284,7 +278,6 @@ class LinearGaussianStateSpace(Continuous):
         steps,
         k_endog=None,
         sequence_names=None,
-        mode=None,
         append_x0=True,
         method="svd",
         **kwargs,
@@ -313,7 +306,6 @@ class LinearGaussianStateSpace(Continuous):
             H,
             Q,
             steps=steps,
-            mode=mode,
             sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -5,7 +5,6 @@ import pytensor
 import pytensor.tensor as pt
 
 from pymc.pytensorf import constant_fold
-from pytensor.compile.mode import get_mode
 from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
 from pytensor.tensor import TensorVariable
@@ -28,14 +27,9 @@ assert_time_varying_dim_correct = Assert(
 
 
 class BaseFilter(ABC):
-    def __init__(self, mode=None):
+    def __init__(self):
         """
         Kalman Filter.
-
-        Parameters
-        ----------
-        mode : str, optional
-            The mode used for Pytensor compilation. Defaults to None.
 
         Notes
         -----
@@ -44,9 +38,6 @@ class BaseFilter(ABC):
 
         Attributes
         ----------
-        mode : str or None
-            The mode used for Pytensor compilation.
-
         seq_names : list[str]
             A list of name representing time-varying statespace matrices. That is, inputs that will need to be
             provided to the `sequences` argument of `pytensor.scan`
@@ -56,7 +47,6 @@ class BaseFilter(ABC):
             to the `non_sequences` argument of `pytensor.scan`
         """
 
-        self.mode: str = mode
         self.seq_names: list[str] = []
         self.non_seq_names: list[str] = []
 
@@ -153,7 +143,6 @@ class BaseFilter(ABC):
         R,
         H,
         Q,
-        mode=None,
         return_updates=False,
         missing_fill_value=None,
         cov_jitter=None,
@@ -165,9 +154,6 @@ class BaseFilter(ABC):
         ----------
         data : TensorVariable
             Data to be filtered
-
-        mode : optional, str
-            Pytensor compile mode, passed to pytensor.scan
 
         return_updates: bool, default False
             Whether to return updates associated with the pytensor scan. Should only be requried to debug pruposes.
@@ -199,7 +185,6 @@ class BaseFilter(ABC):
         if cov_jitter is None:
             cov_jitter = JITTER_DEFAULT
 
-        self.mode = mode
         self.missing_fill_value = missing_fill_value
         self.cov_jitter = cov_jitter
 
@@ -227,7 +212,6 @@ class BaseFilter(ABC):
             outputs_info=[None, a0, None, None, P0, None, None],
             non_sequences=non_sequences,
             name="forward_kalman_pass",
-            mode=get_mode(self.mode),
             strict=False,
         )
 
@@ -800,7 +784,6 @@ class UnivariateFilter(BaseFilter):
             self._univariate_inner_filter_step,
             sequences=[y_masked, Z_masked, d, pt.diag(H_masked), nan_mask],
             outputs_info=[a, P, None, None, None],
-            mode=get_mode(self.mode),
             name="univariate_inner_scan",
         )
 

--- a/pymc_extras/statespace/filters/kalman_smoother.py
+++ b/pymc_extras/statespace/filters/kalman_smoother.py
@@ -1,7 +1,6 @@
 import pytensor
 import pytensor.tensor as pt
 
-from pytensor.compile import get_mode
 from pytensor.tensor.nlinalg import matrix_dot
 
 from pymc_extras.statespace.filters.utilities import (
@@ -18,8 +17,7 @@ class KalmanSmoother:
 
     """
 
-    def __init__(self, mode: str | None = None):
-        self.mode = mode
+    def __init__(self):
         self.cov_jitter = JITTER_DEFAULT
         self.seq_names = []
         self.non_seq_names = []
@@ -64,9 +62,8 @@ class KalmanSmoother:
         return a, P, a_smooth, P_smooth, T, R, Q
 
     def build_graph(
-        self, T, R, Q, filtered_states, filtered_covariances, mode=None, cov_jitter=JITTER_DEFAULT
+        self, T, R, Q, filtered_states, filtered_covariances, cov_jitter=JITTER_DEFAULT
     ):
-        self.mode = mode
         self.cov_jitter = cov_jitter
 
         n, k = filtered_states.type.shape
@@ -88,7 +85,6 @@ class KalmanSmoother:
             non_sequences=non_sequences,
             go_backwards=True,
             name="kalman_smoother",
-            mode=get_mode(self.mode),
         )
 
         smoothed_states, smoothed_covariances = smoother_result

--- a/pymc_extras/statespace/models/ETS.py
+++ b/pymc_extras/statespace/models/ETS.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytensor.tensor as pt
 
 from pytensor import graph_replace
+from pytensor.compile.mode import Mode
 from pytensor.tensor.slinalg import solve_discrete_lyapunov
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace, floatX
@@ -35,6 +36,7 @@ class BayesianETS(PyMCStateSpace):
         initialization_dampening: float = 0.8,
         filter_type: str = "standard",
         verbose: bool = True,
+        mode: str | Mode | None = None,
     ):
         r"""
         Exponential Smoothing State Space Model
@@ -212,6 +214,13 @@ class BayesianETS(PyMCStateSpace):
             and "cholesky". See the docs for kalman filters for more details.
         verbose: bool, default True
             If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
+        mode: str or Mode, optional
+            Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
+            ``forecast``. The mode does **not** effect calls to ``pm.sample``.
+
+            Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
+            to all sampling methods.
+
 
         References
         ----------
@@ -284,6 +293,7 @@ class BayesianETS(PyMCStateSpace):
             filter_type,
             verbose=verbose,
             measurement_error=measurement_error,
+            mode=mode,
         )
 
     @property

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -4,6 +4,7 @@ from typing import Any
 import numpy as np
 import pytensor.tensor as pt
 
+from pytensor.compile.mode import Mode
 from pytensor.tensor.slinalg import solve_discrete_lyapunov
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace, floatX
@@ -90,6 +91,13 @@ class BayesianSARIMA(PyMCStateSpace):
 
     verbose: bool, default True
         If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
+
+    mode: str or Mode, optional
+        Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
+        ``forecast``. The mode does **not** effect calls to ``pm.sample``.
+
+        Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
+        to all sampling methods.
 
     Notes
     -----
@@ -180,7 +188,21 @@ class BayesianSARIMA(PyMCStateSpace):
         state_structure: str = "fast",
         measurement_error: bool = False,
         verbose=True,
+        mode: str | Mode | None = None,
     ):
+        """
+
+        Parameters
+        ----------
+        order
+        seasonal_order
+        stationary_initialization
+        filter_type
+        state_structure
+        measurement_error
+        verbose
+        mode
+        """
         # Model order
         self.p, self.d, self.q = order
         if seasonal_order is None:
@@ -228,6 +250,7 @@ class BayesianSARIMA(PyMCStateSpace):
             filter_type,
             verbose=verbose,
             measurement_error=measurement_error,
+            mode=mode,
         )
 
     @property

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -158,7 +158,7 @@ class BayesianSARIMA(PyMCStateSpace):
             rho = pm.Beta("ar_params", alpha=5, beta=1, dims=ss_mod.param_dims["ar_params"])
             theta = pm.Normal("ma_params", mu=0.0, sigma=0.5, dims=ss_mod.param_dims["ma_params"])
 
-            ss_mod.build_statespace_graph(df, mode="JAX")
+            ss_mod.build_statespace_graph(df)
             idata = pm.sample(nuts_sampler='numpyro')
 
     References
@@ -366,7 +366,7 @@ class BayesianSARIMA(PyMCStateSpace):
 
         return coords
 
-    def _stationary_initialization(self, mode=None):
+    def _stationary_initialization(self):
         # Solve for matrix quadratic for P0
         T = self.ssm["transition"]
         R = self.ssm["selection"]
@@ -374,9 +374,7 @@ class BayesianSARIMA(PyMCStateSpace):
         c = self.ssm["state_intercept"]
 
         x0 = pt.linalg.solve(pt.identity_like(T) - T, c, assume_a="gen", check_finite=True)
-
-        method = "direct" if (self.k_states < 5) or (mode == "JAX") else "bilinear"
-        P0 = solve_discrete_lyapunov(T, pt.linalg.matrix_dot(R, Q, R.T), method=method)
+        P0 = solve_discrete_lyapunov(T, pt.linalg.matrix_dot(R, Q, R.T), method="bilinear")
 
         return x0, P0
 

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
+from pytensor.compile.mode import Mode
 from pytensor.tensor.slinalg import solve_discrete_lyapunov
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
@@ -71,6 +72,13 @@ class BayesianVARMAX(PyMCStateSpace):
 
     verbose: bool, default True
         If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
+
+    mode: str or Mode, optional
+        Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
+        ``forecast``. The mode does **not** effect calls to ``pm.sample``.
+
+        Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
+        to all sampling methods.
 
     Notes
     -----
@@ -147,7 +155,8 @@ class BayesianVARMAX(PyMCStateSpace):
         stationary_initialization: bool = False,
         filter_type: str = "standard",
         measurement_error: bool = False,
-        verbose=True,
+        verbose: bool = True,
+        mode: str | Mode | None = None,
     ):
         if (endog_names is None) and (k_endog is None):
             raise ValueError("Must specify either endog_names or k_endog")
@@ -174,6 +183,7 @@ class BayesianVARMAX(PyMCStateSpace):
             filter_type,
             verbose=verbose,
             measurement_error=measurement_error,
+            mode=mode,
         )
 
         # Save counts of the number of parameters in each category

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -135,7 +135,7 @@ class BayesianVARMAX(PyMCStateSpace):
             ar_params = pm.Normal("ar_params", mu=0, sigma=1, dims=ar_dims)
             state_cov = pm.Deterministic("state_cov", state_chol @ state_chol.T, dims=state_cov_dims)
 
-            bvar_mod.build_statespace_graph(data, mode="JAX")
+            bvar_mod.build_statespace_graph(data)
             idata = pm.sample(nuts_sampler="numpyro")
     """
 

--- a/pymc_extras/statespace/models/structural.py
+++ b/pymc_extras/statespace/models/structural.py
@@ -12,6 +12,7 @@ import pytensor.tensor as pt
 import xarray as xr
 
 from pytensor import Variable
+from pytensor.compile.mode import Mode
 
 from pymc_extras.statespace.core import PytensorRepresentation
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
@@ -81,6 +82,7 @@ class StructuralTimeSeries(PyMCStateSpace):
         name: str | None = None,
         verbose: bool = True,
         filter_type: str = "standard",
+        mode: str | Mode | None = None,
     ):
         # Add the initial state covariance to the parameters
         if name is None:
@@ -112,6 +114,7 @@ class StructuralTimeSeries(PyMCStateSpace):
             filter_type=filter_type,
             verbose=verbose,
             measurement_error=measurement_error,
+            mode=mode,
         )
         self.ssm = ssm.copy()
 
@@ -644,7 +647,9 @@ class Component(ABC):
 
         return new_comp
 
-    def build(self, name=None, filter_type="standard", verbose=True):
+    def build(
+        self, name=None, filter_type="standard", verbose=True, mode: str | Mode | None = None
+    ):
         """
         Build a StructuralTimeSeries statespace model from the current component(s)
 
@@ -659,6 +664,13 @@ class Component(ABC):
 
         verbose : bool, optional
             If True, displays information about the initialized model. Defaults to True.
+
+        mode: str or Mode, optional
+            Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
+            ``forecast``. The mode does **not** effect calls to ``pm.sample``.
+
+            Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
+            to all sampling methods.
 
         Returns
         -------
@@ -685,6 +697,7 @@ class Component(ABC):
             name_to_data=self._name_to_data,
             filter_type=filter_type,
             verbose=verbose,
+            mode=mode,
         )
 
 

--- a/pymc_extras/statespace/models/structural.py
+++ b/pymc_extras/statespace/models/structural.py
@@ -908,7 +908,7 @@ class MeasurementError(Component):
             intitial_trend = pm.Normal('initial_trend', sigma=10, dims=ss_mod.param_dims['initial_trend'])
             sigma_obs = pm.Exponential('sigma_obs', 1, dims=ss_mod.param_dims['sigma_obs'])
 
-            ss_mod.build_statespace_graph(data, mode='JAX')
+            ss_mod.build_statespace_graph(data)
             idata = pm.sample(nuts_sampler='numpyro')
     """
 
@@ -991,7 +991,7 @@ class AutoregressiveComponent(Component):
             ar_params = pm.Normal('ar_params', dims=ss_mod.param_dims['ar_params'])
             sigma_ar = pm.Exponential('sigma_ar', 1, dims=ss_mod.param_dims['sigma_ar'])
 
-            ss_mod.build_statespace_graph(data, mode='JAX')
+            ss_mod.build_statespace_graph(data)
             idata = pm.sample(nuts_sampler='numpyro')
 
     """
@@ -1153,7 +1153,7 @@ class TimeSeasonality(Component):
             intitial_trend = pm.Deterministic('initial_trend', pt.zeros(1), dims=ss_mod.param_dims['initial_trend'])
             annual_coefs = pm.Normal('annual_coefs', sigma=1e-2, dims=ss_mod.param_dims['annual_coefs'])
             trend_sigmas = pm.HalfNormal('trend_sigmas', sigma=1e-6, dims=ss_mod.param_dims['trend_sigmas'])
-            ss_mod.build_statespace_graph(data, mode='JAX')
+            ss_mod.build_statespace_graph(data)
             idata = pm.sample(nuts_sampler='numpyro')
 
     References
@@ -1451,7 +1451,7 @@ class CycleComponent(Component):
             cycle_length = pm.Uniform('business_cycle_length', lower=6, upper=12)
 
             sigma_cycle = pm.HalfNormal('sigma_business_cycle', sigma=1)
-            ss_mod.build_statespace_graph(data, mode='JAX')
+            ss_mod.build_statespace_graph(data)
 
             idata = pm.sample(nuts_sampler='numpyro')
 

--- a/tests/statespace/core/test_statespace_JAX.py
+++ b/tests/statespace/core/test_statespace_JAX.py
@@ -37,9 +37,7 @@ def pymc_mod(ss_mod):
         rho = pm.Beta("rho", 1, 1)
         zeta = pm.Deterministic("zeta", 1 - rho)
 
-        ss_mod.build_statespace_graph(
-            data=nile, mode="JAX", save_kalman_filter_outputs_in_idata=True
-        )
+        ss_mod.build_statespace_graph(data=nile, save_kalman_filter_outputs_in_idata=True)
         names = ["x0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
         for name, matrix in zip(names, ss_mod.unpack_statespace()):
             pm.Deterministic(name, matrix)
@@ -62,7 +60,7 @@ def exog_pymc_mod(exog_ss_mod, rng):
         beta_exog = pm.Normal("beta_exog", dims=["exog_state"])
 
         sigma_trend = pm.Exponential("sigma_trend", 1, dims=["trend_shock"])
-        exog_ss_mod.build_statespace_graph(y, mode="JAX")
+        exog_ss_mod.build_statespace_graph(y)
 
     return m
 
@@ -121,8 +119,6 @@ def test_no_nans_in_sampling_output(ss_mod, group, matrix, idata):
 @pytest.mark.parametrize("group", ["prior", "posterior"])
 @pytest.mark.parametrize("kind", ["conditional", "unconditional"])
 def test_sampling_methods(group, kind, ss_mod, idata, rng):
-    assert ss_mod._fit_mode == "JAX"
-
     f = getattr(ss_mod, f"sample_{kind}_{group}")
     with pytest.warns(UserWarning, match="The RandomType SharedVariables"):
         test_idata = f(idata, random_seed=rng)

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -313,7 +313,7 @@ def test_kalman_filter_jax(filter):
     # TODO: Add UnivariateFilter to test; need to figure out the broadcasting issue when 2nd data dim is defined
 
     p, m, r, n = 1, 5, 1, 10
-    inputs, outputs = initialize_filter(filter(), mode="JAX", p=p, m=m, r=r, n=n)
+    inputs, outputs = initialize_filter(filter(), p=p, m=m, r=r, n=n)
     inputs_np = make_test_inputs(p, m, r, n, rng)
 
     f_jax = get_jaxified_graph(inputs, outputs)

--- a/tests/statespace/models/test_ETS.py
+++ b/tests/statespace/models/test_ETS.py
@@ -18,7 +18,7 @@ def data():
     return load_nile_test_data()
 
 
-def tests_invalid_order_raises():
+def test_invalid_order_raises():
     # Order must be length 3
     with pytest.raises(ValueError, match="Order must be a tuple of three strings"):
         BayesianETS(order=("A", "N"))
@@ -89,7 +89,7 @@ def test_order_flags(order, expected_flags):
         assert getattr(mod, key) == value
 
 
-def tests_mode_argument():
+def test_mode_argument():
     # Mode argument should be passed to the parent class
     mod = BayesianETS(order=("A", "N", "N"), mode="FAST_RUN")
     assert mod.mode == "FAST_RUN"

--- a/tests/statespace/models/test_ETS.py
+++ b/tests/statespace/models/test_ETS.py
@@ -89,6 +89,12 @@ def test_order_flags(order, expected_flags):
         assert getattr(mod, key) == value
 
 
+def tests_mode_argument():
+    # Mode argument should be passed to the parent class
+    mod = BayesianETS(order=("A", "N", "N"), mode="FAST_RUN")
+    assert mod.mode == "FAST_RUN"
+
+
 @pytest.mark.parametrize("order, expected_params", zip(orders, order_params), ids=order_names)
 def test_param_info(order: tuple[str, str, str], expected_params):
     mod = BayesianETS(order=order, seasonal_periods=4)

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -217,6 +217,12 @@ def pymc_mod_interp(arima_mod_interp):
     return pymc_mod
 
 
+def tests_mode_argument():
+    # Mode argument should be passed to the parent class
+    mod = BayesianSARIMA(order=(0, 0, 3), mode="FAST_RUN", verbose=False)
+    assert mod.mode == "FAST_RUN"
+
+
 @pytest.mark.parametrize(
     "p,d,q,P,D,Q,S,expected_names",
     [(*order, name) for order, name in zip(test_orders, test_state_names)],

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -217,7 +217,7 @@ def pymc_mod_interp(arima_mod_interp):
     return pymc_mod
 
 
-def tests_mode_argument():
+def test_mode_argument():
     # Mode argument should be passed to the parent class
     mod = BayesianSARIMA(order=(0, 0, 3), mode="FAST_RUN", verbose=False)
     assert mod.mode == "FAST_RUN"

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -77,6 +77,12 @@ def idata(pymc_mod, rng):
     return idata
 
 
+def tests_mode_argument():
+    # Mode argument should be passed to the parent class
+    mod = BayesianVARMAX(k_endog=2, order=(3, 0), mode="FAST_RUN", verbose=False)
+    assert mod.mode == "FAST_RUN"
+
+
 @pytest.mark.parametrize("order", orders, ids=ids)
 @pytest.mark.parametrize("var", ["AR", "MA", "state_cov"])
 @pytest.mark.filterwarnings("ignore::statsmodels.tools.sm_exceptions.EstimationWarning")

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -77,7 +77,7 @@ def idata(pymc_mod, rng):
     return idata
 
 
-def tests_mode_argument():
+def test_mode_argument():
     # Mode argument should be passed to the parent class
     mod = BayesianVARMAX(k_endog=2, order=(3, 0), mode="FAST_RUN", verbose=False)
     assert mod.mode == "FAST_RUN"

--- a/tests/statespace/models/test_structural.py
+++ b/tests/statespace/models/test_structural.py
@@ -541,7 +541,8 @@ def test_structural_model_against_statsmodels(
 
     _assert_all_statespace_matrices_match(mod, params, sm_mod)
 
-    built_model = mod.build(verbose=False)
+    built_model = mod.build(verbose=False, mode="FAST_RUN")
+    assert built_model.mode == "FAST_RUN"
 
     _assert_coord_shapes_match_matrices(built_model, params)
     _assert_param_dims_correct(built_model.param_dims, expected_dims)

--- a/tests/statespace/test_utilities.py
+++ b/tests/statespace/test_utilities.py
@@ -41,7 +41,7 @@ def load_nile_test_data():
     return nile
 
 
-def initialize_filter(kfilter, mode=None, p=None, m=None, r=None, n=None):
+def initialize_filter(kfilter, p=None, m=None, r=None, n=None):
     ksmoother = KalmanSmoother()
     data = pt.tensor(name="data", dtype=floatX, shape=(n, p))
     a0 = pt.tensor(name="x0", dtype=floatX, shape=(m,))
@@ -64,7 +64,7 @@ def initialize_filter(kfilter, mode=None, p=None, m=None, r=None, n=None):
         predicted_covs,
         observed_covs,
         ll_obs,
-    ) = kfilter.build_graph(*inputs, mode=mode)
+    ) = kfilter.build_graph(*inputs)
 
     smoothed_states, smoothed_covs = ksmoother.build_graph(T, R, Q, filtered_states, filtered_covs)
 

--- a/tests/statespace/utils/test_coord_assignment.py
+++ b/tests/statespace/utils/test_coord_assignment.py
@@ -137,7 +137,6 @@ def make_model(index):
         with pytest.warns(UserWarning, match="No time index found on the supplied data"):
             ss_mod.build_statespace_graph(
                 a["A"],
-                mode="JAX",
             )
     return model
 


### PR DESCRIPTION
Closes #478 

We were previously passing the `mode` argument to scan everywhere in statespace. This isn't strictly necessary, and required a fair amount of bookkeeping. This PR removes the mode argument from all the scans in the repo, and also removes all that bookkeeping.

This will slightly break the user-facing API, because now `build_statespace_graph(data, mode='JAX')` will now raise an error (because you don't need to pass anything). 

It will also now require users to explicitly pass compile_kwargs to all of the sampling functions (`sample_conditional_posterior`, `forecast`, `impulse_response_function`, etc). That's consistent with all PyMC apis, though.

I still need to go through and adjust all the notebooks, but it looks like tests are passing.