### PR TITLE
Pin pytensor to < 2.31

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
   "pymc>=5.21.1",
+  "pytensor<2.31",
   "scikit-learn",
   "better-optimize"
 ]


### PR DESCRIPTION
pytensor introduced some regressions since 2.31

This pins the version below that while the following gets resolved

https://github.com/pymc-devs/pytensor/issues/1425