### PR TITLE
Add lower bound on preliz version

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pydantic>=2.0.0
-  - preliz
+  - preliz>=0.5.0
   - pip
   - pip:
       - jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "dask[all]<2025.1.1",
   "blackjax",
   "statsmodels",
-  "preliz",
+  "preliz>=0.5.0",
 ]
 docs = [
   "nbsphinx>=0.4.2",


### PR DESCRIPTION
Otherwise we risk pulling an ancient version.
Without this, it's not clear why we need Python 3.11