### PR TITLE
Allow multivariate components to share latent states

### DIFF
--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -23,6 +23,11 @@ class AutoregressiveComponent(Component):
     observed_state_names: list[str] | None, default None
         List of strings for observed state labels. If None, defaults to ["data"].
 
+    share_states: bool, default False
+        Whether latent states are shared across the observed states. If True, there will be only one set of latent
+        states, which are observed by all observed states. If False, each observed state has its own set of
+        latent states. This argument has no effect if `k_endog` is 1.
+
     Notes
     -----
     An autoregressive component can be thought of as a way o introducing serially correlated errors into the model.
@@ -73,45 +78,58 @@ class AutoregressiveComponent(Component):
         order: int = 1,
         name: str = "auto_regressive",
         observed_state_names: list[str] | None = None,
+        share_states: bool = False,
     ):
         if observed_state_names is None:
             observed_state_names = ["data"]
 
-        k_posdef = k_endog = len(observed_state_names)
+        k_endog = len(observed_state_names)
+        k_endog_effective = k_posdef = 1 if share_states else k_endog
 
         order = order_to_mask(order)
         ar_lags = np.flatnonzero(order).ravel().astype(int) + 1
         k_states = len(order)
 
+        self.share_states = share_states
         self.order = order
         self.ar_lags = ar_lags
 
         super().__init__(
             name=name,
             k_endog=k_endog,
-            k_states=k_states * k_endog,
+            k_states=k_states * k_endog_effective,
             k_posdef=k_posdef,
             measurement_error=True,
             combine_hidden_states=True,
             observed_state_names=observed_state_names,
-            obs_state_idxs=np.tile(np.r_[[1.0], np.zeros(k_states - 1)], k_endog),
+            obs_state_idxs=np.tile(np.r_[[1.0], np.zeros(k_states - 1)], k_endog_effective),
         )
 
     def populate_component_properties(self):
-        k_states = self.k_states // self.k_endog  # this is also the number of AR lags
+        k_endog = self.k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
 
-        self.state_names = [
-            f"L{i + 1}[{state_name}]"
-            for state_name in self.observed_state_names
-            for i in range(k_states)
-        ]
+        k_states = self.k_states // k_endog_effective  # this is also the number of AR lags
+        base_names = [f"L{i + 1}_{self.name}" for i in range(k_states)]
 
-        self.shock_names = [f"{self.name}[{obs_name}]" for obs_name in self.observed_state_names]
+        if self.share_states:
+            self.state_names = [f"{name}[shared]" for name in base_names]
+            self.shock_names = [f"{self.name}[shared]"]
+        else:
+            self.state_names = [
+                f"{name}[{state_name}]"
+                for state_name in self.observed_state_names
+                for name in base_names
+            ]
+            self.shock_names = [
+                f"{self.name}[{obs_name}]" for obs_name in self.observed_state_names
+            ]
+
         self.param_names = [f"params_{self.name}", f"sigma_{self.name}"]
         self.param_dims = {f"params_{self.name}": (f"lag_{self.name}",)}
         self.coords = {f"lag_{self.name}": self.ar_lags.tolist()}
 
-        if self.k_endog > 1:
+        if k_endog_effective > 1:
             self.param_dims[f"params_{self.name}"] = (
                 f"endog_{self.name}",
                 f"lag_{self.name}",
@@ -140,18 +158,21 @@ class AutoregressiveComponent(Component):
 
     def make_symbolic_graph(self) -> None:
         k_endog = self.k_endog
-        k_states = self.k_states // k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+
+        k_states = self.k_states // k_endog_effective
         k_posdef = self.k_posdef
 
         k_nonzero = int(sum(self.order))
         ar_params = self.make_and_register_variable(
-            f"params_{self.name}", shape=(k_nonzero,) if k_endog == 1 else (k_endog, k_nonzero)
+            f"params_{self.name}",
+            shape=(k_nonzero,) if k_endog_effective == 1 else (k_endog_effective, k_nonzero),
         )
         sigma_ar = self.make_and_register_variable(
-            f"sigma_{self.name}", shape=() if k_endog == 1 else (k_endog,)
+            f"sigma_{self.name}", shape=() if k_endog_effective == 1 else (k_endog_effective,)
         )
 
-        if k_endog == 1:
+        if k_endog_effective == 1:
             T = pt.eye(k_states, k=-1)
             ar_idx = (np.zeros(k_nonzero, dtype="int"), np.nonzero(self.order)[0])
             T = T[ar_idx].set(ar_params)
@@ -159,7 +180,7 @@ class AutoregressiveComponent(Component):
         else:
             transition_matrices = []
 
-            for i in range(k_endog):
+            for i in range(k_endog_effective):
                 T = pt.eye(k_states, k=-1)
                 ar_idx = (np.zeros(k_nonzero, dtype="int"), np.nonzero(self.order)[0])
                 T = T[ar_idx].set(ar_params[i])
@@ -171,18 +192,21 @@ class AutoregressiveComponent(Component):
         self.ssm["transition", :, :] = T
 
         R = np.eye(k_states)
-        R_mask = np.full((k_states), False)
+        R_mask = np.full((k_states,), False)
         R_mask[0] = True
         R = R[:, R_mask]
 
         self.ssm["selection", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[R for _ in range(k_endog)]), (self.k_states, self.k_posdef)
+            pt.linalg.block_diag(*[R for _ in range(k_endog_effective)]), (self.k_states, k_posdef)
         )
 
-        Z = pt.zeros((1, k_states))[0, 0].set(1.0)
-        self.ssm["design", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
-        )
+        Zs = [pt.zeros((1, k_states))[0, 0].set(1.0) for _ in range(k_endog)]
+
+        if self.share_states:
+            Z = pt.join(0, *Zs)
+        else:
+            Z = pt.linalg.block_diag(*Zs)
+        self.ssm["design", :, :] = pt.specify_shape(Z, (k_endog, self.k_states))
 
         cov_idx = ("state_cov", *np.diag_indices(k_posdef))
         self.ssm[cov_idx] = sigma_ar**2

--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -103,6 +103,7 @@ class AutoregressiveComponent(Component):
             combine_hidden_states=True,
             observed_state_names=observed_state_names,
             obs_state_idxs=np.tile(np.r_[[1.0], np.zeros(k_states - 1)], k_endog_effective),
+            share_states=share_states,
         )
 
     def populate_component_properties(self):

--- a/pymc_extras/statespace/models/structural/components/cycle.py
+++ b/pymc_extras/statespace/models/structural/components/cycle.py
@@ -43,6 +43,11 @@ class CycleComponent(Component):
         Names of the observed state variables. For univariate time series, defaults to ``["data"]``.
         For multivariate time series, specify a list of names for each endogenous variable.
 
+    share_states: bool, default False
+        Whether latent states are shared across the observed states. If True, there will be only one set of latent
+        states, which are observed by all observed states. If False, each observed state has its own set of
+        latent states. This argument has no effect if `k_endog` is 1.
+
     Notes
     -----
     The cycle component is very similar in implementation to the frequency domain seasonal component, expect that it
@@ -155,6 +160,7 @@ class CycleComponent(Component):
         dampen: bool = False,
         innovations: bool = True,
         observed_state_names: list[str] | None = None,
+        share_states: bool = False,
     ):
         if observed_state_names is None:
             observed_state_names = ["data"]
@@ -167,6 +173,7 @@ class CycleComponent(Component):
             cycle = int(cycle_length) if cycle_length is not None else "Estimate"
             name = f"Cycle[s={cycle}, dampen={dampen}, innovations={innovations}]"
 
+        self.share_states = share_states
         self.estimate_cycle_length = estimate_cycle_length
         self.cycle_length = cycle_length
         self.innovations = innovations
@@ -175,8 +182,8 @@ class CycleComponent(Component):
 
         k_endog = len(observed_state_names)
 
-        k_states = 2 * k_endog
-        k_posdef = 2 * k_endog
+        k_states = 2 if share_states else 2 * k_endog
+        k_posdef = 2 if share_states else 2 * k_endog
 
         obs_state_idx = np.zeros(k_states)
         obs_state_idx[slice(0, k_states, 2)] = 1
@@ -193,18 +200,22 @@ class CycleComponent(Component):
         )
 
     def make_symbolic_graph(self) -> None:
+        k_endog = self.k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+
         Z = np.array([1.0, 0.0]).reshape((1, -1))
-        design_matrix = block_diag(*[Z for _ in range(self.k_endog)])
+        design_matrix = block_diag(*[Z for _ in range(k_endog_effective)])
         self.ssm["design", :, :] = pt.as_tensor_variable(design_matrix)
 
         # selection matrix R defines structure of innovations (always identity for cycle components)
         # when innovations=False, state cov Q=0, hence R @ Q @ R.T = 0
         R = np.eye(2)  # 2x2 identity for each cycle component
-        selection_matrix = block_diag(*[R for _ in range(self.k_endog)])
+        selection_matrix = block_diag(*[R for _ in range(k_endog_effective)])
         self.ssm["selection", :, :] = pt.as_tensor_variable(selection_matrix)
 
         init_state = self.make_and_register_variable(
-            f"{self.name}", shape=(self.k_endog, 2) if self.k_endog > 1 else (self.k_states,)
+            f"{self.name}",
+            shape=(k_endog_effective, 2) if k_endog_effective > 1 else (self.k_states,),
         )
         self.ssm["initial_state", :] = init_state.ravel()
 
@@ -219,19 +230,19 @@ class CycleComponent(Component):
             rho = 1
 
         T = rho * _frequency_transition_block(lamb, j=1)
-        transition = block_diag(*[T for _ in range(self.k_endog)])
+        transition = block_diag(*[T for _ in range(k_endog_effective)])
         self.ssm["transition"] = pt.specify_shape(transition, (self.k_states, self.k_states))
 
         if self.innovations:
-            if self.k_endog == 1:
+            if k_endog_effective == 1:
                 sigma_cycle = self.make_and_register_variable(f"sigma_{self.name}", shape=())
                 self.ssm["state_cov", :, :] = pt.eye(self.k_posdef) * sigma_cycle**2
             else:
                 sigma_cycle = self.make_and_register_variable(
-                    f"sigma_{self.name}", shape=(self.k_endog,)
+                    f"sigma_{self.name}", shape=(k_endog_effective,)
                 )
                 state_cov = block_diag(
-                    *[pt.eye(2) * sigma_cycle[i] ** 2 for i in range(self.k_endog)]
+                    *[pt.eye(2) * sigma_cycle[i] ** 2 for i in range(k_endog_effective)]
                 )
                 self.ssm["state_cov"] = pt.specify_shape(state_cov, (self.k_states, self.k_states))
         else:
@@ -239,17 +250,25 @@ class CycleComponent(Component):
             self.ssm["state_cov", :, :] = pt.zeros((self.k_posdef, self.k_posdef))
 
     def populate_component_properties(self):
-        self.state_names = [
-            f"{f}_{self.name}[{var_name}]" if self.k_endog > 1 else f"{f}_{self.name}"
-            for var_name in self.observed_state_names
-            for f in ["Cos", "Sin"]
-        ]
+        k_endog = self.k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+
+        base_names = [f"{f}_{self.name}" for f in ["Cos", "Sin"]]
+
+        if self.share_states:
+            self.state_names = [f"{name}[shared]" for name in base_names]
+        else:
+            self.state_names = [
+                f"{name}[{var_name}]" if k_endog_effective > 1 else name
+                for var_name in self.observed_state_names
+                for name in base_names
+            ]
 
         self.param_names = [f"{self.name}"]
 
-        if self.k_endog == 1:
+        if k_endog_effective == 1:
             self.param_dims = {self.name: (f"state_{self.name}",)}
-            self.coords = {f"state_{self.name}": self.state_names}
+            self.coords = {f"state_{self.name}": base_names}
             self.param_info = {
                 f"{self.name}": {
                     "shape": (2,),
@@ -265,7 +284,7 @@ class CycleComponent(Component):
             }
             self.param_info = {
                 f"{self.name}": {
-                    "shape": (self.k_endog, 2),
+                    "shape": (k_endog_effective, 2),
                     "constraints": None,
                     "dims": (f"endog_{self.name}", f"state_{self.name}"),
                 }
@@ -274,22 +293,22 @@ class CycleComponent(Component):
         if self.estimate_cycle_length:
             self.param_names += [f"length_{self.name}"]
             self.param_info[f"length_{self.name}"] = {
-                "shape": () if self.k_endog == 1 else (self.k_endog,),
+                "shape": () if k_endog_effective == 1 else (k_endog_effective,),
                 "constraints": "Positive, non-zero",
-                "dims": None if self.k_endog == 1 else f"endog_{self.name}",
+                "dims": None if k_endog_effective == 1 else f"endog_{self.name}",
             }
 
         if self.dampen:
             self.param_names += [f"dampening_factor_{self.name}"]
             self.param_info[f"dampening_factor_{self.name}"] = {
-                "shape": () if self.k_endog == 1 else (self.k_endog,),
+                "shape": () if k_endog_effective == 1 else (k_endog_effective,),
                 "constraints": "0 < x ≤ 1",
-                "dims": None if self.k_endog == 1 else (f"endog_{self.name}",),
+                "dims": None if k_endog_effective == 1 else (f"endog_{self.name}",),
             }
 
         if self.innovations:
             self.param_names += [f"sigma_{self.name}"]
-            if self.k_endog == 1:
+            if k_endog_effective == 1:
                 self.param_info[f"sigma_{self.name}"] = {
                     "shape": (),
                     "constraints": "Positive",
@@ -298,7 +317,7 @@ class CycleComponent(Component):
             else:
                 self.param_dims[f"sigma_{self.name}"] = (f"endog_{self.name}",)
                 self.param_info[f"sigma_{self.name}"] = {
-                    "shape": (self.k_endog,),
+                    "shape": (k_endog_effective,),
                     "constraints": "Positive",
                     "dims": (f"endog_{self.name}",),
                 }

--- a/pymc_extras/statespace/models/structural/components/cycle.py
+++ b/pymc_extras/statespace/models/structural/components/cycle.py
@@ -197,6 +197,7 @@ class CycleComponent(Component):
             combine_hidden_states=True,
             obs_state_idxs=obs_state_idx,
             observed_state_names=observed_state_names,
+            share_states=share_states,
         )
 
     def make_symbolic_graph(self) -> None:

--- a/pymc_extras/statespace/models/structural/components/level_trend.py
+++ b/pymc_extras/statespace/models/structural/components/level_trend.py
@@ -170,6 +170,7 @@ class LevelTrendComponent(Component):
             obs_state_idxs=np.tile(
                 np.array([1.0] + [0.0] * (k_states - 1)), k_endog if not share_states else 1
             ),
+            share_states=share_states,
         )
 
     def populate_component_properties(self):

--- a/pymc_extras/statespace/models/structural/components/level_trend.py
+++ b/pymc_extras/statespace/models/structural/components/level_trend.py
@@ -13,13 +13,11 @@ class LevelTrendComponent(Component):
     Parameters
     ----------
     order : int
-
         Number of time derivatives of the trend to include in the model. For example, when order=3, the trend will
         be of the form ``y = a + b * t + c * t ** 2``, where the coefficients ``a, b, c`` come from the initial
         state values.
 
     innovations_order : int or sequence of int, optional
-
         The number of stochastic innovations to include in the model. By default, ``innovations_order = order``
 
     name : str, default "level_trend"
@@ -27,6 +25,11 @@ class LevelTrendComponent(Component):
 
     observed_state_names : list[str] | None, default None
         List of strings for observed state labels. If None, defaults to ["data"].
+
+    share_states: bool, default False
+        Whether latent states are shared across the observed states. If True, there will be only one set of latent
+        states, which are observed by all observed states. If False, each observed state has its own set of
+        latent states. This argument has no effect if `k_endog` is 1.
 
     Notes
     -----
@@ -120,7 +123,10 @@ class LevelTrendComponent(Component):
         innovations_order: int | list[int] | None = None,
         name: str = "level_trend",
         observed_state_names: list[str] | None = None,
+        share_states: bool = False,
     ):
+        self.share_states = share_states
+
         if innovations_order is None:
             innovations_order = order
 
@@ -156,37 +162,50 @@ class LevelTrendComponent(Component):
         super().__init__(
             name,
             k_endog=k_endog,
-            k_states=k_states * k_endog,
-            k_posdef=k_posdef * k_endog,
+            k_states=k_states * k_endog if not share_states else k_states,
+            k_posdef=k_posdef * k_endog if not share_states else k_posdef,
             observed_state_names=observed_state_names,
             measurement_error=False,
             combine_hidden_states=False,
-            obs_state_idxs=np.tile(np.array([1.0] + [0.0] * (k_states - 1)), k_endog),
+            obs_state_idxs=np.tile(
+                np.array([1.0] + [0.0] * (k_states - 1)), k_endog if not share_states else 1
+            ),
         )
 
     def populate_component_properties(self):
         k_endog = self.k_endog
-        k_states = self.k_states // k_endog
-        k_posdef = self.k_posdef // k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+
+        k_states = self.k_states // k_endog_effective
+        k_posdef = self.k_posdef // k_endog_effective
 
         name_slice = POSITION_DERIVATIVE_NAMES[:k_states]
         self.param_names = [f"initial_{self.name}"]
         base_names = [name for name, mask in zip(name_slice, self._order_mask) if mask]
-        self.state_names = [
-            f"{name}[{obs_name}]" for obs_name in self.observed_state_names for name in base_names
-        ]
+
+        if self.share_states:
+            self.state_names = [f"{name}[{self.name}_shared]" for name in base_names]
+        else:
+            self.state_names = [
+                f"{name}[{obs_name}]"
+                for obs_name in self.observed_state_names
+                for name in base_names
+            ]
+
         self.param_dims = {f"initial_{self.name}": (f"state_{self.name}",)}
         self.coords = {f"state_{self.name}": base_names}
 
         if k_endog > 1:
+            self.coords[f"endog_{self.name}"] = self.observed_state_names
+
+        if k_endog_effective > 1:
             self.param_dims[f"state_{self.name}"] = (
                 f"endog_{self.name}",
                 f"state_{self.name}",
             )
             self.param_dims = {f"initial_{self.name}": (f"endog_{self.name}", f"state_{self.name}")}
-            self.coords[f"endog_{self.name}"] = self.observed_state_names
 
-        shape = (k_endog, k_states) if k_endog > 1 else (k_states,)
+        shape = (k_endog_effective, k_states) if k_endog_effective > 1 else (k_states,)
         self.param_info = {f"initial_{self.name}": {"shape": shape, "constraints": None}}
 
         if self.k_posdef > 0:
@@ -196,20 +215,23 @@ class LevelTrendComponent(Component):
                 name for name, mask in zip(name_slice, self.innovations_order) if mask
             ]
 
-            self.shock_names = [
-                f"{name}[{obs_name}]"
-                for obs_name in self.observed_state_names
-                for name in base_shock_names
-            ]
+            if self.share_states:
+                self.shock_names = [f"{name}[{self.name}_shared]" for name in base_shock_names]
+            else:
+                self.shock_names = [
+                    f"{name}[{obs_name}]"
+                    for obs_name in self.observed_state_names
+                    for name in base_shock_names
+                ]
 
             self.param_dims[f"sigma_{self.name}"] = (
                 (f"shock_{self.name}",)
-                if k_endog == 1
+                if k_endog_effective == 1
                 else (f"endog_{self.name}", f"shock_{self.name}")
             )
             self.coords[f"shock_{self.name}"] = base_shock_names
             self.param_info[f"sigma_{self.name}"] = {
-                "shape": (k_posdef,) if k_endog == 1 else (k_endog, k_posdef),
+                "shape": (k_posdef,) if k_endog_effective == 1 else (k_endog_effective, k_posdef),
                 "constraints": "Positive",
             }
 
@@ -218,12 +240,14 @@ class LevelTrendComponent(Component):
 
     def make_symbolic_graph(self) -> None:
         k_endog = self.k_endog
-        k_states = self.k_states // k_endog
-        k_posdef = self.k_posdef // k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+
+        k_states = self.k_states // k_endog_effective
+        k_posdef = self.k_posdef // k_endog_effective
 
         initial_trend = self.make_and_register_variable(
             f"initial_{self.name}",
-            shape=(k_states,) if k_endog == 1 else (k_endog, k_states),
+            shape=(k_states,) if k_endog_effective == 1 else (k_endog, k_states),
         )
         self.ssm["initial_state", :] = initial_trend.ravel()
 
@@ -231,27 +255,34 @@ class LevelTrendComponent(Component):
         T = pt.zeros((k_states, k_states))[triu_idx[0], triu_idx[1]].set(1)
 
         self.ssm["transition", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[T for _ in range(k_endog)]), (self.k_states, self.k_states)
+            pt.linalg.block_diag(*[T for _ in range(k_endog_effective)]),
+            (self.k_states, self.k_states),
         )
 
         R = np.eye(k_states)
         R = R[:, self.innovations_order]
 
         self.ssm["selection", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[R for _ in range(k_endog)]), (self.k_states, self.k_posdef)
+            pt.linalg.block_diag(*[R for _ in range(k_endog_effective)]),
+            (self.k_states, self.k_posdef),
         )
 
         Z = np.array([1.0] + [0.0] * (k_states - 1)).reshape((1, -1))
 
-        self.ssm["design", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
-        )
+        if self.share_states:
+            self.ssm["design", :, :] = pt.specify_shape(
+                pt.join(0, *[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
+            )
+        else:
+            self.ssm["design", :, :] = pt.specify_shape(
+                pt.linalg.block_diag(*[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
+            )
 
         if k_posdef > 0:
             sigma_trend = self.make_and_register_variable(
                 f"sigma_{self.name}",
-                shape=(k_posdef,) if k_endog == 1 else (k_endog, k_posdef),
+                shape=(k_posdef,) if k_endog_effective == 1 else (k_endog, k_posdef),
             )
-            diag_idx = np.diag_indices(k_posdef * k_endog)
+            diag_idx = np.diag_indices(k_posdef * k_endog_effective)
             idx = np.s_["state_cov", diag_idx[0], diag_idx[1]]
             self.ssm[idx] = (sigma_trend**2).ravel()

--- a/pymc_extras/statespace/models/structural/components/measurement_error.py
+++ b/pymc_extras/statespace/models/structural/components/measurement_error.py
@@ -119,6 +119,7 @@ class MeasurementError(Component):
             measurement_error=True,
             combine_hidden_states=False,
             observed_state_names=observed_state_names,
+            share_states=share_states,
         )
 
     def populate_component_properties(self):

--- a/pymc_extras/statespace/models/structural/components/regression.py
+++ b/pymc_extras/statespace/models/structural/components/regression.py
@@ -132,6 +132,7 @@ class RegressionComponent(Component):
             k_states=k_states * k_endog if not share_states else k_states,
             k_posdef=k_posdef * k_endog if not share_states else k_posdef,
             state_names=self.state_names,
+            share_states=share_states,
             observed_state_names=observed_state_names,
             measurement_error=False,
             combine_hidden_states=False,

--- a/pymc_extras/statespace/models/structural/components/seasonality.py
+++ b/pymc_extras/statespace/models/structural/components/seasonality.py
@@ -296,6 +296,7 @@ class TimeSeasonality(Component):
             obs_state_idxs=np.tile(
                 np.array([1.0] + [0.0] * (k_states - 1)), 1 if share_states else k_endog
             ),
+            share_states=share_states,
         )
 
     def populate_component_properties(self):
@@ -525,6 +526,7 @@ class FrequencySeasonality(Component):
             k_posdef=k_states * int(self.innovations)
             if share_states
             else k_states * int(self.innovations) * k_endog,
+            share_states=share_states,
             observed_state_names=observed_state_names,
             measurement_error=False,
             combine_hidden_states=True,

--- a/pymc_extras/statespace/models/structural/components/seasonality.py
+++ b/pymc_extras/statespace/models/structural/components/seasonality.py
@@ -44,6 +44,11 @@ class TimeSeasonality(Component):
     observed_state_names: list[str] | None, default None
         List of strings for observed state labels. If None, defaults to ["data"].
 
+    share_states: bool, default False
+        Whether latent states are shared across the observed states. If True, there will be only one set of latent
+        states, which are observed by all observed states. If False, each observed state has its own set of
+        latent states. This argument has no effect if `k_endog` is 1.
+
     Notes
     -----
     A seasonal effect is any pattern that repeats at fixed intervals. There are several ways to model such effects;
@@ -235,6 +240,7 @@ class TimeSeasonality(Component):
         state_names: list | None = None,
         remove_first_state: bool = True,
         observed_state_names: list[str] | None = None,
+        share_states: bool = False,
     ):
         if observed_state_names is None:
             observed_state_names = ["data"]
@@ -261,6 +267,7 @@ class TimeSeasonality(Component):
                 )
             state_names = state_names.copy()
 
+        self.share_states = share_states
         self.innovations = innovations
         self.duration = duration
         self.remove_first_state = remove_first_state
@@ -281,23 +288,33 @@ class TimeSeasonality(Component):
         super().__init__(
             name=name,
             k_endog=k_endog,
-            k_states=k_states * k_endog,
-            k_posdef=k_posdef * k_endog,
+            k_states=k_states if share_states else k_states * k_endog,
+            k_posdef=k_posdef if share_states else k_posdef * k_endog,
             observed_state_names=observed_state_names,
             measurement_error=False,
             combine_hidden_states=True,
-            obs_state_idxs=np.tile(np.array([1.0] + [0.0] * (k_states - 1)), k_endog),
+            obs_state_idxs=np.tile(
+                np.array([1.0] + [0.0] * (k_states - 1)), 1 if share_states else k_endog
+            ),
         )
 
     def populate_component_properties(self):
-        k_states = self.k_states // self.k_endog
         k_endog = self.k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
 
-        self.state_names = [
-            f"{state_name}[{endog_name}]"
-            for endog_name in self.observed_state_names
-            for state_name in self.provided_state_names
-        ]
+        k_states = self.k_states // k_endog_effective
+
+        if self.share_states:
+            self.state_names = [
+                f"{state_name}[{self.name}_shared]" for state_name in self.provided_state_names
+            ]
+        else:
+            self.state_names = [
+                f"{state_name}[{endog_name}]"
+                for endog_name in self.observed_state_names
+                for state_name in self.provided_state_names
+            ]
+
         self.param_names = [f"params_{self.name}"]
 
         self.param_info = {
@@ -305,20 +322,20 @@ class TimeSeasonality(Component):
                 "shape": (k_states,) if k_endog == 1 else (k_endog, k_states),
                 "constraints": None,
                 "dims": (f"state_{self.name}",)
-                if k_endog == 1
+                if k_endog_effective == 1
                 else (f"endog_{self.name}", f"state_{self.name}"),
             }
         }
 
         self.param_dims = {
             f"params_{self.name}": (f"state_{self.name}",)
-            if k_endog == 1
+            if k_endog_effective == 1
             else (f"endog_{self.name}", f"state_{self.name}")
         }
 
         self.coords = (
             {f"state_{self.name}": self.provided_state_names}
-            if k_endog == 1
+            if k_endog_effective == 1
             else {
                 f"endog_{self.name}": self.observed_state_names,
                 f"state_{self.name}": self.provided_state_names,
@@ -327,21 +344,27 @@ class TimeSeasonality(Component):
 
         if self.innovations:
             self.param_names += [f"sigma_{self.name}"]
-            self.shock_names = [f"{self.name}[{name}]" for name in self.observed_state_names]
             self.param_info[f"sigma_{self.name}"] = {
-                "shape": () if k_endog == 1 else (k_endog,),
+                "shape": () if k_endog_effective == 1 else (k_endog,),
                 "constraints": "Positive",
-                "dims": None if k_endog == 1 else (f"endog_{self.name}",),
+                "dims": None if k_endog_effective == 1 else (f"endog_{self.name}",),
             }
+            if self.share_states:
+                self.shock_names = [f"{self.name}[shared]"]
+            else:
+                self.shock_names = [f"{self.name}[{name}]" for name in self.observed_state_names]
+
             if k_endog > 1:
                 self.param_dims[f"sigma_{self.name}"] = (f"endog_{self.name}",)
 
     def make_symbolic_graph(self) -> None:
-        k_states = self.k_states // self.k_endog
-        duration = self.duration
-        k_unique_states = k_states // duration
-        k_posdef = self.k_posdef // self.k_endog
         k_endog = self.k_endog
+        k_endog_effective = 1 if self.share_states else k_endog
+        k_states = self.k_states // k_endog_effective
+        duration = self.duration
+
+        k_unique_states = k_states // duration
+        k_posdef = self.k_posdef // k_endog_effective
 
         if self.remove_first_state:
             # In this case, parameters are normalized to sum to zero, so the current state is the negative sum of
@@ -373,16 +396,18 @@ class TimeSeasonality(Component):
             T = pt.eye(k_states, k=1)
             T = pt.set_subtensor(T[-1, 0], 1)
 
-        self.ssm["transition", :, :] = pt.linalg.block_diag(*[T for _ in range(k_endog)])
+        self.ssm["transition", :, :] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
 
         Z = pt.zeros((1, k_states))[0, 0].set(1)
-        self.ssm["design", :, :] = pt.linalg.block_diag(*[Z for _ in range(k_endog)])
+        self.ssm["design", :, :] = pt.linalg.block_diag(*[Z for _ in range(k_endog_effective)])
 
         initial_states = self.make_and_register_variable(
             f"params_{self.name}",
-            shape=(k_unique_states,) if k_endog == 1 else (k_endog, k_unique_states),
+            shape=(k_unique_states,)
+            if k_endog_effective == 1
+            else (k_endog_effective, k_unique_states),
         )
-        if k_endog == 1:
+        if k_endog_effective == 1:
             self.ssm["initial_state", :] = pt.extra_ops.repeat(initial_states, duration, axis=0)
         else:
             self.ssm["initial_state", :] = pt.extra_ops.repeat(
@@ -391,11 +416,11 @@ class TimeSeasonality(Component):
 
         if self.innovations:
             R = pt.zeros((k_states, k_posdef))[0, 0].set(1.0)
-            self.ssm["selection", :, :] = pt.join(0, *[R for _ in range(k_endog)])
+            self.ssm["selection", :, :] = pt.join(0, *[R for _ in range(k_endog_effective)])
             season_sigma = self.make_and_register_variable(
-                f"sigma_{self.name}", shape=() if k_endog == 1 else (k_endog,)
+                f"sigma_{self.name}", shape=() if k_endog_effective == 1 else (k_endog_effective,)
             )
-            cov_idx = ("state_cov", *np.diag_indices(k_posdef * k_endog))
+            cov_idx = ("state_cov", *np.diag_indices(k_posdef * k_endog_effective))
             self.ssm[cov_idx] = season_sigma**2
 
 

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -471,6 +471,10 @@ class Component:
     obs_state_idxs : np.ndarray | None, optional
         Indices indicating which states contribute to observed variables. If None,
         defaults to None.
+    share_states : bool, optional
+        Whether states are shared across multiple endogenous variables in multivariate
+        models. When True, the same latent states affect all observed variables.
+        Default is False.
 
     Examples
     --------
@@ -512,10 +516,12 @@ class Component:
         combine_hidden_states=True,
         component_from_sum=False,
         obs_state_idxs=None,
+        share_states: bool = False,
     ):
         self.name = name
         self.k_endog = k_endog
         self.k_states = k_states
+        self.share_states = share_states
         self.k_posdef = k_posdef
         self.measurement_error = measurement_error
 
@@ -557,6 +563,7 @@ class Component:
                 "observed_state_names": self.observed_state_names,
                 "combine_hidden_states": combine_hidden_states,
                 "obs_state_idx": obs_state_idxs,
+                "share_states": self.share_states,
             }
         }
 

--- a/tests/statespace/models/structural/components/test_autoregressive.py
+++ b/tests/statespace/models/structural/components/test_autoregressive.py
@@ -15,7 +15,6 @@ from tests.statespace.test_utilities import simulate_from_numpy_model
 def test_autoregressive_model(order, rng):
     ar = st.AutoregressiveComponent(order=order).build(verbose=False)
 
-    # Check coords
     _assert_basic_coords_correct(ar)
 
     lags = np.arange(len(order) if isinstance(order, list) else order, dtype="int") + 1
@@ -25,7 +24,7 @@ def test_autoregressive_model(order, rng):
 
 
 def test_autoregressive_multiple_observed_build(rng):
-    ar = st.AutoregressiveComponent(order=3, observed_state_names=["data_1", "data_2"])
+    ar = st.AutoregressiveComponent(order=3, name="ar", observed_state_names=["data_1", "data_2"])
     mod = ar.build(verbose=False)
 
     assert mod.k_endog == 2
@@ -33,18 +32,18 @@ def test_autoregressive_multiple_observed_build(rng):
     assert mod.k_posdef == 2
 
     assert mod.state_names == [
-        "L1[data_1]",
-        "L2[data_1]",
-        "L3[data_1]",
-        "L1[data_2]",
-        "L2[data_2]",
-        "L3[data_2]",
+        "L1_ar[data_1]",
+        "L2_ar[data_1]",
+        "L3_ar[data_1]",
+        "L1_ar[data_2]",
+        "L2_ar[data_2]",
+        "L3_ar[data_2]",
     ]
 
-    assert mod.shock_names == ["auto_regressive[data_1]", "auto_regressive[data_2]"]
+    assert mod.shock_names == ["ar[data_1]", "ar[data_2]"]
 
     params = {
-        "params_auto_regressive": np.full(
+        "params_ar": np.full(
             (
                 2,
                 sum(ar.order),
@@ -52,7 +51,7 @@ def test_autoregressive_multiple_observed_build(rng):
             0.5,
             dtype=config.floatX,
         ),
-        "sigma_auto_regressive": np.array([0.05, 0.12]),
+        "sigma_ar": np.array([0.05, 0.12]),
     }
     _, _, _, _, T, Z, R, _, Q = mod._unpack_statespace_with_placeholders()
     input_vars = explicit_graph_inputs([T, Z, R, Q])
@@ -89,6 +88,33 @@ def test_autoregressive_multiple_observed_build(rng):
     np.testing.assert_allclose(Q, np.diag([0.05**2, 0.12**2]))
 
 
+def test_autoregressive_multiple_observed_shared():
+    ar = st.AutoregressiveComponent(
+        order=1,
+        name="latent",
+        observed_state_names=["data_1", "data_2", "data_3"],
+        share_states=True,
+    )
+    mod = ar.build(verbose=False)
+
+    assert mod.k_endog == 3
+    assert mod.k_states == 1
+    assert mod.k_posdef == 1
+
+    assert mod.state_names == ["L1_latent[shared]"]
+    assert mod.shock_names == ["latent[shared]"]
+    assert mod.coords["lag_latent"] == [1]
+    assert "endog_latent" not in mod.coords
+
+    outputs = [mod.ssm["transition"], mod.ssm["design"]]
+    params = {"params_latent": np.array([0.9])}
+    T, Z = pytensor.function(list(explicit_graph_inputs(outputs)), outputs)(**params)
+
+    np.testing.assert_allclose(np.array([[1.0], [1.0], [1.0]]), Z)
+
+    np.testing.assert_allclose(np.array([[0.9]]), T)
+
+
 def test_autoregressive_multiple_observed_data(rng):
     ar = st.AutoregressiveComponent(order=1, observed_state_names=["data_1", "data_2", "data_3"])
     mod = ar.build(verbose=False)
@@ -112,21 +138,130 @@ def test_add_autoregressive_different_observed():
 
     mod = (mod_1 + mod_2).build(verbose=False)
 
-    print(mod.coords)
-
     assert mod.k_endog == 2
     assert mod.k_states == 7
     assert mod.k_posdef == 2
     assert mod.state_names == [
-        "L1[data_1]",
-        "L1[data_2]",
-        "L2[data_2]",
-        "L3[data_2]",
-        "L4[data_2]",
-        "L5[data_2]",
-        "L6[data_2]",
+        f"L1_{mod_1.name}[data_1]",
+        f"L1_{mod_2.name}[data_2]",
+        f"L2_{mod_2.name}[data_2]",
+        f"L3_{mod_2.name}[data_2]",
+        f"L4_{mod_2.name}[data_2]",
+        f"L5_{mod_2.name}[data_2]",
+        f"L6_{mod_2.name}[data_2]",
     ]
 
     assert mod.shock_names == ["ar1[data_1]", "ar6[data_2]"]
     assert mod.coords["lag_ar1"] == [1]
     assert mod.coords["lag_ar6"] == [1, 2, 3, 4, 5, 6]
+
+
+def test_autoregressive_shared_and_not_shared():
+    shared = st.AutoregressiveComponent(
+        order=3,
+        name="shared_ar",
+        observed_state_names=["data_1", "data_2", "data_3"],
+        share_states=True,
+    )
+    individual = st.AutoregressiveComponent(
+        order=3,
+        name="individual_ar",
+        observed_state_names=["data_1", "data_2", "data_3"],
+        share_states=False,
+    )
+
+    mod = (shared + individual).build(verbose=False)
+
+    assert mod.k_endog == 3
+    assert mod.k_states == 3 + 3 * 3
+    assert mod.k_posdef == 4
+
+    assert mod.state_names == [
+        "L1_shared_ar[shared]",
+        "L2_shared_ar[shared]",
+        "L3_shared_ar[shared]",
+        "L1_individual_ar[data_1]",
+        "L2_individual_ar[data_1]",
+        "L3_individual_ar[data_1]",
+        "L1_individual_ar[data_2]",
+        "L2_individual_ar[data_2]",
+        "L3_individual_ar[data_2]",
+        "L1_individual_ar[data_3]",
+        "L2_individual_ar[data_3]",
+        "L3_individual_ar[data_3]",
+    ]
+
+    assert mod.shock_names == [
+        "shared_ar[shared]",
+        "individual_ar[data_1]",
+        "individual_ar[data_2]",
+        "individual_ar[data_3]",
+    ]
+    assert mod.coords["lag_shared_ar"] == [1, 2, 3]
+    assert mod.coords["lag_individual_ar"] == [1, 2, 3]
+
+    outputs = [mod.ssm["transition"], mod.ssm["design"], mod.ssm["selection"], mod.ssm["state_cov"]]
+    T, Z, R, Q = pytensor.function(
+        list(explicit_graph_inputs(outputs)),
+        outputs,
+    )(
+        **{
+            "params_shared_ar": np.array([0.9, 0.8, 0.7]),
+            "params_individual_ar": np.full((3, 3), 0.5),
+            "sigma_shared_ar": np.array(0.1),
+            "sigma_individual_ar": np.array([0.05, 0.12, 0.22]),
+        }
+    )
+
+    np.testing.assert_allclose(
+        T,
+        np.array(
+            [
+                [0.9, 0.8, 0.7, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, 0.5, 0.5],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_allclose(
+        Z,
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_allclose(
+        R,
+        np.array(
+            [
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_allclose(Q, np.diag([0.1, 0.05, 0.12, 0.22]) ** 2)

--- a/tests/statespace/models/structural/components/test_cycle.py
+++ b/tests/statespace/models/structural/components/test_cycle.py
@@ -122,9 +122,9 @@ def test_multivariate_cycle_with_shared(rng):
 
     assert cycle.state_names == ["Cos_cycle[shared]", "Sin_cycle[shared]"]
     assert cycle.shock_names == []
-    assert cycle.param_names == ["cycle"]
+    assert cycle.param_names == ["params_cycle"]
 
-    params = {"cycle": np.array([1.0, 2.0], dtype=config.floatX)}
+    params = {"params_cycle": np.array([1.0, 2.0], dtype=config.floatX)}
     x, y = simulate_from_numpy_model(cycle, rng, params, steps=12 * 12)
 
     np.testing.assert_allclose(y[:, 0], y[:, 1], atol=ATOL, rtol=RTOL)
@@ -351,9 +351,9 @@ def test_add_multivariate_shared_and_not_shared():
     assert mod.shock_names == expected_states[:2]
 
     assert mod.param_names == [
-        "shared_cycle",
+        "params_shared_cycle",
         "sigma_shared_cycle",
-        "individual_cycle",
+        "params_individual_cycle",
         "length_individual_cycle",
         "dampening_factor_individual_cycle",
         "P0",
@@ -364,17 +364,17 @@ def test_add_multivariate_shared_and_not_shared():
     assert mod.coords["state_individual_cycle"] == ["Cos_individual_cycle", "Sin_individual_cycle"]
     assert mod.coords["endog_individual_cycle"] == ["gdp", "inflation", "unemployment"]
 
-    assert mod.param_info["shared_cycle"]["dims"] == ("state_shared_cycle",)
-    assert mod.param_info["shared_cycle"]["shape"] == (2,)
+    assert mod.param_info["params_shared_cycle"]["dims"] == ("state_shared_cycle",)
+    assert mod.param_info["params_shared_cycle"]["shape"] == (2,)
 
     assert mod.param_info["sigma_shared_cycle"]["dims"] is None
     assert mod.param_info["sigma_shared_cycle"]["shape"] == ()
 
-    assert mod.param_info["individual_cycle"]["dims"] == (
+    assert mod.param_info["params_individual_cycle"]["dims"] == (
         "endog_individual_cycle",
         "state_individual_cycle",
     )
-    assert mod.param_info["individual_cycle"]["shape"] == (3, 2)
+    assert mod.param_info["params_individual_cycle"]["shape"] == (3, 2)
 
     params = {
         "length_individual_cycle": 12.0,

--- a/tests/statespace/models/structural/components/test_level_trend.py
+++ b/tests/statespace/models/structural/components/test_level_trend.py
@@ -91,6 +91,44 @@ def test_level_trend_multiple_observed_construction():
     )
 
 
+def test_level_trend_multiple_shared_construction():
+    mod = st.LevelTrendComponent(
+        order=2, innovations_order=1, observed_state_names=["data_1", "data_2"], share_states=True
+    )
+    mod = mod.build(verbose=False)
+
+    assert mod.k_endog == 2
+    assert mod.k_states == 2
+    assert mod.k_posdef == 1
+
+    assert mod.coords["state_level_trend"] == ["level", "trend"]
+    assert mod.coords["endog_level_trend"] == ["data_1", "data_2"]
+
+    assert mod.state_names == [
+        "level[level_trend_shared]",
+        "trend[level_trend_shared]",
+    ]
+    assert mod.shock_names == ["level[level_trend_shared]"]
+
+    Z, T, R = pytensor.function(
+        [], [mod.ssm["design"], mod.ssm["transition"], mod.ssm["selection"]], mode="FAST_COMPILE"
+    )()
+
+    np.testing.assert_allclose(
+        Z,
+        np.array(
+            [
+                [1.0, 0.0],
+                [1.0, 0.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_allclose(T, np.array([[1.0, 1.0], [0.0, 1.0]]))
+
+    np.testing.assert_allclose(R, np.array([[1.0], [0.0]]))
+
+
 def test_level_trend_multiple_observed(rng):
     mod = st.LevelTrendComponent(
         order=2, innovations_order=0, observed_state_names=["data_1", "data_2", "data_3"]
@@ -100,6 +138,19 @@ def test_level_trend_multiple_observed(rng):
     x, y = simulate_from_numpy_model(mod, rng, params)
     assert (np.diff(y, axis=0) == np.array([[1.0, 2.0, 3.0]])).all().all()
     assert (np.diff(x, axis=0) == np.array([[1.0, 0.0, 2.0, 0.0, 3.0, 0.0]])).all().all()
+
+
+def test_level_trend_multiple_shared_observed(rng):
+    mod = st.LevelTrendComponent(
+        order=2,
+        innovations_order=0,
+        observed_state_names=["data_1", "data_2", "data_3"],
+        share_states=True,
+    )
+    params = {"initial_level_trend": np.array([10.0, 0.1])}
+    x, y = simulate_from_numpy_model(mod, rng, params)
+    np.testing.assert_allclose(y[:, 0], y[:, 1])
+    np.testing.assert_allclose(y[:, 0], y[:, 2])
 
 
 def test_add_level_trend_with_different_observed():
@@ -153,6 +204,80 @@ def test_add_level_trend_with_different_observed():
                 [0.0, 0.0],
                 [1.0, 0.0],
                 [0.0, 1.0],
+            ]
+        ),
+    )
+
+
+def test_mixed_shared_and_not_shared():
+    mod_1 = st.LevelTrendComponent(
+        name="individual",
+        order=2,
+        innovations_order=[0, 1],
+        observed_state_names=["data_1", "data_2"],
+    )
+    mod_2 = st.LevelTrendComponent(
+        name="joint",
+        order=2,
+        innovations_order=[1, 1],
+        observed_state_names=["data_1", "data_2"],
+        share_states=True,
+    )
+
+    mod = (mod_1 + mod_2).build(verbose=False)
+
+    assert mod.k_endog == 2
+    assert mod.k_states == 6
+    assert mod.k_posdef == 4
+
+    assert mod.state_names == [
+        "level[data_1]",
+        "trend[data_1]",
+        "level[data_2]",
+        "trend[data_2]",
+        "level[joint_shared]",
+        "trend[joint_shared]",
+    ]
+
+    assert mod.shock_names == [
+        "trend[data_1]",
+        "trend[data_2]",
+        "level[joint_shared]",
+        "trend[joint_shared]",
+    ]
+
+    Z, T, R = pytensor.function(
+        [], [mod.ssm["design"], mod.ssm["transition"], mod.ssm["selection"]], mode="FAST_COMPILE"
+    )()
+
+    np.testing.assert_allclose(
+        Z, np.array([[1.0, 0.0, 0.0, 0.0, 1.0, 0.0], [0.0, 0.0, 1.0, 0.0, 1.0, 0.0]])
+    )
+
+    np.testing.assert_allclose(
+        T,
+        np.array(
+            [
+                [1.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, 1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            ]
+        ),
+    )
+
+    np.testing.assert_allclose(
+        R,
+        np.array(
+            [
+                [0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0],
             ]
         ),
     )

--- a/tests/statespace/models/structural/components/test_measurement_error.py
+++ b/tests/statespace/models/structural/components/test_measurement_error.py
@@ -1,4 +1,7 @@
 import numpy as np
+import pytensor
+
+from pytensor.graph.basic import explicit_graph_inputs
 
 from pymc_extras.statespace.models import structural as st
 from tests.statespace.models.structural.conftest import _assert_basic_coords_correct
@@ -17,6 +20,45 @@ def test_measurement_error_multiple_observed():
     assert mod.k_endog == 2
     assert mod.coords["endog_obs"] == ["data_1", "data_2"]
     assert mod.param_dims["sigma_obs"] == ("endog_obs",)
+
+
+def test_measurement_error_share_states():
+    mod = st.MeasurementError("obs", observed_state_names=["data_1", "data_2"], share_states=True)
+    mod.build(verbose=False)
+
+    assert mod.k_endog == 2
+    assert mod.param_names == ["sigma_obs", "P0"]
+    assert "endog_obs" not in mod.coords
+
+    # Check that the parameter is shared across the observed states
+    assert mod.param_info["sigma_obs"]["shape"] == ()
+
+    outputs = mod.ssm["obs_cov"]
+
+    H = pytensor.function(list(explicit_graph_inputs([outputs])), outputs)(sigma_obs=np.array(0.5))
+    np.testing.assert_allclose(H, np.diag([0.5, 0.5]) ** 2)
+
+
+def test_measurement_error_shared_and_not_shared():
+    shared = st.MeasurementError(
+        "error_shared", observed_state_names=["data_1", "data_2"], share_states=True
+    )
+    individual = st.MeasurementError("error_individual", observed_state_names=["data_1", "data_2"])
+    mod = (shared + individual).build(verbose=False)
+
+    assert mod.k_endog == 2
+    assert mod.param_names == ["sigma_error_shared", "sigma_error_individual", "P0"]
+    assert mod.coords["endog_error_individual"] == ["data_1", "data_2"]
+
+    assert mod.param_info["sigma_error_shared"]["shape"] == ()
+    assert mod.param_info["sigma_error_individual"]["shape"] == (2,)
+
+    outputs = mod.ssm["obs_cov"]
+
+    H = pytensor.function(list(explicit_graph_inputs([outputs])), outputs)(
+        sigma_error_shared=np.array(0.5), sigma_error_individual=np.array([0.1, 0.9])
+    )
+    np.testing.assert_allclose(H, np.diag([0.5, 0.5]) ** 2 + np.diag([0.1, 0.9]) ** 2)
 
 
 def test_build_with_measurement_error_subset():

--- a/tests/statespace/models/structural/components/test_seasonality.py
+++ b/tests/statespace/models/structural/components/test_seasonality.py
@@ -474,6 +474,39 @@ def test_frequency_seasonality_multiple_observed(rng):
     np.testing.assert_allclose(Q_diag, expected_Q_diag, atol=ATOL, rtol=RTOL)
 
 
+def test_frequency_seasonality_multivariate_shared_states():
+    mod = st.FrequencySeasonality(
+        season_length=4,
+        n=1,
+        name="season",
+        innovations=True,
+        observed_state_names=["data_1", "data_2"],
+        share_states=True,
+    )
+
+    assert mod.k_endog == 2
+    assert mod.k_states == 2
+    assert mod.k_posdef == 2
+
+    assert mod.state_names == ["Cos_0_season[shared]", "Sin_0_season[shared]"]
+    assert mod.shock_names == ["Cos_0_season[shared]", "Sin_0_season[shared]"]
+
+    assert mod.coords["state_season"] == ["Cos_0_season", "Sin_0_season"]
+
+    Z, T, R = pytensor.function(
+        [], [mod.ssm["design"], mod.ssm["transition"], mod.ssm["selection"]], mode="FAST_COMPILE"
+    )()
+
+    np.testing.assert_allclose(np.array([[1.0, 0.0], [1.0, 0.0]]), Z)
+
+    np.testing.assert_allclose(np.array([[1.0, 0.0], [0.0, 1.0]]), R)
+
+    lam = 2 * np.pi * 1 / 4
+    np.testing.assert_allclose(
+        np.array([[np.cos(lam), np.sin(lam)], [-np.sin(lam), np.cos(lam)]]), T
+    )
+
+
 def test_add_two_frequency_seasonality_different_observed(rng):
     mod1 = st.FrequencySeasonality(
         season_length=4,
@@ -559,6 +592,42 @@ def test_add_two_frequency_seasonality_different_observed(rng):
     expected_T[4:6, 4:6] = freq2_T
 
     np.testing.assert_allclose(expected_T, T_v, atol=ATOL, rtol=RTOL)
+
+
+def test_add_frequency_seasonality_shared_and_not_shared():
+    shared_season = st.FrequencySeasonality(
+        season_length=4,
+        n=1,
+        name="shared_season",
+        innovations=True,
+        observed_state_names=["data_1", "data_2"],
+        share_states=True,
+    )
+
+    individual_season = st.FrequencySeasonality(
+        season_length=4,
+        n=2,
+        name="individual_season",
+        innovations=True,
+        observed_state_names=["data_1", "data_2"],
+        share_states=False,
+    )
+
+    mod = (shared_season + individual_season).build(verbose=False)
+
+    assert mod.k_endog == 2
+    assert mod.k_states == 10
+    assert mod.k_posdef == 10
+
+    assert mod.coords["state_shared_season"] == [
+        "Cos_0_shared_season",
+        "Sin_0_shared_season",
+    ]
+    assert mod.coords["state_individual_season"] == [
+        "Cos_0_individual_season",
+        "Sin_0_individual_season",
+        "Cos_1_individual_season",
+    ]
 
 
 @pytest.mark.parametrize(

--- a/tests/statespace/models/structural/test_against_statsmodels.py
+++ b/tests/statespace/models/structural/test_against_statsmodels.py
@@ -404,7 +404,7 @@ def create_structural_model_and_equivalent_statsmodel(
         components.append(comp)
 
     if autoregressive is not None:
-        ar_names = [f"L{i + 1}" for i in range(autoregressive)]
+        ar_names = [f"L{i + 1}_ar" for i in range(autoregressive)]
         params_ar = rng.normal(size=(autoregressive,)).astype(floatX)
         if autoregressive == 1:
             params_ar = params_ar.item()


### PR DESCRIPTION
This PR allows multivariate components to share latent states between observed states. For example, if we want two states to have a shared component and an idiosyncratic component, as in:

$$
\begin{align}
a_t &= x_t + y_t \\
b_t &= x_t + z_t \\
\end{align}
$$

This can be accomplished as follows:

```py
    shared_level = st.LevelTrendComponent(
        name="shared_level",
        order=1,
        innovations_order=1,
        observed_state_names=["a", "b"],
        share_states=True,
    )
    individual_level = st.LevelTrendComponent(
        name="individual_level",
        order=1,
        innovations_order=1,
        observed_state_names=["a", "b"],
    )

    mod = (shared_level + individual_level).build(verbose=False)
```

This will require a refactor for each component to add the `shared_states` argument. Here's the TODO list:

- [x] LevelTrendComponent
- [x] AutoregressiveComponent
- [x] CycleComponent
- [x] RegressionComponent
- [x] TimeSeasonality
- [x] FrequencySeasonality
- [x] MeasurementError

