### PR TITLE
use deserialize in Censored.from_dict

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -1176,7 +1176,7 @@ class Censored:
         """Create a censored distribution from a dictionary."""
         data = data["data"]
         return cls(  # type: ignore
-            distribution=Prior.from_dict(data["dist"]),
+            distribution=deserialize(data["dist"]),
             lower=data["lower"],
             upper=data["upper"],
         )


### PR DESCRIPTION

This allows for alternative serializations for the distribution in the Censored class
