### PR TITLE
Import `apply_permutation` function from `linear_operator`

### DIFF
--- a/pymc_extras/utils/pivoted_cholesky.py
+++ b/pymc_extras/utils/pivoted_cholesky.py
@@ -1,7 +1,7 @@
 try:
     import torch
 
-    from gpytorch.utils.permutation import apply_permutation
+    from linear_operator.utils.permutation import apply_permutation
 except ImportError as e:
     raise ImportError("PyTorch and GPyTorch not found.") from e
 


### PR DESCRIPTION
Instead of `gpytorch` . This fixes a Deprecation warning