### PR TITLE
Use vectorized sampling for post-estimation methods

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1021,7 +1021,6 @@ class PyMCStateSpace:
             .. deprecated:: 0.2.5
                 The `mode` argument is deprecated and will be removed in a future version. Pass ``mode`` to the
                 model constructor, or manually specify ``compile_kwargs`` in sampling functions instead.
-
         """
         if mode is not None:
             warnings.warn(
@@ -1559,7 +1558,11 @@ class PyMCStateSpace:
         """
 
         return self._sample_conditional(
-            idata=idata, group="prior", random_seed=random_seed, mvn_method=mvn_method, **kwargs
+            idata=idata,
+            group="prior",
+            random_seed=random_seed,
+            mvn_method=mvn_method,
+            **kwargs,
         )
 
     def sample_conditional_posterior(
@@ -1602,7 +1605,11 @@ class PyMCStateSpace:
         """
 
         return self._sample_conditional(
-            idata=idata, group="posterior", random_seed=random_seed, mvn_method=mvn_method, **kwargs
+            idata=idata,
+            group="posterior",
+            random_seed=random_seed,
+            mvn_method=mvn_method,
+            **kwargs,
         )
 
     def sample_unconditional_prior(


### PR DESCRIPTION
This PR adds an argument `vectorize_draws=True` to all off the `PyMCStateSpace` methods that use `SequentialMvNormal`. 

These were always brutally slow. When I first wrote statespace we didn't support vectorized inputs to MvNormal, so that's why it was written this way. This PR speeds them up significantly. Running `Structural Time Series Modeling.ipynb`, I see times on `sample_conditional_posterior` go from 5 minutes to ~30 seconds.

I initially planned to remove the scan altogether, but decided to keep it as a "low memory" option in case someone has a really monsterous model. But the default is to use the (much faster) vectorized method, and the docstring urges you not to change it.  