### PR TITLE
fix import error due to moving progress bar functions in latest pymc

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-  - pymc>=5.24.0
+  - pymc>=5.24.1
   - pytensor>=2.31.4
   - scikit-learn
   - better-optimize>=0.1.5

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -4,8 +4,9 @@ channels:
 - nodefaults
 dependencies:
   - pymc>=5.24.0
+  - pytensor>=2.31.4
   - scikit-learn
-  - better-optimize>=0.1.2
+  - better-optimize>=0.1.5
   - dask<2025.1.1
   - xhistogram
   - statsmodels
@@ -13,7 +14,7 @@ dependencies:
   - pytest
   - pytest-cov
   - pydantic>=2.0.0
-  - preliz>=0.5.0
+  - preliz>=0.20.0
   - pip
   - pip:
       - jax

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -3,7 +3,7 @@ channels:
 - conda-forge
 - nodefaults
 dependencies:
-  - pymc>=5.21.1
+  - pymc>=5.24.0
   - scikit-learn
   - better-optimize>=0.1.2
   - dask<2025.1.1

--- a/pymc_extras/inference/pathfinder/pathfinder.py
+++ b/pymc_extras/inference/pathfinder/pathfinder.py
@@ -38,16 +38,15 @@ from pymc.blocking import DictToArrayBijection, RaveledVars
 from pymc.initial_point import make_initial_point_fn
 from pymc.model import modelcontext
 from pymc.model.core import Point
+from pymc.progress_bar import CustomProgress, default_progress_theme
 from pymc.pytensorf import (
     compile,
     find_rng_nodes,
     reseed_rngs,
 )
 from pymc.util import (
-    CustomProgress,
     RandomSeed,
     _get_seeds_per_chain,
-    default_progress_theme,
     get_default_varnames,
 )
 from pytensor.compile.function.types import Function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
-  "pymc>=5.24.0",
+  "pymc>=5.24.1",
   "pytensor>=2.31.4",
   "scikit-learn",
   "better-optimize>=0.1.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ keywords = [
 license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
-  "pymc>=5.21.1",
+  "pymc>=5.24.0",
   "scikit-learn",
   "better-optimize>=0.1.4",
   "pydantic>=2.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,9 +35,11 @@ license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
   "pymc>=5.24.0",
+  "pytensor>=2.31.4",
   "scikit-learn",
-  "better-optimize>=0.1.4",
+  "better-optimize>=0.1.5",
   "pydantic>=2.0.0",
+  "preliz>=0.20.0",
 ]
 
 [project.optional-dependencies]
@@ -51,7 +53,6 @@ dev = [
   "dask[all]<2025.1.1",
   "blackjax",
   "statsmodels",
-  "preliz>=0.5.0",
 ]
 docs = [
   "nbsphinx>=0.4.2",


### PR DESCRIPTION
import progress bar functions from `pymc.progress_bar` instead of `pymc.util`

This addresses the issue in #541 

What I am not sure of though is what happens if a user wants to use the latest `pymc-extras` version with `pymc<5.24.0`?