### PR TITLE
Restore Python 3.10 support

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,7 +17,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.10"
       - name: Build the sdist and the wheel
         run: |
           pip install build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,6 +55,7 @@ jobs:
         run: |
           pip install -e ".[dev]"
           python --version
+          pip check
       - name: Run tests
         run: |
           python -m pytest --color=yes -vv --cov=pymc_extras --cov-append --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.11"]
+        python-version: ["3.10"]
         test-subset:
           - tests/model
           - tests/statespace/core/test_statespace.py
@@ -55,7 +55,6 @@ jobs:
         run: |
           pip install -e ".[dev]"
           python --version
-          pip check
       - name: Run tests
         run: |
           python -m pytest --color=yes -vv --cov=pymc_extras --cov-append --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -13,7 +13,6 @@ dependencies:
   - pytest
   - pytest-cov
   - pydantic>=2.0.0
-  - preliz
   - pip
   - pip:
       - jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ dev = [
   "dask[all]<2025.1.1",
   "blackjax",
   "statsmodels",
-  "preliz",
+  "preliz>=0.5.0",
 ]
 docs = [
   "nbsphinx>=0.4.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
@@ -22,7 +23,7 @@ classifiers = [
   "Operating System :: OS Independent",
 ]
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.10"
 keywords = [
   "probability",
   "machine learning",


### PR DESCRIPTION
With #522 we no longer need to restrict to Python >=3.11.