### PR TITLE
Allow exogenous regressors in `BayesianVARMAX`

### DIFF
--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -181,7 +181,7 @@ class BayesianVARMAX(PyMCStateSpace):
             if len(endog_names) != k_endog:
                 raise ValueError("Length of provided endog_names does not match provided k_endog")
 
-        if k_exog is not None and not isinstance(k_endog, int | dict):
+        if k_exog is not None and not isinstance(k_exog, int | dict):
             raise ValueError("If not None, k_endog must be either an int or a dict")
         if exog_state_names is not None and not isinstance(exog_state_names, list | dict):
             raise ValueError("If not None, exog_state_names must be either a list or a dict")

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -223,6 +223,16 @@ class BayesianVARMAX(PyMCStateSpace):
             elif isinstance(exog_state_names, dict):
                 k_exog = {name: len(names) for name, names in exog_state_names.items()}
 
+        # If exog_state_names is a dict but 1) all endog variables are among the keys, and 2) all values are the same
+        # then we can drop back to the list case.
+        if (
+            isinstance(exog_state_names, dict)
+            and set(exog_state_names.keys()) == set(endog_names)
+            and len({frozenset(val) for val in exog_state_names.values()}) == 1
+        ):
+            exog_state_names = exog_state_names[endog_names[0]]
+            k_exog = len(exog_state_names)
+
         self.endog_names = list(endog_names)
         self.exog_state_names = exog_state_names
 

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -174,7 +174,7 @@ class BayesianVARMAX(PyMCStateSpace):
         if (endog_names is not None) and (k_endog is None):
             k_endog = len(endog_names)
         if (endog_names is None) and (k_endog is not None):
-            endog_names = [f"state.{i + 1}" for i in range(k_endog)]
+            endog_names = [f"observed_{i}" for i in range(k_endog)]
         if (endog_names is not None) and (k_endog is not None):
             if len(endog_names) != k_endog:
                 raise ValueError("Length of provided endog_names does not match provided k_endog")
@@ -209,10 +209,10 @@ class BayesianVARMAX(PyMCStateSpace):
 
         if k_exog is not None and exog_state_names is None:
             if isinstance(k_exog, int):
-                exog_state_names = [f"exog.{i + 1}" for i in range(k_exog)]
+                exog_state_names = [f"exogenous_{i}" for i in range(k_exog)]
             elif isinstance(k_exog, dict):
                 exog_state_names = {
-                    name: [f"{name}.exog.{i + 1}" for i in range(k)] for name, k in k_exog.items()
+                    name: [f"{name}_exogenous_{i}" for i in range(k)] for name, k in k_exog.items()
                 }
 
         if k_exog is None and exog_state_names is not None:
@@ -222,6 +222,9 @@ class BayesianVARMAX(PyMCStateSpace):
                 k_exog = {name: len(names) for name, names in exog_state_names.items()}
 
         self.endog_names = list(endog_names)
+        self.exog_state_names = exog_state_names
+
+        self.k_exog = k_exog
         self.p, self.q = order
         self.stationary_initialization = stationary_initialization
 
@@ -299,7 +302,11 @@ class BayesianVARMAX(PyMCStateSpace):
 
     @property
     def data_names(self) -> list[str]:
-        return self._exog_names
+        if isinstance(self.exog_state_names, list):
+            return ["exogenous_data"]
+        elif isinstance(self.exog_state_names, dict):
+            return [f"{endog_state}_exogenous_data" for endog_state in self.exog_state_names.keys()]
+        return []
 
     @property
     def state_names(self):

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -191,355 +191,355 @@ def test_impulse_response(parameters, varma_mod, idata, rng):
     assert not np.any(np.isnan(irf.irf.values))
 
 
-def test_create_varmax_with_exogenous_k_exog_int(data):
-    mod = BayesianVARMAX(
-        k_endog=data.shape[1],
-        order=(1, 0),
-        k_exog=2,
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == 2
-    assert mod.exog_state_names == ["exogenous_0", "exogenous_1"]
-    assert mod.data_names == ["exogenous_data"]
-    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
-    assert mod.coords["exogenous"] == ["exogenous_0", "exogenous_1"]
-    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
-    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
-
-
-def test_create_varmax_with_exogenous_list_of_names(data):
-    mod = BayesianVARMAX(
-        k_endog=data.shape[1],
-        order=(1, 0),
-        exog_state_names=["foo", "bar"],
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == 2
-    assert mod.exog_state_names == ["foo", "bar"]
-    assert mod.data_names == ["exogenous_data"]
-    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
-    assert mod.coords["exogenous"] == ["foo", "bar"]
-    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
-    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
-
-
-def test_create_varmax_with_exogenous_both_defined_correctly(data):
-    mod = BayesianVARMAX(
-        k_endog=data.shape[1],
-        order=(1, 0),
-        k_exog=2,
-        exog_state_names=["a", "b"],
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == 2
-    assert mod.exog_state_names == ["a", "b"]
-    assert mod.data_names == ["exogenous_data"]
-    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
-    assert mod.coords["exogenous"] == ["a", "b"]
-    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
-    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
-
-
-def test_create_varmax_with_exogenous_k_exog_dict(data):
-    k_exog = {"observed_0": 2, "observed_1": 1, "observed_2": 0}
-    mod = BayesianVARMAX(
-        endog_names=["observed_0", "observed_1", "observed_2"],
-        order=(1, 0),
-        k_exog=k_exog,
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == k_exog
-    assert mod.exog_state_names == {
-        "observed_0": ["observed_0_exogenous_0", "observed_0_exogenous_1"],
-        "observed_1": ["observed_1_exogenous_0"],
-        "observed_2": [],
-    }
-    assert mod.data_names == [
-        "observed_0_exogenous_data",
-        "observed_1_exogenous_data",
-        "observed_2_exogenous_data",
-    ]
-    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
-    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
-    assert (
-        "beta_observed_2" not in mod.param_dims
-        or mod.param_info.get("beta_observed_2") is None
-        or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
-    )
-
-    assert mod.coords["exogenous_observed_0"] == [
-        "observed_0_exogenous_0",
-        "observed_0_exogenous_1",
-    ]
-    assert mod.coords["exogenous_observed_1"] == ["observed_1_exogenous_0"]
-    assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
-
-    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
-    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
-    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
-    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
-
-
-def test_create_varmax_with_exogenous_exog_names_dict(data):
-    exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"], "observed_2": []}
-    mod = BayesianVARMAX(
-        endog_names=["observed_0", "observed_1", "observed_2"],
-        order=(1, 0),
-        exog_state_names=exog_state_names,
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == {"observed_0": 2, "observed_1": 1, "observed_2": 0}
-    assert mod.exog_state_names == exog_state_names
-    assert mod.data_names == [
-        "observed_0_exogenous_data",
-        "observed_1_exogenous_data",
-        "observed_2_exogenous_data",
-    ]
-    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
-    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
-    assert (
-        "beta_observed_2" not in mod.param_dims
-        or mod.param_info.get("beta_observed_2") is None
-        or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
-    )
-
-    assert mod.coords["exogenous_observed_0"] == ["a", "b"]
-    assert mod.coords["exogenous_observed_1"] == ["c"]
-    assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
-
-    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
-    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
-    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
-    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
-
-
-def test_create_varmax_with_exogenous_both_dict_correct(data):
-    k_exog = {"observed_0": 2, "observed_1": 1}
-    exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"]}
-    mod = BayesianVARMAX(
-        endog_names=["observed_0", "observed_1"],
-        order=(1, 0),
-        k_exog=k_exog,
-        exog_state_names=exog_state_names,
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-    assert mod.k_exog == k_exog
-    assert mod.exog_state_names == exog_state_names
-    assert mod.data_names == ["observed_0_exogenous_data", "observed_1_exogenous_data"]
-    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
-    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
-    assert mod.coords["exogenous_observed_0"] == ["a", "b"]
-    assert mod.coords["exogenous_observed_1"] == ["c"]
-    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
-    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
-    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
-    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
-
-
-def test_create_varmax_with_exogenous_dict_converts_to_list(data):
-    exog_state_names = {
-        "observed_0": ["a", "b"],
-        "observed_1": ["a", "b"],
-        "observed_2": ["a", "b"],
-    }
-    mod = BayesianVARMAX(
-        endog_names=["observed_0", "observed_1", "observed_2"],
-        order=(1, 0),
-        exog_state_names=exog_state_names,
-        verbose=False,
-        measurement_error=False,
-        stationary_initialization=False,
-    )
-
-    assert mod.k_exog == 2
-    assert mod.exog_state_names == ["a", "b"]
-    assert mod.data_names == ["exogenous_data"]
-    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
-    assert mod.coords["exogenous"] == ["a", "b"]
-    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
-    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
-
-
-def test_create_varmax_with_exogenous_raises_if_args_disagree(data):
-    # List case
-    with pytest.raises(
-        ValueError, match="Length of exog_state_names does not match provided k_exog"
-    ):
-        BayesianVARMAX(
-            k_endog=2,
-            order=(1, 0),
-            k_exog=3,
-            exog_state_names=["a", "b"],
-            verbose=False,
-            measurement_error=False,
-            stationary_initialization=False,
-        )
-
-    # Dict case
-    with pytest.raises(
-        ValueError, match="If k_exog is an int, exog_state_names must be a list of the same length"
-    ):
-        BayesianVARMAX(
-            k_endog=2,
+class TestVARMAXWithExogenous:
+    def test_create_varmax_with_exogenous_k_exog_int(self, data):
+        mod = BayesianVARMAX(
+            k_endog=data.shape[1],
             order=(1, 0),
             k_exog=2,
-            exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,
         )
+        assert mod.k_exog == 2
+        assert mod.exog_state_names == ["exogenous_0", "exogenous_1"]
+        assert mod.data_names == ["exogenous_data"]
+        assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+        assert mod.coords["exogenous"] == ["exogenous_0", "exogenous_1"]
+        assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+        assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
 
-    # dict + list
-    with pytest.raises(
-        ValueError, match="If k_exog is a dict, exog_state_names must be a dict as well"
-    ):
-        BayesianVARMAX(
-            endog_names=["observed_0", "observed_1"],
+    def test_create_varmax_with_exogenous_list_of_names(self, data):
+        mod = BayesianVARMAX(
+            k_endog=data.shape[1],
             order=(1, 0),
-            k_exog={"observed_0": 1, "observed_1": 1},
+            exog_state_names=["foo", "bar"],
+            verbose=False,
+            measurement_error=False,
+            stationary_initialization=False,
+        )
+        assert mod.k_exog == 2
+        assert mod.exog_state_names == ["foo", "bar"]
+        assert mod.data_names == ["exogenous_data"]
+        assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+        assert mod.coords["exogenous"] == ["foo", "bar"]
+        assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+        assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
+
+    def test_create_varmax_with_exogenous_both_defined_correctly(self, data):
+        mod = BayesianVARMAX(
+            k_endog=data.shape[1],
+            order=(1, 0),
+            k_exog=2,
             exog_state_names=["a", "b"],
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,
         )
+        assert mod.k_exog == 2
+        assert mod.exog_state_names == ["a", "b"]
+        assert mod.data_names == ["exogenous_data"]
+        assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+        assert mod.coords["exogenous"] == ["a", "b"]
+        assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+        assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
 
-    # Dict/dict, key mismatch
-    with pytest.raises(ValueError, match="Keys of k_exog and exog_state_names dicts must match"):
-        BayesianVARMAX(
-            endog_names=["observed_0", "observed_1"],
+    def test_create_varmax_with_exogenous_k_exog_dict(self, data):
+        k_exog = {"observed_0": 2, "observed_1": 1, "observed_2": 0}
+        mod = BayesianVARMAX(
+            endog_names=["observed_0", "observed_1", "observed_2"],
             order=(1, 0),
-            k_exog={"observed_0": 1, "observed_1": 1},
-            exog_state_names={"observed_0": ["a"], "observed_2": ["b"]},
+            k_exog=k_exog,
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,
         )
-
-    # Dict/dict, length mismatch
-    with pytest.raises(ValueError, match="lengths of exog_state_names lists must match"):
-        BayesianVARMAX(
-            endog_names=["observed_0", "observed_1"],
-            order=(1, 0),
-            k_exog={"observed_0": 2, "observed_1": 1},
-            exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
-            verbose=False,
-            measurement_error=False,
-            stationary_initialization=False,
-        )
-
-
-@pytest.mark.parametrize(
-    "k_exog, exog_state_names",
-    [
-        (2, None),
-        (None, ["foo", "bar"]),
-        (None, {"y1": ["a", "b"], "y2": ["c"]}),
-    ],
-    ids=["k_exog_int", "exog_state_names_list", "exog_state_names_dict"],
-)
-@pytest.mark.filterwarnings("ignore::UserWarning")
-def test_varmax_with_exog(rng, k_exog, exog_state_names):
-    endog_names = ["y1", "y2", "y3"]
-    n_obs = 50
-    time_idx = pd.date_range(start="2020-01-01", periods=n_obs, freq="D")
-
-    y = rng.normal(size=(n_obs, len(endog_names)))
-    df = pd.DataFrame(y, columns=endog_names, index=time_idx).astype(floatX)
-
-    if isinstance(exog_state_names, dict):
-        exog_data = {
-            f"{name}_exogenous_data": pd.DataFrame(
-                rng.normal(size=(n_obs, len(exog_names))).astype(floatX),
-                columns=exog_names,
-                index=time_idx,
-            )
-            for name, exog_names in exog_state_names.items()
+        assert mod.k_exog == k_exog
+        assert mod.exog_state_names == {
+            "observed_0": ["observed_0_exogenous_0", "observed_0_exogenous_1"],
+            "observed_1": ["observed_1_exogenous_0"],
+            "observed_2": [],
         }
-    else:
-        exog_names = exog_state_names or [f"exogenous_{i}" for i in range(k_exog)]
-        exog_data = {
-            "exogenous_data": pd.DataFrame(
-                rng.normal(size=(n_obs, k_exog or len(exog_state_names))).astype(floatX),
-                columns=exog_names,
-                index=time_idx,
-            )
-        }
-
-    mod = BayesianVARMAX(
-        endog_names=endog_names,
-        order=(1, 0),
-        k_exog=k_exog,
-        exog_state_names=exog_state_names,
-        verbose=True,
-        measurement_error=False,
-        stationary_initialization=False,
-        mode="JAX",
-    )
-
-    with pm.Model(coords=mod.coords) as m:
-        for var_name, data in exog_data.items():
-            pm.Data(var_name, data, dims=mod.data_info[var_name]["dims"])
-
-        x0 = pm.Deterministic("x0", pt.zeros(mod.k_states), dims=mod.param_dims["x0"])
-        P0_diag = pm.Exponential("P0_diag", 1.0, dims=mod.param_dims["P0"][0])
-        P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=mod.param_dims["P0"])
-
-        ar_params = pm.Normal("ar_params", mu=0, sigma=1, dims=mod.param_dims["ar_params"])
-        state_cov_diag = pm.Exponential("state_cov_diag", 1.0, dims=mod.param_dims["state_cov"][0])
-        state_cov = pm.Deterministic(
-            "state_cov", pt.diag(state_cov_diag), dims=mod.param_dims["state_cov"]
-        )
-
-        # Exogenous priors
-        if isinstance(mod.exog_state_names, list):
-            beta_exog = pm.Normal("beta_exog", mu=0, sigma=1, dims=mod.param_dims["beta_exog"])
-        elif isinstance(mod.exog_state_names, dict):
-            for name in mod.exog_state_names:
-                if mod.exog_state_names.get(name):
-                    pm.Normal(f"beta_{name}", mu=0, sigma=1, dims=mod.param_dims[f"beta_{name}"])
-
-        mod.build_statespace_graph(data=df)
-
-    with freeze_dims_and_data(m):
-        prior = pm.sample_prior_predictive(
-            draws=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
-        )
-
-    prior_cond = mod.sample_conditional_prior(prior, mvn_method="eigh")
-    beta_dot_data = prior_cond.filtered_prior_observed.values - prior_cond.filtered_prior.values
-
-    if isinstance(exog_state_names, list) or k_exog is not None:
-        beta = prior.prior.beta_exog
-        assert beta.shape == (1, 10, 3, 2)
-
-        np.testing.assert_allclose(
-            beta_dot_data,
-            np.einsum("tx,...sx->...ts", exog_data["exogenous_data"].values, beta),
-            atol=1e-2,
-        )
-
-    elif isinstance(exog_state_names, dict):
-        assert prior.prior.beta_y1.shape == (1, 10, 2)
-        assert prior.prior.beta_y2.shape == (1, 10, 1)
-
-        obs_intercept = [
-            np.einsum("tx,...x->...t", exog_data[f"{name}_exogenous_data"].values, beta)
-            for name, beta in zip(["y1", "y2"], [prior.prior.beta_y1, prior.prior.beta_y2])
+        assert mod.data_names == [
+            "observed_0_exogenous_data",
+            "observed_1_exogenous_data",
+            "observed_2_exogenous_data",
         ]
+        assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+        assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+        assert (
+            "beta_observed_2" not in mod.param_dims
+            or mod.param_info.get("beta_observed_2") is None
+            or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
+        )
 
-        # y3 has no exogenous variables
-        obs_intercept.append(np.zeros_like(obs_intercept[0]))
+        assert mod.coords["exogenous_observed_0"] == [
+            "observed_0_exogenous_0",
+            "observed_0_exogenous_1",
+        ]
+        assert mod.coords["exogenous_observed_1"] == ["observed_1_exogenous_0"]
+        assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
 
-        np.testing.assert_allclose(beta_dot_data, np.stack(obs_intercept, axis=-1), atol=1e-2)
+        assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+        assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+        assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+        assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
+
+    def test_create_varmax_with_exogenous_exog_names_dict(self, data):
+        exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"], "observed_2": []}
+        mod = BayesianVARMAX(
+            endog_names=["observed_0", "observed_1", "observed_2"],
+            order=(1, 0),
+            exog_state_names=exog_state_names,
+            verbose=False,
+            measurement_error=False,
+            stationary_initialization=False,
+        )
+        assert mod.k_exog == {"observed_0": 2, "observed_1": 1, "observed_2": 0}
+        assert mod.exog_state_names == exog_state_names
+        assert mod.data_names == [
+            "observed_0_exogenous_data",
+            "observed_1_exogenous_data",
+            "observed_2_exogenous_data",
+        ]
+        assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+        assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+        assert (
+            "beta_observed_2" not in mod.param_dims
+            or mod.param_info.get("beta_observed_2") is None
+            or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
+        )
+
+        assert mod.coords["exogenous_observed_0"] == ["a", "b"]
+        assert mod.coords["exogenous_observed_1"] == ["c"]
+        assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
+
+        assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+        assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+        assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+        assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
+
+    def test_create_varmax_with_exogenous_both_dict_correct(self, data):
+        k_exog = {"observed_0": 2, "observed_1": 1}
+        exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"]}
+        mod = BayesianVARMAX(
+            endog_names=["observed_0", "observed_1"],
+            order=(1, 0),
+            k_exog=k_exog,
+            exog_state_names=exog_state_names,
+            verbose=False,
+            measurement_error=False,
+            stationary_initialization=False,
+        )
+        assert mod.k_exog == k_exog
+        assert mod.exog_state_names == exog_state_names
+        assert mod.data_names == ["observed_0_exogenous_data", "observed_1_exogenous_data"]
+        assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+        assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+        assert mod.coords["exogenous_observed_0"] == ["a", "b"]
+        assert mod.coords["exogenous_observed_1"] == ["c"]
+        assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+        assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+        assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+        assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
+
+    def test_create_varmax_with_exogenous_dict_converts_to_list(self, data):
+        exog_state_names = {
+            "observed_0": ["a", "b"],
+            "observed_1": ["a", "b"],
+            "observed_2": ["a", "b"],
+        }
+        mod = BayesianVARMAX(
+            endog_names=["observed_0", "observed_1", "observed_2"],
+            order=(1, 0),
+            exog_state_names=exog_state_names,
+            verbose=False,
+            measurement_error=False,
+            stationary_initialization=False,
+        )
+
+        assert mod.k_exog == 2
+        assert mod.exog_state_names == ["a", "b"]
+        assert mod.data_names == ["exogenous_data"]
+        assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+        assert mod.coords["exogenous"] == ["a", "b"]
+        assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+        assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
+
+    def test_create_varmax_with_exogenous_raises_if_args_disagree(self, data):
+        # List case
+        with pytest.raises(
+            ValueError, match="Length of exog_state_names does not match provided k_exog"
+        ):
+            BayesianVARMAX(
+                k_endog=2,
+                order=(1, 0),
+                k_exog=3,
+                exog_state_names=["a", "b"],
+                verbose=False,
+                measurement_error=False,
+                stationary_initialization=False,
+            )
+
+        # Dict case
+        with pytest.raises(
+            ValueError,
+            match="If k_exog is an int, exog_state_names must be a list of the same length",
+        ):
+            BayesianVARMAX(
+                k_endog=2,
+                order=(1, 0),
+                k_exog=2,
+                exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
+                verbose=False,
+                measurement_error=False,
+                stationary_initialization=False,
+            )
+
+        # dict + list
+        with pytest.raises(
+            ValueError, match="If k_exog is a dict, exog_state_names must be a dict as well"
+        ):
+            BayesianVARMAX(
+                endog_names=["observed_0", "observed_1"],
+                order=(1, 0),
+                k_exog={"observed_0": 1, "observed_1": 1},
+                exog_state_names=["a", "b"],
+                verbose=False,
+                measurement_error=False,
+                stationary_initialization=False,
+            )
+
+        # Dict/dict, key mismatch
+        with pytest.raises(
+            ValueError, match="Keys of k_exog and exog_state_names dicts must match"
+        ):
+            BayesianVARMAX(
+                endog_names=["observed_0", "observed_1"],
+                order=(1, 0),
+                k_exog={"observed_0": 1, "observed_1": 1},
+                exog_state_names={"observed_0": ["a"], "observed_2": ["b"]},
+                verbose=False,
+                measurement_error=False,
+                stationary_initialization=False,
+            )
+
+        # Dict/dict, length mismatch
+        with pytest.raises(ValueError, match="lengths of exog_state_names lists must match"):
+            BayesianVARMAX(
+                endog_names=["observed_0", "observed_1"],
+                order=(1, 0),
+                k_exog={"observed_0": 2, "observed_1": 1},
+                exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
+                verbose=False,
+                measurement_error=False,
+                stationary_initialization=False,
+            )
+
+    @pytest.mark.parametrize(
+        "k_exog, exog_state_names",
+        [
+            (2, None),
+            (None, ["foo", "bar"]),
+            (None, {"y1": ["a", "b"], "y2": ["c"]}),
+        ],
+        ids=["k_exog_int", "exog_state_names_list", "exog_state_names_dict"],
+    )
+    @pytest.mark.filterwarnings("ignore::UserWarning")
+    def test_varmax_with_exog(self, rng, k_exog, exog_state_names):
+        endog_names = ["y1", "y2", "y3"]
+        n_obs = 50
+        time_idx = pd.date_range(start="2020-01-01", periods=n_obs, freq="D")
+
+        y = rng.normal(size=(n_obs, len(endog_names)))
+        df = pd.DataFrame(y, columns=endog_names, index=time_idx).astype(floatX)
+
+        if isinstance(exog_state_names, dict):
+            exog_data = {
+                f"{name}_exogenous_data": pd.DataFrame(
+                    rng.normal(size=(n_obs, len(exog_names))).astype(floatX),
+                    columns=exog_names,
+                    index=time_idx,
+                )
+                for name, exog_names in exog_state_names.items()
+            }
+        else:
+            exog_names = exog_state_names or [f"exogenous_{i}" for i in range(k_exog)]
+            exog_data = {
+                "exogenous_data": pd.DataFrame(
+                    rng.normal(size=(n_obs, k_exog or len(exog_state_names))).astype(floatX),
+                    columns=exog_names,
+                    index=time_idx,
+                )
+            }
+
+        mod = BayesianVARMAX(
+            endog_names=endog_names,
+            order=(1, 0),
+            k_exog=k_exog,
+            exog_state_names=exog_state_names,
+            verbose=False,
+            measurement_error=False,
+            stationary_initialization=False,
+            mode="JAX",
+        )
+
+        with pm.Model(coords=mod.coords) as m:
+            for var_name, data in exog_data.items():
+                pm.Data(var_name, data, dims=mod.data_info[var_name]["dims"])
+
+            x0 = pm.Deterministic("x0", pt.zeros(mod.k_states), dims=mod.param_dims["x0"])
+            P0_diag = pm.Exponential("P0_diag", 1.0, dims=mod.param_dims["P0"][0])
+            P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=mod.param_dims["P0"])
+
+            ar_params = pm.Normal("ar_params", mu=0, sigma=1, dims=mod.param_dims["ar_params"])
+            state_cov_diag = pm.Exponential(
+                "state_cov_diag", 1.0, dims=mod.param_dims["state_cov"][0]
+            )
+            state_cov = pm.Deterministic(
+                "state_cov", pt.diag(state_cov_diag), dims=mod.param_dims["state_cov"]
+            )
+
+            # Exogenous priors
+            if isinstance(mod.exog_state_names, list):
+                beta_exog = pm.Normal("beta_exog", mu=0, sigma=1, dims=mod.param_dims["beta_exog"])
+            elif isinstance(mod.exog_state_names, dict):
+                for name in mod.exog_state_names:
+                    if mod.exog_state_names.get(name):
+                        pm.Normal(
+                            f"beta_{name}", mu=0, sigma=1, dims=mod.param_dims[f"beta_{name}"]
+                        )
+
+            mod.build_statespace_graph(data=df)
+
+        with freeze_dims_and_data(m):
+            prior = pm.sample_prior_predictive(
+                draws=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
+            )
+
+        prior_cond = mod.sample_conditional_prior(prior, mvn_method="eigh")
+        beta_dot_data = prior_cond.filtered_prior_observed.values - prior_cond.filtered_prior.values
+
+        if isinstance(exog_state_names, list) or k_exog is not None:
+            beta = prior.prior.beta_exog
+            assert beta.shape == (1, 10, 3, 2)
+
+            np.testing.assert_allclose(
+                beta_dot_data,
+                np.einsum("tx,...sx->...ts", exog_data["exogenous_data"].values, beta),
+                atol=1e-2,
+            )
+
+        elif isinstance(exog_state_names, dict):
+            assert prior.prior.beta_y1.shape == (1, 10, 2)
+            assert prior.prior.beta_y2.shape == (1, 10, 1)
+
+            obs_intercept = [
+                np.einsum("tx,...x->...t", exog_data[f"{name}_exogenous_data"].values, beta)
+                for name, beta in zip(["y1", "y2"], [prior.prior.beta_y1, prior.prior.beta_y2])
+            ]
+
+            # y3 has no exogenous variables
+            obs_intercept.append(np.zeros_like(obs_intercept[0]))
+
+            np.testing.assert_allclose(beta_dot_data, np.stack(obs_intercept, axis=-1), atol=1e-2)

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -9,6 +9,7 @@ import pytest
 import statsmodels.api as sm
 
 from numpy.testing import assert_allclose, assert_array_less
+from pymc.model.transform.optimization import freeze_dims_and_data
 
 from pymc_extras.statespace import BayesianVARMAX
 from pymc_extras.statespace.utils.constants import SHORT_NAME_TO_LONG
@@ -203,6 +204,10 @@ def test_create_varmax_with_exogenous(data):
     assert mod.k_exog == 2
     assert mod.exog_state_names == ["exogenous_0", "exogenous_1"]
     assert mod.data_names == ["exogenous_data"]
+    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+    assert mod.coords["exogenous"] == ["exogenous_0", "exogenous_1"]
+    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
 
     # Case 2: exog_state_names as list, k_exog is None
     mod = BayesianVARMAX(
@@ -216,6 +221,10 @@ def test_create_varmax_with_exogenous(data):
     assert mod.k_exog == 2
     assert mod.exog_state_names == ["foo", "bar"]
     assert mod.data_names == ["exogenous_data"]
+    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+    assert mod.coords["exogenous"] == ["foo", "bar"]
+    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
 
     # Case 3: k_exog as int, exog_state_names as list (matching)
     mod = BayesianVARMAX(
@@ -230,6 +239,10 @@ def test_create_varmax_with_exogenous(data):
     assert mod.k_exog == 2
     assert mod.exog_state_names == ["a", "b"]
     assert mod.data_names == ["exogenous_data"]
+    assert mod.param_dims["beta_exog"] == ("observed_state", "exogenous")
+    assert mod.coords["exogenous"] == ["a", "b"]
+    assert mod.param_info["beta_exog"]["shape"] == (mod.k_endog, 2)
+    assert mod.param_info["beta_exog"]["dims"] == ("observed_state", "exogenous")
 
     # Case 4: k_exog as dict, exog_state_names is None
     k_exog = {"observed_0": 2, "observed_1": 1, "observed_2": 0}
@@ -252,6 +265,25 @@ def test_create_varmax_with_exogenous(data):
         "observed_1_exogenous_data",
         "observed_2_exogenous_data",
     ]
+    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+    assert (
+        "beta_observed_2" not in mod.param_dims
+        or mod.param_info.get("beta_observed_2") is None
+        or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
+    )
+
+    assert mod.coords["exogenous_observed_0"] == [
+        "observed_0_exogenous_0",
+        "observed_0_exogenous_1",
+    ]
+    assert mod.coords["exogenous_observed_1"] == ["observed_1_exogenous_0"]
+    assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
+
+    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
 
     # Case 5: exog_state_names as dict, k_exog is None
     exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"], "observed_2": []}
@@ -270,6 +302,22 @@ def test_create_varmax_with_exogenous(data):
         "observed_1_exogenous_data",
         "observed_2_exogenous_data",
     ]
+    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+    assert (
+        "beta_observed_2" not in mod.param_dims
+        or mod.param_info.get("beta_observed_2") is None
+        or mod.param_info.get("beta_observed_2", {}).get("shape", (0,))[0] == 0
+    )
+
+    assert mod.coords["exogenous_observed_0"] == ["a", "b"]
+    assert mod.coords["exogenous_observed_1"] == ["c"]
+    assert "exogenous_observed_2" in mod.coords and mod.coords["exogenous_observed_2"] == []
+
+    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
 
     # Case 6: k_exog as dict, exog_state_names as dict (matching)
     k_exog = {"observed_0": 2, "observed_1": 1}
@@ -286,6 +334,14 @@ def test_create_varmax_with_exogenous(data):
     assert mod.k_exog == k_exog
     assert mod.exog_state_names == exog_state_names
     assert mod.data_names == ["observed_0_exogenous_data", "observed_1_exogenous_data"]
+    assert mod.param_dims["beta_observed_0"] == ("exogenous_observed_0",)
+    assert mod.param_dims["beta_observed_1"] == ("exogenous_observed_1",)
+    assert mod.coords["exogenous_observed_0"] == ["a", "b"]
+    assert mod.coords["exogenous_observed_1"] == ["c"]
+    assert mod.param_info["beta_observed_0"]["shape"] == (2,)
+    assert mod.param_info["beta_observed_0"]["dims"] == ("exogenous_observed_0",)
+    assert mod.param_info["beta_observed_1"]["shape"] == (1,)
+    assert mod.param_info["beta_observed_1"]["dims"] == ("exogenous_observed_1",)
 
     # Error: k_exog as int, exog_state_names as list (length mismatch)
     with pytest.raises(
@@ -348,3 +404,108 @@ def test_create_varmax_with_exogenous(data):
             measurement_error=False,
             stationary_initialization=False,
         )
+
+
+@pytest.mark.parametrize(
+    "k_exog, exog_state_names",
+    [
+        (2, None),
+        (None, ["foo", "bar"]),
+        (None, {"y1": ["a", "b"], "y2": ["c"]}),
+    ],
+    ids=["k_exog_int", "exog_state_names_list", "exog_state_names_dict"],
+)
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_varmax_with_exog(rng, k_exog, exog_state_names):
+    endog_names = ["y1", "y2", "y3"]
+    n_obs = 50
+    time_idx = pd.date_range(start="2020-01-01", periods=n_obs, freq="D")
+
+    y = rng.normal(size=(n_obs, len(endog_names)))
+    df = pd.DataFrame(y, columns=endog_names, index=time_idx).astype(floatX)
+
+    if isinstance(exog_state_names, dict):
+        exog_data = {
+            f"{name}_exogenous_data": pd.DataFrame(
+                rng.normal(size=(n_obs, len(exog_names))).astype(floatX),
+                columns=exog_names,
+                index=time_idx,
+            )
+            for name, exog_names in exog_state_names.items()
+        }
+    else:
+        exog_names = exog_state_names or [f"exogenous_{i}" for i in range(k_exog)]
+        exog_data = {
+            "exogenous_data": pd.DataFrame(
+                rng.normal(size=(n_obs, k_exog or len(exog_state_names))).astype(floatX),
+                columns=exog_names,
+                index=time_idx,
+            )
+        }
+
+    mod = BayesianVARMAX(
+        endog_names=endog_names,
+        order=(1, 0),
+        k_exog=k_exog,
+        exog_state_names=exog_state_names,
+        verbose=True,
+        measurement_error=False,
+        stationary_initialization=False,
+        mode="JAX",
+    )
+
+    with pm.Model(coords=mod.coords) as m:
+        for var_name, data in exog_data.items():
+            pm.Data(var_name, data, dims=mod.data_info[var_name]["dims"])
+
+        x0 = pm.Deterministic("x0", pt.zeros(mod.k_states), dims=mod.param_dims["x0"])
+        P0_diag = pm.Exponential("P0_diag", 1.0, dims=mod.param_dims["P0"][0])
+        P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=mod.param_dims["P0"])
+
+        ar_params = pm.Normal("ar_params", mu=0, sigma=1, dims=mod.param_dims["ar_params"])
+        state_cov_diag = pm.Exponential("state_cov_diag", 1.0, dims=mod.param_dims["state_cov"][0])
+        state_cov = pm.Deterministic(
+            "state_cov", pt.diag(state_cov_diag), dims=mod.param_dims["state_cov"]
+        )
+
+        # Exogenous priors
+        if isinstance(mod.exog_state_names, list):
+            beta_exog = pm.Normal("beta_exog", mu=0, sigma=1, dims=mod.param_dims["beta_exog"])
+        elif isinstance(mod.exog_state_names, dict):
+            for name in mod.exog_state_names:
+                if mod.exog_state_names.get(name):
+                    pm.Normal(f"beta_{name}", mu=0, sigma=1, dims=mod.param_dims[f"beta_{name}"])
+
+        mod.build_statespace_graph(data=df)
+
+    with freeze_dims_and_data(m):
+        prior = pm.sample_prior_predictive(
+            draws=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
+        )
+
+    prior_cond = mod.sample_conditional_prior(prior, mvn_method="eigh")
+    beta_dot_data = prior_cond.filtered_prior_observed.values - prior_cond.filtered_prior.values
+
+    if isinstance(exog_state_names, list) or k_exog is not None:
+        beta = prior.prior.beta_exog
+        assert beta.shape == (1, 10, 3, 2)
+
+        np.testing.assert_allclose(
+            beta_dot_data,
+            np.einsum("tx,...sx->...ts", exog_data["exogenous_data"].values, beta),
+            atol=1e-2,
+        )
+
+    elif isinstance(exog_state_names, dict):
+        assert prior.prior.beta_y1.shape == (1, 10, 2)
+        assert prior.prior.beta_y2.shape == (1, 10, 1)
+
+        obs_intercept = [
+            np.einsum("tx,...x->...t", exog_data[f"{name}_exogenous_data"].values, beta)
+            for name, beta in zip(["y1", "y2"], [prior.prior.beta_y1, prior.prior.beta_y2])
+        ]
+
+        # y3 has no exogenous variables
+        obs_intercept.append(np.zeros_like(obs_intercept[0]))
+
+        np.testing.assert_allclose(beta_dot_data, np.stack(obs_intercept, axis=-1), atol=1e-2)

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -201,7 +201,8 @@ def test_create_varmax_with_exogenous(data):
         stationary_initialization=False,
     )
     assert mod.k_exog == 2
-    assert mod.exog_state_names == ["exog.1", "exog.2"]
+    assert mod.exog_state_names == ["exogenous_0", "exogenous_1"]
+    assert mod.data_names == ["exogenous_data"]
 
     # Case 2: exog_state_names as list, k_exog is None
     mod = BayesianVARMAX(
@@ -214,6 +215,7 @@ def test_create_varmax_with_exogenous(data):
     )
     assert mod.k_exog == 2
     assert mod.exog_state_names == ["foo", "bar"]
+    assert mod.data_names == ["exogenous_data"]
 
     # Case 3: k_exog as int, exog_state_names as list (matching)
     mod = BayesianVARMAX(
@@ -227,11 +229,12 @@ def test_create_varmax_with_exogenous(data):
     )
     assert mod.k_exog == 2
     assert mod.exog_state_names == ["a", "b"]
+    assert mod.data_names == ["exogenous_data"]
 
     # Case 4: k_exog as dict, exog_state_names is None
-    k_exog = {"state.1": 2, "state.2": 1, "state.3": 0}
+    k_exog = {"observed_0": 2, "observed_1": 1, "observed_2": 0}
     mod = BayesianVARMAX(
-        endog_names=["state.1", "state.2", "state.3"],
+        endog_names=["observed_0", "observed_1", "observed_2"],
         order=(1, 0),
         k_exog=k_exog,
         verbose=False,
@@ -240,29 +243,39 @@ def test_create_varmax_with_exogenous(data):
     )
     assert mod.k_exog == k_exog
     assert mod.exog_state_names == {
-        "state.1": ["state.1.exog.1", "state.1.exog.2"],
-        "state.2": ["state.2.exog.1"],
-        "state.3": [],
+        "observed_0": ["observed_0_exogenous_0", "observed_0_exogenous_1"],
+        "observed_1": ["observed_1_exogenous_0"],
+        "observed_2": [],
     }
+    assert mod.data_names == [
+        "observed_0_exogenous_data",
+        "observed_1_exogenous_data",
+        "observed_2_exogenous_data",
+    ]
 
     # Case 5: exog_state_names as dict, k_exog is None
-    exog_state_names = {"state.1": ["a", "b"], "state.2": ["c"], "state.3": []}
+    exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"], "observed_2": []}
     mod = BayesianVARMAX(
-        endog_names=["state.1", "state.2", "state.3"],
+        endog_names=["observed_0", "observed_1", "observed_2"],
         order=(1, 0),
         exog_state_names=exog_state_names,
         verbose=False,
         measurement_error=False,
         stationary_initialization=False,
     )
-    assert mod.k_exog == {"state.1": 2, "state.2": 1, "state.3": 0}
+    assert mod.k_exog == {"observed_0": 2, "observed_1": 1, "observed_2": 0}
     assert mod.exog_state_names == exog_state_names
+    assert mod.data_names == [
+        "observed_0_exogenous_data",
+        "observed_1_exogenous_data",
+        "observed_2_exogenous_data",
+    ]
 
     # Case 6: k_exog as dict, exog_state_names as dict (matching)
-    k_exog = {"state.1": 2, "state.2": 1}
-    exog_state_names = {"state.1": ["a", "b"], "state.2": ["c"]}
+    k_exog = {"observed_0": 2, "observed_1": 1}
+    exog_state_names = {"observed_0": ["a", "b"], "observed_1": ["c"]}
     mod = BayesianVARMAX(
-        endog_names=["state.1", "state.2"],
+        endog_names=["observed_0", "observed_1"],
         order=(1, 0),
         k_exog=k_exog,
         exog_state_names=exog_state_names,
@@ -272,6 +285,7 @@ def test_create_varmax_with_exogenous(data):
     )
     assert mod.k_exog == k_exog
     assert mod.exog_state_names == exog_state_names
+    assert mod.data_names == ["observed_0_exogenous_data", "observed_1_exogenous_data"]
 
     # Error: k_exog as int, exog_state_names as list (length mismatch)
     with pytest.raises(
@@ -293,7 +307,7 @@ def test_create_varmax_with_exogenous(data):
             k_endog=2,
             order=(1, 0),
             k_exog=2,
-            exog_state_names={"state.1": ["a"], "state.2": ["b"]},
+            exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,
@@ -302,9 +316,9 @@ def test_create_varmax_with_exogenous(data):
     # Error: k_exog as dict, exog_state_names as list
     with pytest.raises(ValueError):
         BayesianVARMAX(
-            endog_names=["state.1", "state.2"],
+            endog_names=["observed_0", "observed_1"],
             order=(1, 0),
-            k_exog={"state.1": 1, "state.2": 1},
+            k_exog={"observed_0": 1, "observed_1": 1},
             exog_state_names=["a", "b"],
             verbose=False,
             measurement_error=False,
@@ -314,10 +328,10 @@ def test_create_varmax_with_exogenous(data):
     # Error: k_exog as dict, exog_state_names as dict (keys mismatch)
     with pytest.raises(ValueError, match="Keys of k_exog and exog_state_names dicts must match"):
         BayesianVARMAX(
-            endog_names=["state.1", "state.2"],
+            endog_names=["observed_0", "observed_1"],
             order=(1, 0),
-            k_exog={"state.1": 1, "state.2": 1},
-            exog_state_names={"state.1": ["a"], "state.3": ["b"]},
+            k_exog={"observed_0": 1, "observed_1": 1},
+            exog_state_names={"observed_0": ["a"], "observed_2": ["b"]},
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,
@@ -326,10 +340,10 @@ def test_create_varmax_with_exogenous(data):
     # Error: k_exog as dict, exog_state_names as dict (length mismatch)
     with pytest.raises(ValueError, match="lengths of exog_state_names lists must match"):
         BayesianVARMAX(
-            endog_names=["state.1", "state.2"],
+            endog_names=["observed_0", "observed_1"],
             order=(1, 0),
-            k_exog={"state.1": 2, "state.2": 1},
-            exog_state_names={"state.1": ["a"], "state.2": ["b"]},
+            k_exog={"observed_0": 2, "observed_1": 1},
+            exog_state_names={"observed_0": ["a"], "observed_1": ["b"]},
             verbose=False,
             measurement_error=False,
             stationary_initialization=False,


### PR DESCRIPTION
This PR adds support for exogenous variables in `BayesianVARMAX` via the observation intercept. Same deal as SARIMAX -- it's implemented in a way that minimizes the number of states in the system.

Unlike Statsmodels, we have support for each observed state to have its own regressors by passing a dictionary. If you just pass a list, everyone shares the same data.

Example 1: Everyone shares data, data names are auto-assigned 

```py
mod = BayesianVARMAX(
        endog_names=["y1", "y2", "y3"],
        order=(1, 0),
        k_exog=2,
    )
```

Example 2: Everyone shares data, data names are provided 

```py
mod = BayesianVARMAX(
        endog_names=["y1", "y2", "y3"],
        order=(1, 0),
        exog_state_names=['x1', 'x2']
    )
```

Example 3: Each observes state (endogenous state) has its own exogenous regressors. y3 has no exogenous regressors at all, so it is omitted from the dictionary. It just so happens that each observed has its own regressors, but they could also share all or a subset.

```py
mod = BayesianVARMAX(
        endog_names=["y1", "y2", "y3"],
        order=(1, 0),
        exog_state_names={'y1':['x1', 'x2'], 'y2':['x3']}
    )
```

