### PR TITLE
Add `BaseEstimator` mixin to `LinearModel`

### DIFF
--- a/pymc_extras/linearmodel.py
+++ b/pymc_extras/linearmodel.py
@@ -2,10 +2,12 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 
+from sklearn.base import BaseEstimator
+
 from pymc_extras.model_builder import ModelBuilder
 
 
-class LinearModel(ModelBuilder):
+class LinearModel(ModelBuilder, BaseEstimator):
     def __init__(
         self, model_config: dict | None = None, sampler_config: dict | None = None, nsamples=100
     ):


### PR DESCRIPTION
Scikit-learn 1.7.0 wants all `LinearModel` estimators to also have a `BaseEstimator` mixin to the far right. This is currently raising a DepreciationWarning, but will switch to an error at some point.