### PR TITLE
Update to support the latest blackjax

### DIFF
--- a/pymc_extras/inference/smc/sampling.py
+++ b/pymc_extras/inference/smc/sampling.py
@@ -238,7 +238,7 @@ class SMCDiagnostics(NamedTuple):
     def update_diagnosis(i, history, info, state):
         le, lli, ancestors, weights_evolution = history
         return SMCDiagnostics(
-            le.at[i].set(state.lmbda),
+            le.at[i].set(state.tempering_param),
             lli.at[i].set(info.log_likelihood_increment),
             ancestors.at[i].set(info.ancestors),
             weights_evolution.at[i].set(state.weights),
@@ -265,7 +265,7 @@ def inference_loop(rng_key, initial_state, kernel, iterations_to_diagnose, n_par
 
     def cond(carry):
         i, state, _, _ = carry
-        return state.lmbda < 1
+        return state.tempering_param < 1
 
     def one_step(carry):
         i, state, k, previous_info = carry

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dev = [
   "pytest>=6.0",
   "pytest-mock",
   "dask[all]<2025.1.1",
-  "blackjax",
+  "blackjax>=0.12",
   "statsmodels",
 ]
 docs = [

--- a/tests/test_blackjax_smc.py
+++ b/tests/test_blackjax_smc.py
@@ -75,9 +75,6 @@ def fast_model():
     return m
 
 
-@pytest.mark.xfail(
-    reason="TODO: fix AttributeError: 'TemperedSMCState' object has no attribute 'lmbda'"
-)
 @pytest.mark.parametrize(
     "kernel, check_for_integration_steps, inner_kernel_params",
     [


### PR DESCRIPTION
A little while back, blackjax [renamed their tempering parameter](https://github.com/blackjax-devs/blackjax/pull/801). This change makes pymc-extras work with the latest version of blackjax

