### PR TITLE
Fix AR labeling + `core` docstrings typo

### DIFF
--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -114,7 +114,7 @@ class AutoregressiveComponent(Component):
         if self.k_endog > 1:
             self.param_dims[f"params_{self.name}"] = (
                 f"endog_{self.name}",
-                AR_PARAM_DIM,
+                f"lag_{self.name}",
             )
             self.param_dims[f"sigma_{self.name}"] = (f"endog_{self.name}",)
 

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -362,7 +362,7 @@ class StructuralTimeSeries(PyMCStateSpace):
         Returns
         -------
         idata: Dataset
-            An Dataset object with hidden states transformed to represent only the "interpretable" subcomponents
+            A Dataset object with hidden states transformed to represent only the "interpretable" subcomponents
             of the structural model.
 
         Notes


### PR DESCRIPTION
Small fix for #546 + a typo fix in `core`'s docstrings