### PR TITLE
Support getattr for prior module

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -84,6 +84,7 @@ from __future__ import annotations
 import copy
 
 from collections.abc import Callable
+from functools import partial
 from inspect import signature
 from typing import Any, Protocol, runtime_checkable
 
@@ -1354,3 +1355,34 @@ def _is_censored_type(data: dict) -> bool:
 
 register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_dict)
 register_deserialization(is_type=_is_censored_type, deserialize=Censored.from_dict)
+
+
+def __getattr__(name: str):
+    """Get Prior class through the module.
+
+    Examples
+    --------
+    Create a normal distribution.
+
+    .. code-block:: python
+
+        from pymc_extras.prior import Normal
+
+        dist = Normal(mu=1, sigma=2)
+
+    Create a hierarchical normal distribution.
+
+    .. code-block:: python
+
+        import pymc_extras.prior as pr
+
+        dist = pr.Normal(mu=pr.Normal(), sigma=pr.HalfNormal(), dims="channel")
+        samples = dist.sample_prior(coords={"channel": ["C1", "C2", "C3"]})
+
+    """
+    # Protect against doctest
+    if name == "__wrapped__":
+        return
+
+    _get_pymc_distribution(name)
+    return partial(Prior, distribution=name)

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -12,6 +12,8 @@ from preliz.distributions import distributions as preliz_distributions
 from pydantic import ValidationError
 from pymc.model_graph import fast_eval
 
+import pymc_extras.prior as pr
+
 from pymc_extras.deserialize import (
     DESERIALIZERS,
     deserialize,
@@ -1141,3 +1143,22 @@ def test_scaled_sample_prior() -> None:
     assert prior.sizes == {"chain": 1, "draw": 25, "channel": 3}
     assert "scaled_var" in prior
     assert "scaled_var_unscaled" in prior
+
+
+def test_getattr() -> None:
+    assert pr.Normal() == Prior("Normal")
+
+
+def test_import_directly() -> None:
+    try:
+        from pymc_extras.prior import Normal
+    except Exception as e:
+        pytest.fail(f"Unexpected exception: {e}")
+
+    assert Normal() == Prior("Normal")
+
+
+def test_import_incorrect_directly() -> None:
+    match = "PyMC doesn't have a distribution of name 'SomeIncorrectDistribution'"
+    with pytest.raises(UnsupportedDistributionError, match=match):
+        from pymc_extras.prior import SomeIncorrectDistribution  # noqa: F401


### PR DESCRIPTION
This ports this PR: https://github.com/pymc-labs/pymc-marketing/pull/1534

It was removed from PyMC-Marketing due to the documentation build failing. However, since the 
build for PyMC-extras requires specified classes and functions, it should work.

The prior class now has the convenience imports:

```python
# Direct import of a distribution
from pymc_extras.prior import Normal, HalfNormal

distribution = Normal(mu=Normal(), sigma=HalfNormal(), dims="covariate")

# dot notation for convenience
import pymc_extras.prior as pr

distribution = pr.Normal(mu=pr.Normal(), sigma=pr.HalfNormal(), dims="covariate")
```

Then use like normal:

```python
assert isinstance(distribution, pr.Prior)
assert distribution == Prior("Normal", mu=Prior("Normal"), sigma=Prior("HalfNormal"), dims="covariate")
```

No functional change. Just a convenience import
