### PR TITLE
MarginalRV: fix inner graph mutation when deriving support_point

### DIFF
--- a/pymc_extras/model/marginal/distributions.py
+++ b/pymc_extras/model/marginal/distributions.py
@@ -83,43 +83,46 @@ def support_point_marginal_rv(op: MarginalRV, rv, *inputs):
     """
     outputs = rv.owner.outputs
 
-    inner_rv = op.inner_outputs[outputs.index(rv)]
+    fgraph = op.fgraph.clone()
+    inner_inputs = fgraph.inputs
+    inner_outputs = fgraph.outputs
+    del op
+
+    inner_rv = inner_outputs[outputs.index(rv)]
     marginalized_inner_rv, *other_dependent_inner_rvs = (
-        out
-        for out in op.inner_outputs
-        if out is not inner_rv and not isinstance(out.type, RandomType)
+        out for out in inner_outputs if out is not inner_rv and not isinstance(out.type, RandomType)
     )
 
     # Replace references to inner rvs by the dummy variables (including the marginalized RV)
     # This is necessary because the inner RVs may depend on each other
     marginalized_inner_rv_dummy = marginalized_inner_rv.clone()
-    other_dependent_inner_rv_to_dummies = {
-        inner_rv: inner_rv.clone() for inner_rv in other_dependent_inner_rvs
-    }
-    inner_rv = clone_replace(
-        inner_rv,
-        replace={marginalized_inner_rv: marginalized_inner_rv_dummy}
-        | other_dependent_inner_rv_to_dummies,
-    )
+    # Map inner rvs to dummies, saving what outer output each corresponds to.
+    # We need dummies because inner RVs may depend on each other.
+    inner_to_dummy_replacements = []
+    dummy_to_outer_replacements = []
+    for other_inner_rv in other_dependent_inner_rvs:
+        dummy = other_inner_rv.clone()
+        inner_to_dummy_replacements.append((other_inner_rv, dummy))
+        dummy_to_outer_replacements.append((dummy, outputs[inner_outputs.index(other_inner_rv)]))
+
+    fgraph.replace(marginalized_inner_rv, marginalized_inner_rv_dummy, import_missing=True)
+    fgraph.replace_all(tuple(inner_to_dummy_replacements), import_missing=True)
 
     # Get support point of inner RV and marginalized RV
     inner_rv_support_point = support_point(inner_rv)
     marginalized_inner_rv_support_point = support_point(marginalized_inner_rv)
 
-    replacements = [
-        # Replace the marginalized RV dummy by its support point
-        (marginalized_inner_rv_dummy, marginalized_inner_rv_support_point),
-        # Replace other dependent RVs dummies by the respective outer outputs.
-        # PyMC will replace them by their support points later
-        *(
-            (v, outputs[op.inner_outputs.index(k)])
-            for k, v in other_dependent_inner_rv_to_dummies.items()
-        ),
-        # Replace outer input RVs
-        *zip(op.inner_inputs, inputs),
-    ]
     fgraph = FunctionGraph(outputs=[inner_rv_support_point], clone=False)
-    fgraph.replace_all(replacements, import_missing=True)
+    # Replace the marginalized RV dummy by its support point
+    fgraph.replace(
+        marginalized_inner_rv_dummy, marginalized_inner_rv_support_point, import_missing=True
+    )
+    # Replace the inner inputs by the outer inputs
+    fgraph.replace_all(tuple(zip(inner_inputs, inputs)), import_missing=True)
+    # Replace other dependent RVs dummies by the respective outer outputs.
+    # PyMC will replace them by their support points later
+    fgraph.replace_all(tuple(dummy_to_outer_replacements), import_missing=True)
+
     [rv_support_point] = fgraph.outputs
     return rv_support_point
 

--- a/tests/model/marginal/test_marginal_model.py
+++ b/tests/model/marginal/test_marginal_model.py
@@ -978,3 +978,16 @@ class TestRecoverMarginals:
         )
         np.testing.assert_almost_equal(logsumexp(post.lp_idx, axis=-1), 0)
         np.testing.assert_almost_equal(logsumexp(post.lp_sub_idx, axis=-1), 0)
+
+
+def test_numpyro_compat():
+    pytest.importorskip("numpyro")
+
+    with pm.Model() as m:
+        p_outlier = pm.Beta("p_outlier", 1, 1)
+        is_outlier = pm.Bernoulli("is_outlier", p=p_outlier, shape=(10,))
+        sigma = pm.Exponential("sigma", 1, shape=(2,))
+        pm.Normal("y_hat", mu=0, sigma=sigma[is_outlier])
+
+    with marginalize(m, [is_outlier]):
+        pm.sample(nuts_sampler="numpyro", chains=1, tune=1, draws=1)

--- a/tests/model/marginal/test_marginal_model.py
+++ b/tests/model/marginal/test_marginal_model.py
@@ -24,7 +24,7 @@ from pymc_extras.model.marginal.marginal_model import (
     recover_marginals,
     unmarginalize,
 )
-from pymc_extras.utils.model_equivalence import equivalent_models
+from pymc_extras.utils.model_equivalence import equal_computations_up_to_root, equivalent_models
 
 # FIXME: A Blockwise of Reshape should be rewritten into a Reshape, as it's rather inneficient
 # This shows up in `test_one_to_many_unaligned_marginalized_rvs`
@@ -978,6 +978,33 @@ class TestRecoverMarginals:
         )
         np.testing.assert_almost_equal(logsumexp(post.lp_idx, axis=-1), 0)
         np.testing.assert_almost_equal(logsumexp(post.lp_sub_idx, axis=-1), 0)
+
+
+def test_forward_after_sampling():
+    # Regression test where forward graph was modified during sampling
+    # Specifically `model.initial_point`, but we test the whole pipeline
+
+    with pm.Model() as m:
+        p_outlier = pm.Beta("p_outlier", 1, 1)
+        is_outlier = pm.Bernoulli("is_outlier", p=p_outlier, shape=(10,))
+        sigma = pm.Exponential("sigma", 1, shape=(2,))
+        pm.Normal("y_hat", mu=0, sigma=sigma[is_outlier])
+
+    marginalized_mod = marginalize(m, [is_outlier])
+
+    # Check that model.initial_point() does not modify the inner graph of the MarginalRV
+    marginal_rv = marginalized_mod["y_hat"]
+    inner_outputs_before = marginal_rv.owner.op.fgraph.clone().outputs
+    marginalized_mod.initial_point()
+    inner_outputs_after = marginal_rv.owner.op.fgraph.outputs
+    assert equal_computations_up_to_root(inner_outputs_before, inner_outputs_after)
+
+    assert pm.draw(marginalized_mod["y_hat"]).shape == (10,)
+
+    with marginalized_mod:
+        pm.sample(tune=1, chains=1, draws=1, compute_convergence_checks=False)
+
+    assert pm.draw(marginalized_mod["y_hat"]).shape == (10,)
 
 
 def test_numpyro_compat():


### PR DESCRIPTION
Also adds a test for sampling compatibility with numpyro (although we don't seem to have it installed in the CI). This would actually depend on https://github.com/pymc-devs/pytensor/pull/1943