### PR TITLE
Removing some spurious checks with the observation intercept has a time-varying dimension.

### DIFF
--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -298,7 +298,7 @@ class PytensorRepresentation:
                     )
 
                 # Time varying vector case, check only the static shapes
-                if X.ndim == 2 and X.shape[1:] != expected_shape:
+                if X.ndim == 2 and shape[1:] != expected_shape:
                     raise ValueError(
                         f"Last dimension of array provided for {name} has shape {X.shape[1]}, "
                         f"expected {expected_shape}"
@@ -334,7 +334,7 @@ class PytensorRepresentation:
                 X = pt.expand_dims(X, (0,))
                 X = pt.specify_shape(X, self.shapes[name])
 
-            elif X.ndim == 2:
+            elif X.ndim == 2 and name not in VECTOR_VALUED:
                 X = pt.expand_dims(X, (0,))
                 X = pt.specify_shape(X, self.shapes[name])
 


### PR DESCRIPTION

This PR fixes two issues in the PytensorRepresentation class that affect how time-varying parameters are validated and reshaped. 

Changes

    1. Corrected a bug in shape validation:
    The check for mismatched static shape of time-varying inputs (when X.ndim == 2) incorrectly compared X.shape[1:] instead of shape[1:].  X.shape is a symbolic tensor. 

    2.  X has two dimensions if it is time-varying & vector valued or if is not-tie-varying and not vector valued.  I added a check to ensure that we were in case two before adding additional dimensions. 