### PR TITLE
Allow exogenous regressions in `BayesianSARIMAX`

### DIFF
--- a/pymc_extras/statespace/__init__.py
+++ b/pymc_extras/statespace/__init__.py
@@ -1,12 +1,12 @@
 from pymc_extras.statespace.core.compile import compile_statespace
 from pymc_extras.statespace.models import structural
 from pymc_extras.statespace.models.ETS import BayesianETS
-from pymc_extras.statespace.models.SARIMAX import BayesianSARIMA
+from pymc_extras.statespace.models.SARIMAX import BayesianSARIMAX
 from pymc_extras.statespace.models.VARMAX import BayesianVARMAX
 
 __all__ = [
     "BayesianETS",
-    "BayesianSARIMA",
+    "BayesianSARIMAX",
     "BayesianVARMAX",
     "compile_statespace",
     "structural",

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -233,10 +233,9 @@ class PyMCStateSpace:
         self._fit_coords: dict[str, Sequence[str]] | None = None
         self._fit_dims: dict[str, Sequence[str]] | None = None
         self._fit_data: pt.TensorVariable | None = None
+        self._fit_exog_data: dict[str, dict] = {}
 
         self._needs_exog_data = None
-        self._exog_names = []
-        self._exog_data_info = {}
         self._name_to_variable = {}
         self._name_to_data = {}
 
@@ -671,7 +670,7 @@ class PyMCStateSpace:
         pymc_mod = modelcontext(None)
         for data_name in self.data_names:
             data = pymc_mod[data_name]
-            self._exog_data_info[data_name] = {
+            self._fit_exog_data[data_name] = {
                 "name": data_name,
                 "value": data.get_value(),
                 "dims": pymc_mod.named_vars_to_dims.get(data_name, None),
@@ -685,7 +684,7 @@ class PyMCStateSpace:
         --------
         .. code:: python
 
-            ss_mod = pmss.BayesianSARIMA(order=(2, 0, 2), verbose=False, stationary_initialization=True)
+            ss_mod = pmss.BayesianSARIMAX(order=(2, 0, 2), verbose=False, stationary_initialization=True)
             with pm.Model():
                  x0 = pm.Normal('x0', size=ss_mod.k_states)
                  ar_params = pm.Normal('ar_params', size=ss_mod.p)
@@ -1082,7 +1081,7 @@ class PyMCStateSpace:
 
         for name in self.data_names:
             if name not in pm_mod:
-                pm.Data(**self._exog_data_info[name])
+                pm.Data(**self._fit_exog_data[name])
 
         self._insert_data_variables()
 
@@ -1229,7 +1228,7 @@ class PyMCStateSpace:
                     method=mvn_method,
                 )
 
-                obs_mu = (Z @ mu[..., None]).squeeze(-1)
+                obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
                 obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
 
                 SequenceMvNormal(
@@ -1351,7 +1350,7 @@ class PyMCStateSpace:
             self._insert_random_variables()
 
             for name in self.data_names:
-                pm.Data(**self._exog_data_info[name])
+                pm.Data(**self._fit_exog_data[name])
 
             self._insert_data_variables()
 
@@ -1651,7 +1650,7 @@ class PyMCStateSpace:
             self._insert_random_variables()
 
             for name in self.data_names:
-                pm.Data(**self._exog_data_info[name])
+                pm.Data(**self.data_info[name])
 
             self._insert_data_variables()
             matrices = self.unpack_statespace()
@@ -1703,7 +1702,7 @@ class PyMCStateSpace:
 
             if self.data_names:
                 for name in self.data_names:
-                    pm.Data(**self._exog_data_info[name])
+                    pm.Data(**self._fit_exog_data[name])
 
             self._insert_data_variables()
 
@@ -1846,7 +1845,7 @@ class PyMCStateSpace:
         }
 
         if self._needs_exog_data and scenario is None:
-            exog_str = ",".join(self._exog_names)
+            exog_str = ",".join(self.data_names)
             suffix = "s" if len(exog_str) > 1 else ""
             raise ValueError(
                 f"This model was fit using exogenous data. Forecasting cannot be performed without "
@@ -1855,7 +1854,7 @@ class PyMCStateSpace:
 
         if isinstance(scenario, dict):
             for name, data in scenario.items():
-                if name not in self._exog_names:
+                if name not in self.data_names:
                     raise ValueError(
                         f"Scenario data provided for variable '{name}', which is not an exogenous variable "
                         f"used to fit the model."
@@ -1896,12 +1895,12 @@ class PyMCStateSpace:
                 # name should only be None on the first non-recursive call. We only arrive to this branch in that case
                 # if a non-dictionary was passed, which in turn should only happen if only a single exogenous data
                 # needs to be set.
-                if len(self._exog_names) > 1:
+                if len(self.data_names) > 1:
                     raise ValueError(
                         "Multiple exogenous variables were used to fit the model. Provide a dictionary of "
                         "scenario data instead."
                     )
-                name = self._exog_names[0]
+                name = self.data_names[0]
 
             # Omit dataframe from this basic shape check so we can give more detailed information about missing columns
             # in the next check
@@ -2103,7 +2102,7 @@ class PyMCStateSpace:
             return scenario
 
         # This was already checked as valid
-        name = self._exog_names[0] if name is None else name
+        name = self.data_names[0] if name is None else name
 
         # Small tidying up in the case we just have a single scenario that's already a dataframe.
         if isinstance(scenario, pd.DataFrame | pd.Series):

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -17,6 +17,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
     ALL_STATE_DIM,
     AR_PARAM_DIM,
+    EXOGENOUS_DIM,
     MA_PARAM_DIM,
     OBS_STATE_DIM,
     SARIMAX_STATE_STRUCTURES,
@@ -314,7 +315,7 @@ class BayesianSARIMAX(PyMCStateSpace):
     def data_info(self) -> dict[str, dict[str, Any]]:
         info = {
             "exogenous_data": {
-                "dims": (TIME_DIM, "exogenous"),
+                "dims": (TIME_DIM, EXOGENOUS_DIM),
                 "shape": (None, self.k_exog),
             }
         }
@@ -350,7 +351,7 @@ class BayesianSARIMAX(PyMCStateSpace):
             },
             "seasonal_ar_params": {"shape": (self.P,), "constraints": "None"},
             "seasonal_ma_params": {"shape": (self.Q,), "constraints": "None"},
-            "beta_exog": {"shape": (self.k_exog,), "constraints": "None", "dims": ("exogenous",)},
+            "beta_exog": {"shape": (self.k_exog,), "constraints": "None"},
         }
 
         for name in self.param_names:
@@ -402,7 +403,7 @@ class BayesianSARIMAX(PyMCStateSpace):
             "ma_params": (MA_PARAM_DIM,),
             "seasonal_ar_params": (SEASONAL_AR_PARAM_DIM,),
             "seasonal_ma_params": (SEASONAL_MA_PARAM_DIM,),
-            "beta_exog": ("exogenous",),
+            "beta_exog": (EXOGENOUS_DIM,),
         }
         if self.k_endog == 1:
             coord_map["sigma_state"] = None
@@ -437,7 +438,7 @@ class BayesianSARIMAX(PyMCStateSpace):
         if self.Q > 0:
             coords.update({SEASONAL_MA_PARAM_DIM: list(range(1, self.Q + 1))})
         if self.k_exog > 0:
-            coords.update({"exogenous": self.exog_state_names})
+            coords.update({EXOGENOUS_DIM: self.exog_state_names})
         return coords
 
     def _stationary_initialization(self):

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -40,68 +40,15 @@ def _verify_order(p, d, q, P, D, Q, S):
 
 class BayesianSARIMA(PyMCStateSpace):
     r"""
-    Seasonal AutoRegressive Integrated Moving Average with eXogenous regressors
+    Seasonal AutoRegressive Integrated Moving Average with eXogenous regressors.
 
-    Parameters
-    ----------
-    order: tuple(int, int, int)
-        Order of the ARIMA process. The order has the notation (p, d, q), where p is the number of autoregressive
-        lags, q is the number of moving average components, and d is order of integration -- the number of
-        differences needed to render the data stationary.
-
-        If d > 0, the differences are modeled as components of the hidden state, and all available data can be used.
-        This is only possible if state_structure = 'fast'. For interpretable states, the user must manually
-        difference the data prior to calling the `build_statespace_graph` method.
-
-    seasonal_order: tuple(int, int, int, int), optional
-        Seasonal order of the SARIMA process. The order has the notation (P, D, Q, S), where P is the number of seasonal
-        lags to include, Q is the number of seasonal innovation lags to include, and D is the number of seasonal
-        differences to perform. S is the length of the season.
-
-        Seasonal terms are similar to ARIMA terms, in that they are merely lags of the data or innovations. It is thus
-        possible for the seasonal lags and the ARIMA lags to overlap, for example if P <= p. In this case, an error
-        will be raised.
-
-    stationary_initialization: bool, default False
-        If true, the initial state and initial state covariance will not be assigned priors. Instead, their steady
-        state values will be used.
-
-        .. warning:: This option is very sensitive to the priors placed on the AR and MA parameters. If the model dynamics
-                  for a given sample are not stationary, sampling will fail with a "covariance is not positive semi-definite"
-                  error.
-
-    filter_type: str, default "standard"
-        The type of Kalman Filter to use. Options are "standard", "single", "univariate", "steady_state",
-        and "cholesky". See the docs for kalman filters for more details.
-
-    state_structure: str, default "fast"
-        How to represent the state-space system. Currently, there are two choices: "fast" or "interpretable"
-
-        - "fast" corresponds to the state space used by [2], and is called the "Harvey" representation in statsmodels.
-           This is also the default representation used by statsmodels.tsa.statespace.SARIMAX. The states combine lags
-           and innovations at different lags to compress the dimension of the state vector to max(p, 1+q). As a result,
-           it is very preformat, but only the first state has a clear interpretation.
-
-        - "interpretable" maximally expands the state vector, doing zero state compression. As a result, the state has
-          dimension max(1, p) + max(1, q). What is gained by doing this is that every state has an obvious meaning, as
-          either the data, an innovation, or a lag thereof.
-
-    measurement_error: bool, default True
-        If true, a measurement error term is added to the model.
-
-    verbose: bool, default True
-        If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
-
-    mode: str or Mode, optional
-        Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
-        ``forecast``. The mode does **not** effect calls to ``pm.sample``.
-
-        Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
-        to all sampling methods.
+    This class implements a Bayesian approach to SARIMA models, which are used for
+    modeling univariate time series data with seasonal and non-seasonal components.
+    The model supports exogenous regressors and can be represented in state-space form.
 
     Notes
     -----
-        The ARIMAX model is a univariate time series model that posits the future evolution of a stationary time series will
+    The ARIMAX model is a univariate time series model that posits the future evolution of a stationary time series will
     be a function of its past values, together with exogenous "innovations" and their past history. The model is
     described by its "order", a 3-tuple (p, d, q), that are:
 
@@ -183,6 +130,8 @@ class BayesianSARIMA(PyMCStateSpace):
         self,
         order: tuple[int, int, int],
         seasonal_order: tuple[int, int, int, int] | None = None,
+        exog_state_names: list[str] | None = None,
+        k_exog: int | None = None,
         stationary_initialization: bool = True,
         filter_type: str = "standard",
         state_structure: str = "fast",
@@ -191,22 +140,92 @@ class BayesianSARIMA(PyMCStateSpace):
         mode: str | Mode | None = None,
     ):
         """
+        Initialize a BayesianSARIMA model.
 
         Parameters
         ----------
-        order
-        seasonal_order
-        stationary_initialization
-        filter_type
-        state_structure
-        measurement_error
-        verbose
-        mode
+        order : tuple(int, int, int)
+            Order of the ARIMA process. The order has the notation (p, d, q), where p is the number of autoregressive
+            lags, q is the number of moving average components, and d is order of integration -- the number of
+            differences needed to render the data stationary.
+
+            If d > 0, the differences are modeled as components of the hidden state, and all available data can be used.
+            This is only possible if state_structure = 'fast'. For interpretable states, the user must manually
+            difference the data prior to calling the `build_statespace_graph` method.
+
+        seasonal_order : tuple(int, int, int, int), optional
+            Seasonal order of the SARIMA process. The order has the notation (P, D, Q, S), where P is the number of seasonal
+            lags to include, Q is the number of seasonal innovation lags to include, and D is the number of seasonal
+            differences to perform. S is the length of the season.
+
+            Seasonal terms are similar to ARIMA terms, in that they are merely lags of the data or innovations. It is thus
+            possible for the seasonal lags and the ARIMA lags to overlap, for example if P <= p. In this case, an error
+            will be raised.
+
+        exog_state_names : list[str], optional
+            Names of the exogenous state variables.
+
+        k_exog : int, optional
+            Number of exogenous variables. If provided, must match the length of
+            `exog_state_names`.
+
+        stationary_initialization : bool, default True
+            If true, the initial state and initial state covariance will not be assigned priors. Instead, their steady
+            state values will be used.
+
+            .. warning:: This option is very sensitive to the priors placed on the AR and MA parameters. If the model dynamics
+                      for a given sample are not stationary, sampling will fail with a "covariance is not positive semi-definite"
+                      error.
+
+        filter_type : str, default "standard"
+            The type of Kalman Filter to use. Options are "standard", "single", "univariate", "steady_state",
+            and "cholesky". See the docs for kalman filters for more details.
+
+        state_structure : str, default "fast"
+            How to represent the state-space system. Currently, there are two choices: "fast" or "interpretable"
+
+            - "fast" corresponds to the state space used by [2], and is called the "Harvey" representation in statsmodels.
+               This is also the default representation used by statsmodels.tsa.statespace.SARIMAX. The states combine lags
+               and innovations at different lags to compress the dimension of the state vector to max(p, 1+q). As a result,
+               it is very performant, but only the first state has a clear interpretation.
+
+            - "interpretable" maximally expands the state vector, doing zero state compression. As a result, the state has
+              dimension max(1, p) + max(1, q). What is gained by doing this is that every state has an obvious meaning, as
+              either the data, an innovation, or a lag thereof.
+
+        measurement_error : bool, default False
+            If true, a measurement error term is added to the model.
+
+        verbose : bool, default True
+            If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
+
+        mode : str or Mode, optional
+            Pytensor compile mode, used in auxiliary sampling methods such as ``sample_conditional_posterior`` and
+            ``forecast``. The mode does **not** affect calls to ``pm.sample``.
+
+            Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
+            to all sampling methods.
         """
         # Model order
         self.p, self.d, self.q = order
         if seasonal_order is None:
             seasonal_order = (0, 0, 0, 0)
+
+        if exog_state_names is None and k_exog is not None:
+            exog_state_names = [f"exogenous_{i}" for i in range(k_exog)]
+        elif exog_state_names is not None and k_exog is None:
+            k_exog = len(exog_state_names)
+        elif exog_state_names is not None and k_exog is not None:
+            if len(exog_state_names) != k_exog:
+                raise ValueError(
+                    f"Based on provided inputs, expected exog_state_names to have {k_exog} elements, but "
+                    f"found {len(exog_state_names)}"
+                )
+        else:
+            k_exog = 0
+
+        self.exog_state_names = exog_state_names
+        self.k_exog = k_exog
 
         self.P, self.D, self.Q, self.S = seasonal_order
         _verify_order(self.p, self.d, self.q, self.P, self.D, self.Q, self.S)
@@ -262,6 +281,7 @@ class BayesianSARIMA(PyMCStateSpace):
             "ma_params",
             "seasonal_ar_params",
             "seasonal_ma_params",
+            "beta_exog",
             "sigma_state",
             "sigma_obs",
         ]
@@ -276,6 +296,8 @@ class BayesianSARIMA(PyMCStateSpace):
             names.remove("ma_params")
         if self.Q == 0:
             names.remove("seasonal_ma_params")
+        if self.k_exog == 0:
+            names.remove("beta_exog")
         if not self.measurement_error:
             names.remove("sigma_obs")
 
@@ -310,6 +332,7 @@ class BayesianSARIMA(PyMCStateSpace):
             },
             "seasonal_ar_params": {"shape": (self.P,), "constraints": "None"},
             "seasonal_ma_params": {"shape": (self.Q,), "constraints": "None"},
+            "beta_exog": {"shape": (self.k_exog,), "constraints": "None"},
         }
 
         for name in self.param_names:
@@ -334,6 +357,9 @@ class BayesianSARIMA(PyMCStateSpace):
         else:
             raise NotImplementedError()
 
+        if self.k_exog > 0:
+            states += ["exogenous"]
+
         return states
 
     @property
@@ -355,6 +381,7 @@ class BayesianSARIMA(PyMCStateSpace):
             "ma_params": (MA_PARAM_DIM,),
             "seasonal_ar_params": (SEASONAL_AR_PARAM_DIM,),
             "seasonal_ma_params": (SEASONAL_MA_PARAM_DIM,),
+            "beta_exog": ("exogenous",),
         }
         if self.k_endog == 1:
             coord_map["sigma_state"] = None
@@ -369,6 +396,8 @@ class BayesianSARIMA(PyMCStateSpace):
             del coord_map["seasonal_ar_params"]
         if self.Q == 0:
             del coord_map["seasonal_ma_params"]
+        if not self.k_exog == 0:
+            del coord_map["beta_exog"]
         if self.stationary_initialization:
             del coord_map["P0"]
             del coord_map["x0"]
@@ -386,7 +415,8 @@ class BayesianSARIMA(PyMCStateSpace):
             coords.update({SEASONAL_AR_PARAM_DIM: list(range(1, self.P + 1))})
         if self.Q > 0:
             coords.update({SEASONAL_MA_PARAM_DIM: list(range(1, self.Q + 1))})
-
+        if self.k_exog > 0:
+            coords.update({"exogenous": self.exog_state_names})
         return coords
 
     def _stationary_initialization(self):
@@ -534,6 +564,18 @@ class BayesianSARIMA(PyMCStateSpace):
                     self.ssm[cross_term_idx] = pt.repeat(seasonal_ma_params, q) * pt.tile(
                         ma_params, Q
                     )
+
+        # If exogenous regressors are present, register them as data and include a regression term
+        # in the observation intercept
+        if self.k_exog > 0:
+            exog_data = self.make_and_register_data(
+                "exogenous_data", shape=(None, self.k_exog), dtype=floatX
+            )
+            exog_beta = self.make_and_register_variable(
+                "beta_exog", shape=(self.k_exog,), dtype=floatX
+            )
+
+            self.ssm["obs_intercept", :, :] = exog_data @ exog_beta
 
         # Set up the state covariance matrix
         state_cov_idx = ("state_cov", *np.diag_indices(self.k_posdef))

--- a/pymc_extras/statespace/models/__init__.py
+++ b/pymc_extras/statespace/models/__init__.py
@@ -1,6 +1,6 @@
 from pymc_extras.statespace.models import structural
 from pymc_extras.statespace.models.ETS import BayesianETS
-from pymc_extras.statespace.models.SARIMAX import BayesianSARIMA
+from pymc_extras.statespace.models.SARIMAX import BayesianSARIMAX
 from pymc_extras.statespace.models.VARMAX import BayesianVARMAX
 
-__all__ = ["BayesianETS", "BayesianSARIMA", "BayesianVARMAX", "structural"]
+__all__ = ["BayesianSARIMAX", "BayesianVARMAX", "BayesianETS", "structural"]

--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -46,7 +46,7 @@ class AutoregressiveComponent(Component):
     The coefficient :math:`\rho_3` has been constrained to zero.
 
     .. warning:: This class is meant to be used as a component in a structural time series model. For modeling of
-              stationary processes with ARIMA, use ``statespace.BayesianSARIMA``.
+              stationary processes with ARIMA, use ``statespace.BayesianSARIMAX``.
 
     Examples
     --------

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -12,6 +12,7 @@ MA_PARAM_DIM = "lag_ma"
 SEASONAL_AR_PARAM_DIM = "seasonal_lag_ar"
 SEASONAL_MA_PARAM_DIM = "seasonal_lag_ma"
 ETS_SEASONAL_DIM = "seasonal_lag"
+EXOGENOUS_DIM = "exogenous"
 
 NEVER_TIME_VARYING = ["initial_state", "initial_state_cov", "a0", "P0"]
 VECTOR_VALUED = ["initial_state", "state_intercept", "obs_intercept", "a0", "c", "d"]

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -2,6 +2,7 @@ import re
 
 from collections.abc import Sequence
 from functools import partial
+from typing import Any
 
 import numpy as np
 import pandas as pd
@@ -44,8 +45,12 @@ def make_statespace_mod(k_endog, k_states, k_posdef, filter_type, verbose=False,
             pass
 
         @property
-        def data_info(self):
+        def data_info(self) -> dict[str, dict[str, Any]]:
             return data_info
+
+        @property
+        def data_names(self) -> list[str]:
+            return list(data_info.keys()) if data_info is not None else []
 
     ss = StateSpace(
         k_states=k_states,
@@ -55,7 +60,6 @@ def make_statespace_mod(k_endog, k_states, k_posdef, filter_type, verbose=False,
         verbose=verbose,
     )
     ss._needs_exog_data = data_info is not None
-    ss._exog_names = list(data_info.keys()) if data_info is not None else []
 
     return ss
 

--- a/tests/statespace/models/structural/components/test_regression.py
+++ b/tests/statespace/models/structural/components/test_regression.py
@@ -6,8 +6,6 @@ import pytest
 from numpy.testing import assert_allclose
 from pytensor import config
 from pytensor import tensor as pt
-from pytensor.graph.basic import explicit_graph_inputs
-from scipy.linalg import block_diag
 
 from pymc_extras.statespace.models import structural as st
 from tests.statespace.models.structural.conftest import _assert_basic_coords_correct
@@ -327,13 +325,14 @@ def test_regression_mixed_shared_and_not_shared():
         Z,
         np.concat(
             (
-                block_diag(*[data_individual[:, np.newaxis] for _ in range(mod.k_endog)]),
-                np.concat((data_joint[:, np.newaxis], data_joint[:, np.newaxis]), axis=1),
+                pt.linalg.block_diag(
+                    *[data_individual[:, None] for _ in range(mod.k_endog)]
+                ).eval(),
+                np.concat((data_joint[:, None], data_joint[:, None]), axis=1),
             ),
             axis=2,
         ),
     )
 
     np.testing.assert_allclose(T, np.eye(mod.k_states))
-
     np.testing.assert_allclose(R, np.eye(mod.k_states))


### PR DESCRIPTION
Exogenous regressors are added via a time-varying observation bias to keep the statespace as small as possible.

We could consider allowing something fancier, but this is a good v0.