### PR TITLE
Improve `xarray` display of structural components for multivariate time series

### DIFF
--- a/pymc_extras/statespace/utils/__init__.py
+++ b/pymc_extras/statespace/utils/__init__.py
@@ -1,0 +1,11 @@
+from .component_parsing import (
+    create_component_multiindex,
+    parse_component_state_name,
+    restructure_components_idata,
+)
+
+__all__ = [
+    "create_component_multiindex",
+    "parse_component_state_name",
+    "restructure_components_idata",
+]

--- a/pymc_extras/statespace/utils/component_parsing.py
+++ b/pymc_extras/statespace/utils/component_parsing.py
@@ -1,0 +1,135 @@
+"""
+Parsing utilities for component state names in structural time series models.
+
+This module provides functionality to parse complex state names like 'trend[level[observed_state]]'
+into structured multi-index coordinates that enable easy component and state selection.
+
+NB: This is still a work in progress, and probably need to be expanded to more complex cases.
+"""
+
+from __future__ import annotations
+
+import re
+
+from collections.abc import Sequence
+
+import pandas as pd
+import xarray as xr
+
+
+def parse_component_state_name(state_name: str) -> tuple[str, str]:
+    """
+    Parse a component state name into its constituent parts.
+
+    Extracts the actual interpretable state name and observed state from
+    various component naming formats.
+
+    Parameters
+    ----------
+    state_name : str
+        The state name to parse, e.g., 'trend[level[observed_state]]' or 'ar[observed_state]'
+
+    Returns
+    -------
+    tuple[str, str]
+        A tuple of (component, observed) where component is the interpretable component name
+        and observed is the observed state name
+
+    Examples
+    --------
+    >>> parse_component_state_name('trend[level[chirac2]]')
+    ('level', 'chirac2')
+    >>> parse_component_state_name('ar[macron]')
+    ('ar', 'macron')
+    """
+    # Handle the nested bracket pattern: component[state[observed]]
+    # For these, we want the inner state name (level, trend, etc.)
+    # because the first level is redundant with the component name
+    nested_pattern = r"^([^[]+)\[([^[]+)\[([^]]+)\]\]$"
+    nested_match = re.match(nested_pattern, state_name)
+
+    if nested_match:
+        # Return the inner state name and observed state
+        return nested_match.group(2), nested_match.group(3)
+
+    # Handle the simple bracket pattern: component[observed]
+    # For these, we want the component name directly
+    simple_pattern = r"^([^[]+)\[([^]]+)\]$"
+    simple_match = re.match(simple_pattern, state_name)
+
+    if simple_match:
+        # Return the component name and observed state
+        return simple_match.group(1), simple_match.group(2)
+
+    # If no pattern matches, treat the whole string as a state name
+    # This is a fallback for edge cases
+    return state_name, "default"
+
+
+def create_component_multiindex(
+    state_names: Sequence[str], coord_name: str = "state"
+) -> xr.Coordinates:
+    """
+    Create xarray coordinates with multi-index from component state names.
+
+    Parameters
+    ----------
+    state_names : Sequence[str]
+        List of state names to parse into multi-index
+    coord_name : str, default "state"
+        Name for the coordinate dimension to transform into a multi-index
+
+    Returns
+    -------
+    xr.Coordinates
+        xarray coordinates with multi-index structure
+
+    Examples
+    --------
+    >>> state_names = ['trend[level[observed_state]]', 'trend[trend[observed_state]]', 'ar[observed_state]']
+    >>> coords = create_component_multiindex(state_names)
+    >>> coords.to_index().names
+    ['component', 'observed']
+    >>> coords.to_index().values
+    [('level', 'observed_state'), ('trend', 'observed_state'), ('ar', 'observed_state')]
+    """
+    tuples = [parse_component_state_name(name) for name in state_names]
+    midx = pd.MultiIndex.from_tuples(tuples, names=["component", "observed"])
+
+    return xr.Coordinates.from_pandas_multiindex(midx, dim=coord_name)
+
+
+def restructure_components_idata(idata: xr.Dataset) -> xr.Dataset:
+    """
+    Restructure idata with multi-index coordinates for easier component selection.
+
+    Parameters
+    ----------
+    idata : xr.Dataset
+        Dataset with component state names as coordinates
+
+    Returns
+    -------
+    xr.Dataset
+        Dataset with restructured multi-index coordinates
+
+    Examples
+    --------
+    >>> # After calling extract_components_from_idata from core.py
+    >>> restructured = restructure_components_idata(components_idata)
+    >>> # Now you can select by component or observed state
+    >>> level_data = restructured.sel(component='level')  # All level components
+    >>> gdp_data = restructured.sel(observed='gdp')  # All gdp data
+    >>> level_gdp = restructured.sel(component='level', observed='gdp')  # Specific combination
+    """
+    # name of the coordinate containing state names
+    # should be `state`, by default, as users don't access it directly
+    # would need to be updated if we want to support custom names
+    state_coord_name = "state"
+    if state_coord_name not in idata.coords:
+        raise ValueError(f"Coordinate '{state_coord_name}' not found in dataset")
+
+    state_names = idata.coords[state_coord_name].values
+    mindex_coords = create_component_multiindex(state_names, state_coord_name)
+
+    return idata.assign_coords(mindex_coords)

--- a/tests/statespace/utils/test_component_parsing.py
+++ b/tests/statespace/utils/test_component_parsing.py
@@ -1,0 +1,230 @@
+"""
+Tests for component state name parsing utilities.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+import xarray as xr
+
+from pymc_extras.statespace.utils.component_parsing import (
+    create_component_multiindex,
+    parse_component_state_name,
+    restructure_components_idata,
+)
+
+
+class TestParseComponentStateName:
+    """Test the core parsing function for component state names."""
+
+    def test_nested_pattern(self):
+        """Test parsing of nested bracket patterns like 'component[state[observed]]'."""
+        result = parse_component_state_name("trend[level[chirac2]]")
+        assert result == ("level", "chirac2")
+
+        result = parse_component_state_name("seasonal[coef_0[macron]]")
+        assert result == ("coef_0", "macron")
+
+    def test_simple_pattern(self):
+        """Test parsing of simple bracket patterns like 'component[observed]'."""
+        result = parse_component_state_name("ar[macron]")
+        assert result == ("ar", "macron")
+
+        result = parse_component_state_name("measurement_error[hollande]")
+        assert result == ("measurement_error", "hollande")
+
+    def test_complex_component_names(self):
+        """Test parsing with complex component names that might include special characters."""
+        # Test with underscores
+        result = parse_component_state_name("level_trend[level[data_1]]")
+        assert result == ("level", "data_1")
+
+        # Test with numbers
+        result = parse_component_state_name("ar2[lag1[series_1]]")
+        assert result == ("lag1", "series_1")
+
+    def test_complex_observed_names(self):
+        """Test parsing with complex observed variable names."""
+        result = parse_component_state_name("trend[level[data_var_1]]")
+        assert result == ("level", "data_var_1")
+
+        result = parse_component_state_name("seasonal[coef[obs_2024_Q1]]")
+        assert result == ("coef", "obs_2024_Q1")
+
+    def test_fallback_pattern(self):
+        """Test the fallback behavior for unusual patterns."""
+        result = parse_component_state_name("simple_state_name")
+        assert result == ("simple_state_name", "default")
+
+        result = parse_component_state_name("no_brackets")
+        assert result == ("no_brackets", "default")
+
+    def test_edge_cases(self):
+        """Test edge cases and malformed inputs."""
+        # Empty brackets - should fall back to treating as simple component name
+        result = parse_component_state_name("component[]")
+        assert result == ("component[]", "default")
+
+        # Mismatched brackets - should be parsed as simple pattern component[state[observed]
+        result = parse_component_state_name("component[state[observed]")
+        assert result == ("component", "state[observed")
+
+
+class TestCreateComponentMultiindex:
+    """Test the multi-index creation functionality."""
+
+    def test_basic_multiindex_creation(self):
+        """Test creating a multi-index from basic state names."""
+        state_names = [
+            "trend[level[chirac2]]",
+            "trend[trend[chirac2]]",
+            "ar[chirac2]",
+            "trend[level[macron]]",
+            "ar[macron]",
+        ]
+
+        coords = create_component_multiindex(state_names)
+
+        index = coords.to_index()
+        assert isinstance(index, pd.MultiIndex)
+        assert index.names == ["component", "observed"]
+        assert "state" in coords.dims
+
+    def test_custom_coord_name(self):
+        """Test creating multi-index with custom coordinate name."""
+        state_names = ["trend[level[data]]", "ar[data]"]
+        coords = create_component_multiindex(state_names, coord_name="custom_state")
+
+        assert "custom_state" in coords.dims
+
+    def test_mixed_patterns(self):
+        """Test with a mix of nested and simple patterns."""
+        state_names = [
+            "trend[level[obs1]]",
+            "ar[obs1]",
+            "seasonal[coef_1[obs2]]",
+            "measurement_error[obs2]",
+        ]
+
+        coords = create_component_multiindex(state_names)
+        index = coords.to_index()
+
+        # check we get right structure
+        expected_tuples = [
+            ("level", "obs1"),
+            ("ar", "obs1"),
+            ("coef_1", "obs2"),
+            ("measurement_error", "obs2"),
+        ]
+
+        for i, expected in enumerate(expected_tuples):
+            assert index[i] == expected
+
+    def test_empty_input(self):
+        """Test with empty state names list."""
+        coords = create_component_multiindex([])
+        index = coords.to_index()
+        assert len(index) == 0
+        assert index.names == ["component", "observed"]
+
+
+class TestRestructureComponentsIdata:
+    """Test the idata restructuring functionality."""
+
+    @staticmethod
+    def create_sample_idata(state_names):
+        n_chains, n_draws, n_time, n_states = 2, 100, 50, len(state_names)
+        data = np.random.normal(size=(n_chains, n_draws, n_time, n_states))
+        return xr.Dataset(
+            {
+                "filtered_latent": xr.DataArray(
+                    data,
+                    dims=["chain", "draw", "time", "state"],
+                    coords={
+                        "chain": range(n_chains),
+                        "draw": range(n_draws),
+                        "time": range(n_time),
+                        "state": state_names,
+                    },
+                )
+            }
+        )
+
+    def test_basic_restructuring(self):
+        state_names = [
+            "trend[level[chirac2]]",
+            "trend[trend[chirac2]]",
+            "ar[chirac2]",
+            "trend[level[macron]]",
+            "ar[macron]",
+        ]
+
+        idata = self.create_sample_idata(state_names)
+        restructured = restructure_components_idata(idata)
+
+        state_index = restructured.coords["state"].to_index()
+        assert isinstance(state_index, pd.MultiIndex)
+        assert state_index.names == ["component", "observed"]
+
+        # check we can select by component
+        level_data = restructured.sel(component="level")
+        assert "level" in restructured.coords["component"].values
+        assert (
+            "ar" in restructured.coords["component"].values
+        )  # ar should be here from ar[chirac2] and ar[macron]
+
+        # check we can select by observed state
+        chirac_data = restructured.sel(observed="chirac2")
+        assert "chirac2" in restructured.coords["observed"].values
+
+    def test_missing_coordinate_error(self):
+        """Test error handling when coordinate doesn't exist."""
+        idata = xr.Dataset({"data": xr.DataArray([1, 2, 3], dims=["x"], coords={"x": [1, 2, 3]})})
+
+        with pytest.raises(ValueError, match="Coordinate 'state' not found"):
+            restructure_components_idata(idata)
+
+
+class TestIntegrationScenarios:
+    def test_real_world_example(self):
+        state_names = [
+            "trend[level[chirac2]]",
+            "trend[trend[chirac2]]",
+            "trend[level[sarkozy]]",
+            "trend[trend[sarkozy]]",
+            "trend[level[hollande]]",
+            "trend[trend[hollande]]",
+            "trend[level[macron]]",
+            "trend[trend[macron]]",
+            "trend[level[macron2]]",
+            "trend[trend[macron2]]",
+            "ar[chirac2]",
+            "ar[sarkozy]",
+            "ar[hollande]",
+            "ar[macron]",
+            "ar[macron2]",
+        ]
+        n_chains, n_draws, n_time = 4, 500, 100
+        data = np.random.normal(size=(n_chains, n_draws, n_time, len(state_names)))
+        idata = xr.Dataset(
+            {
+                "filtered_latent": xr.DataArray(
+                    data, dims=["chain", "draw", "time", "state"], coords={"state": state_names}
+                )
+            }
+        )
+        restructured = restructure_components_idata(idata)
+
+        macron_data = restructured.sel(observed="macron")
+        assert macron_data.filtered_latent.shape == (
+            4,
+            500,
+            100,
+            3,
+        )  # 3 because trend level, trend trend, ar
+
+        ar_data = restructured.sel(component="ar")
+        assert ar_data.filtered_latent.shape == (4, 500, 100, 5)  # 5 observed states
+
+        level_macron = restructured.sel(component="level", observed="macron")
+        assert level_macron.filtered_latent.shape == (4, 500, 100)  # single level component


### PR DESCRIPTION
Closes #545 

Currently `extract_components_from_idata` returns square brackets notations for the `state` coord, making it hard to select components when working with multivariate series. Things like:
```python
state = [
            "trend[level[gdp]]",
            "trend[trend[gdp]]",
            "trend[level[unemployment]]",
            "trend[trend[unemployment]]",
            "ar[gdp]",
            "ar[unemployment]",
]
```
This PR adds a `restructure` argument to `extract_components_from_idata` (default `False` for backwards compatibility). When `True`, it will restructure the `state` coordinates as a multi-index for easier component selection, thus enabling selections like `idata.sel(component='level')`, `idata.sel(observed='gdp')`, or even `idata.sel(component='level', observed='gdp')`.
Again, this is especially useful for multivariate models with _multiple_ observed states.

More precisely, the `state` dimension is broken down into two new ones, `component` and `observed`, whose coordinates will be `[('level', 'gdp'), ('trend', 'gdp'), ('ar', 'gdp')], [('level', 'unemployment'), ('trend', 'unemployment'), ('ar', 'unemployment')] `.

This also allows each observed state to have arbitrary model structure inside, which the current multivariate setup allows.

_NB: This PR is a first pass, and in no way exhaustive -- we probably need to expand to more complex cases, that users will surface up. But at least it gets the ball rolling and should be self-sufficient to already merge_.