### PR TITLE
Fix ordering of time-varying statespace matices for UnivariateFilter's kalman step

### DIFF
--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -778,7 +778,10 @@ class UnivariateFilter(BaseFilter):
 
         return a_filtered, P_filtered, pt.atleast_1d(y_hat), pt.atleast_2d(F), ll_inner
 
-    def kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
+    def kalman_step(self, *args):
+
+        y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
+
         nan_mask = pt.isnan(y)
 
         W = pt.set_subtensor(pt.eye(y.shape[0])[nan_mask, nan_mask], 0.0)

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -779,15 +779,10 @@ class UnivariateFilter(BaseFilter):
         return a_filtered, P_filtered, pt.atleast_1d(y_hat), pt.atleast_2d(F), ll_inner
 
     def kalman_step(self, *args):
-
         y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
 
-        nan_mask = pt.isnan(y)
-
-        W = pt.set_subtensor(pt.eye(y.shape[0])[nan_mask, nan_mask], 0.0)
-        Z_masked = W.dot(Z)
-        H_masked = W.dot(H)
-        y_masked = pt.set_subtensor(y[nan_mask], 0.0)
+        nan_mask = pt.or_(pt.isnan(y), pt.eq(y, self.missing_fill_value))
+        y_masked, Z_masked, H_masked, all_nan_flag = self.handle_missing_values(y, Z, H)
 
         result = pytensor.scan(
             self._univariate_inner_filter_step,
@@ -808,6 +803,10 @@ class UnivariateFilter(BaseFilter):
         P_filtered = stabilize(0.5 * (P_filtered + P_filtered.mT), self.cov_jitter)
         a_hat, P_hat = self.predict(a=a_filtered, P=P_filtered, c=c, T=T, R=R, Q=Q)
 
-        ll = -0.5 * ((pt.neq(ll_inner, 0).sum()) * MVN_CONST + ll_inner.sum())
+        ll = pt.switch(
+            all_nan_flag,
+            0.0,
+            -0.5 * ((pt.neq(ll_inner, 0).sum()) * MVN_CONST + ll_inner.sum()),
+        )
 
         return a_filtered, a_hat, obs_mu, P_filtered, P_hat, obs_cov, ll


### PR DESCRIPTION
This aims to address #612 

Following the error in #612, the design matrix Z should have shape (2,3) not (3,3). Intial thought is the latter shape corresponds to the transition matrix T.

In BaseFilter, the kalman_step function calls the method unpack_args to reorganise the inputs into a standardized order. This is needed because when the user specifies time varying matrices, the kalman_step arguments (y, a, P, c, d, T, Z, R, H, Q) can get 'mixed-up' depending on which variables are assigned to the sequences and non_sequences in pytensor.scan.

UnivariateFilter redefines the kalman_step function and does not currently call unpack_args. Therefore, when the selection matrix R is the only time varying matrix (as in #612) it gets sent to the sequences/start (with y) and shifts the remaining args up by 1. As a result, T is incorrectly used for the Z input, which aligns with the shape error. 

When all matrices are time-invariant unpack_args is not required because the correct ordering is preserved -- this is why UnivariateFilter works for the time-invariant matrices as mentioned in #612.

To address this I have added the method unpack_args to the kalman_step in UnivariateFilter.

**Some extra stuff:**

The above changes should hopefully be enough, but to keep things consistent with the BaseFilter you could possibly deal with the nan values using handle_missing_values instead i.e.:

```
def kalman_step(self, *args):
    
    y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
    
    nan_mask = pt.isnan(y)
    
    y_masked, Z_masked, H_masked, all_nan_flag = self.handle_missing_values(y, Z, H)
    
    result = pytensor.scan(
        self._univariate_inner_filter_step,
        sequences=[y_masked, Z_masked, d, pt.diag(H_masked), nan_mask],
        outputs_info=[a, P, None, None, None],
        name="univariate_inner_scan",
        return_updates=False,
    )
```
I'm happy to add this if you think it's best!