### PR TITLE
Make preliz optional

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,6 @@ dependencies = [
   "scikit-learn",
   "better-optimize>=0.1.2",
   "pydantic>=2.0.0",
-  "preliz",
 ]
 
 [project.optional-dependencies]
@@ -52,6 +51,7 @@ dev = [
   "dask[all]<2025.1.1",
   "blackjax",
   "statsmodels",
+  "preliz",
 ]
 docs = [
   "nbsphinx>=0.4.2",


### PR DESCRIPTION
Preliz is not imported at the top level so this makes it optional dependency. I was having issues with preliz since it has numba as a dependency which has no python only wheel making pyodide not able to use it. 