### PR TITLE
ENH: Cholesky-form Kalman filter Op — Phase 1 (GSoC 2026)

### DIFF
--- a/pymc_extras/statespace/filters/chol_kalman.py
+++ b/pymc_extras/statespace/filters/chol_kalman.py
@@ -1,0 +1,494 @@
+"""Cholesky-form Kalman filtering utilities.
+
+This file holds the phase-1 reference implementation for the square-root
+Kalman filter. The NumPy functions are the baseline implementation used by the
+tests, and they are written to favor clarity and numerical safety over being as
+factorized as possible.
+
+There are two main pieces here:
+
+1. A NumPy predict/update path used as the ground-truth implementation for the
+    current milestone.
+2. A small PyTensor Op that reuses the same forward logic and rebuilds the step
+    symbolically when gradients are needed.
+
+The filter keeps covariance matrices in Cholesky form, uses a QR-based predict
+step, and computes the update with triangular solves instead of explicit matrix
+inversion. That keeps the implementation stable enough for long filtering runs
+while still being easy to check against a standard covariance-form filter.
+
+Missing data is handled conservatively for now: if any entry of `y` is NaN, the
+whole observation is treated as missing and the step becomes predict-only.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pytensor.gradient import DisconnectedType
+from pytensor.gradient import Rop as _Rop
+from pytensor.graph.basic import Apply
+from pytensor.graph.op import Op
+from scipy.linalg import solve_triangular
+
+
+def _shape_tuple(a: np.ndarray) -> tuple[int, ...]:
+    """Return a plain tuple so shape errors read cleanly."""
+    return tuple(int(d) for d in a.shape)
+
+
+def _validate_numeric_shapes(
+    x_prev: np.ndarray,
+    L_prev: np.ndarray,
+    T: np.ndarray,
+    R: np.ndarray,
+    Q: np.ndarray,
+    Z: np.ndarray,
+    H: np.ndarray,
+    y: np.ndarray,
+    c: np.ndarray | None = None,
+) -> None:
+    """Fail early on shape mismatches in the NumPy path."""
+    if x_prev.ndim != 1:
+        raise ValueError(f"x_prev must be 1-D, got shape {_shape_tuple(x_prev)}")
+    if L_prev.ndim != 2:
+        raise ValueError(f"L_prev must be 2-D, got shape {_shape_tuple(L_prev)}")
+    if T.ndim != 2:
+        raise ValueError(f"T must be 2-D, got shape {_shape_tuple(T)}")
+    if R.ndim != 2:
+        raise ValueError(f"R must be 2-D, got shape {_shape_tuple(R)}")
+    if Q.ndim != 2:
+        raise ValueError(f"Q must be 2-D, got shape {_shape_tuple(Q)}")
+    if Z.ndim != 2:
+        raise ValueError(f"Z must be 2-D, got shape {_shape_tuple(Z)}")
+    if H.ndim != 2:
+        raise ValueError(f"H must be 2-D, got shape {_shape_tuple(H)}")
+    if y.ndim != 1:
+        raise ValueError(f"y must be 1-D, got shape {_shape_tuple(y)}")
+    if c is not None and c.ndim != 1:
+        raise ValueError(f"c must be 1-D, got shape {_shape_tuple(c)}")
+
+    n = x_prev.shape[0]
+    if L_prev.shape != (n, n):
+        raise ValueError(f"L_prev must be square with shape ({n}, {n}), got {_shape_tuple(L_prev)}")
+    if T.shape != (n, n):
+        raise ValueError(f"T must have shape ({n}, {n}), got {_shape_tuple(T)}")
+    if R.shape[0] != n:
+        raise ValueError(f"R.shape[0] must be {n}, got {R.shape[0]}")
+
+    q = R.shape[1]
+    if Q.shape != (q, q):
+        raise ValueError(f"Q must have shape ({q}, {q}), got {_shape_tuple(Q)}")
+
+    m = y.shape[0]
+    if Z.shape != (m, n):
+        raise ValueError(f"Z must have shape ({m}, {n}), got {_shape_tuple(Z)}")
+    if H.shape != (m, m):
+        raise ValueError(f"H must have shape ({m}, {m}), got {_shape_tuple(H)}")
+    if c is not None and c.shape != (n,):
+        raise ValueError(f"c must have shape ({n},), got {_shape_tuple(c)}")
+
+
+def _validate_static_shapes_make_node(
+    x_prev,
+    L_prev,
+    T,
+    R,
+    Q,
+    Z,
+    H,
+    y,
+) -> None:
+    """Check static PyTensor shapes when enough shape information is available."""
+    sx = x_prev.type.shape
+    sL = L_prev.type.shape
+    sT = T.type.shape
+    sR = R.type.shape
+    sQ = Q.type.shape
+    sZ = Z.type.shape
+    sH = H.type.shape
+    sy = y.type.shape
+
+    n = sx[0]
+    m = sy[0]
+
+    if sL[0] is not None and sL[1] is not None and sL[0] != sL[1]:
+        raise TypeError(f"L_prev must be square, got static shape {sL}")
+    if n is not None and sL[0] is not None and sL[0] != n:
+        raise TypeError(f"L_prev.shape[0] must match x_prev length ({n}), got {sL[0]}")
+    if n is not None and sL[1] is not None and sL[1] != n:
+        raise TypeError(f"L_prev.shape[1] must match x_prev length ({n}), got {sL[1]}")
+
+    if sT[0] is not None and sT[1] is not None and sT[0] != sT[1]:
+        raise TypeError(f"T must be square, got static shape {sT}")
+    if n is not None and sT[0] is not None and sT[0] != n:
+        raise TypeError(f"T.shape[0] must match x_prev length ({n}), got {sT[0]}")
+    if n is not None and sT[1] is not None and sT[1] != n:
+        raise TypeError(f"T.shape[1] must match x_prev length ({n}), got {sT[1]}")
+
+    if n is not None and sR[0] is not None and sR[0] != n:
+        raise TypeError(f"R.shape[0] must match x_prev length ({n}), got {sR[0]}")
+    q = sR[1]
+    if q is not None and sQ[0] is not None and sQ[0] != q:
+        raise TypeError(f"Q.shape[0] must match R.shape[1] ({q}), got {sQ[0]}")
+    if q is not None and sQ[1] is not None and sQ[1] != q:
+        raise TypeError(f"Q.shape[1] must match R.shape[1] ({q}), got {sQ[1]}")
+
+    if m is not None and sZ[0] is not None and sZ[0] != m:
+        raise TypeError(f"Z.shape[0] must match y length ({m}), got {sZ[0]}")
+    if n is not None and sZ[1] is not None and sZ[1] != n:
+        raise TypeError(f"Z.shape[1] must match x_prev length ({n}), got {sZ[1]}")
+
+    if sH[0] is not None and sH[1] is not None and sH[0] != sH[1]:
+        raise TypeError(f"H must be square, got static shape {sH}")
+    if m is not None and sH[0] is not None and sH[0] != m:
+        raise TypeError(f"H.shape[0] must match y length ({m}), got {sH[0]}")
+    if m is not None and sH[1] is not None and sH[1] != m:
+        raise TypeError(f"H.shape[1] must match y length ({m}), got {sH[1]}")
+
+
+def _qr_chol_predict_numpy(
+    L_prev: np.ndarray,
+    T: np.ndarray,
+    R: np.ndarray,
+    L_Q: np.ndarray,
+) -> np.ndarray:
+    """Return the predicted covariance factor using a QR step.
+
+    The QR form is a little more robust than propagating the full covariance
+    directly and then taking a Cholesky factor afterwards.
+    """
+    A = np.concatenate([T @ L_prev, R @ L_Q], axis=1)  # (n, n+q)
+
+    _, R_thin = np.linalg.qr(A.T, mode="reduced")  # R_thin: (n, n)
+
+    # Keep the usual Cholesky sign convention.
+    signs = np.sign(np.diag(R_thin))
+    signs[signs == 0.0] = 1.0
+    R_thin = R_thin * signs[:, np.newaxis]  # flip rows
+
+    return R_thin.T  # lower-triangular, positive diagonal
+
+
+def _chol_kalman_update_numpy(
+    x_pred: np.ndarray,
+    L_pred: np.ndarray,
+    Z: np.ndarray,
+    H: np.ndarray,
+    y: np.ndarray,
+    jitter: float = 1e-8,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Run the NumPy update step and return the new mean, factor, and logp.
+
+    This uses triangular solves for both the gain and the likelihood term, so
+    there is no explicit matrix inverse in the update.
+    """
+    n = x_pred.shape[0]
+    m = y.shape[0]
+
+    # In this version, a partially missing observation is treated as missing.
+    if np.isnan(y).any():
+        return x_pred.copy(), L_pred.copy(), 0.0
+
+    P_pred = L_pred @ L_pred.T
+    v = y - Z @ x_pred  # (m,)
+
+    S = Z @ P_pred @ Z.T + H
+    S = 0.5 * (S + S.T)
+    S += jitter * np.eye(m)
+
+    L_S = np.linalg.cholesky(S)  # (m, m) lower-triangular
+
+    ZP = Z @ P_pred  # (m, n)
+    tmp1 = solve_triangular(L_S, ZP, lower=True)  # L_S  tmp1  = ZP
+    tmp2 = solve_triangular(L_S.T, tmp1, lower=False)  # L_S^T K^T = tmp1
+    K = tmp2.T  # (n, m)
+
+    x_new = x_pred + K @ v  # (n,)
+
+    IKZ = np.eye(n) - K @ Z  # (n, n)
+    P_new = IKZ @ P_pred @ IKZ.T + K @ H @ K.T  # (n, n)
+    P_new = 0.5 * (P_new + P_new.T)
+    P_new += jitter * np.eye(n)
+
+    L_new = np.linalg.cholesky(P_new)  # (n, n)
+
+    log_det_S = 2.0 * np.sum(np.log(np.diag(L_S)))
+    Sinv_v = solve_triangular(L_S, v, lower=True)  # (m,)
+    quad = float(np.dot(Sinv_v, Sinv_v))
+    log_lik = -0.5 * (log_det_S + quad + m * np.log(2.0 * np.pi))
+
+    return x_new, L_new, float(log_lik)
+
+
+def chol_kalman_step_numpy(
+    x_prev: np.ndarray,
+    L_prev: np.ndarray,
+    T: np.ndarray,
+    R: np.ndarray,
+    Q: np.ndarray,
+    Z: np.ndarray,
+    H: np.ndarray,
+    y: np.ndarray,
+    c: np.ndarray | None = None,
+    jitter: float = 1e-8,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Run one predict/update step with the NumPy reference code."""
+    if jitter <= 0:
+        raise ValueError(f"jitter must be positive, got {jitter}")
+
+    _validate_numeric_shapes(x_prev, L_prev, T, R, Q, Z, H, y, c=c)
+    q = Q.shape[0]
+
+    L_Q = np.linalg.cholesky(Q + jitter * np.eye(q))
+
+    if c is None:
+        x_pred = T @ x_prev
+    else:
+        x_pred = T @ x_prev + c
+    L_pred = _qr_chol_predict_numpy(L_prev, T, R, L_Q)
+
+    x_new, L_new, log_lik = _chol_kalman_update_numpy(x_pred, L_pred, Z, H, y, jitter=jitter)
+    return x_new, L_new, log_lik
+
+
+def run_chol_kalman_filter_numpy(
+    x0: np.ndarray,
+    P0: np.ndarray,
+    T: np.ndarray,
+    R: np.ndarray,
+    Q: np.ndarray,
+    Z: np.ndarray,
+    H: np.ndarray,
+    observations: np.ndarray,
+    c: np.ndarray | None = None,
+    jitter: float = 1e-8,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Filter a full observation sequence with the NumPy reference code."""
+    n = x0.shape[0]
+    T_steps = observations.shape[0]
+
+    L0 = np.linalg.cholesky(P0 + jitter * np.eye(n))
+
+    means = np.zeros((T_steps, n))
+    chols = np.zeros((T_steps, n, n))
+    lls = np.zeros(T_steps)
+
+    x, L = x0.copy(), L0.copy()
+    for t in range(T_steps):
+        x, L, ll = chol_kalman_step_numpy(x, L, T, R, Q, Z, H, observations[t], c=c, jitter=jitter)
+        means[t] = x
+        chols[t] = L
+        lls[t] = ll
+
+    return means, chols, lls
+
+
+def _chol_kalman_step_symbolic(
+    x_prev,
+    L_prev,
+    T,
+    R,
+    Q,
+    Z,
+    H,
+    y,
+    jitter: float = 1e-8,
+    c=None,
+):
+    """Symbolic version of the same step, used for gradients.
+
+    The forward `perform` method uses NumPy, but `grad` rebuilds the step with
+    PyTensor ops so autodiff can see through it.
+
+    Note: The predict step here uses the standard covariance form
+    (T P T' + R Q R') rather than the QR decomposition used in the NumPy path.
+    PyTensor's QR gradient support is incomplete, so the covariance form is used
+    to keep the symbolic graph differentiable. The two forms are mathematically
+    equivalent.
+    """
+    n_state = T.shape[0]
+    n_obs = H.shape[0]
+
+    # Match the NumPy missing-data rule.
+    any_missing = pt.any(pt.isnan(y))
+    y_safe = pt.switch(any_missing, pt.zeros_like(y), y)
+
+    if c is None:
+        x_pred = T @ x_prev
+    else:
+        x_pred = T @ x_prev + c
+
+    # PyTensor's QR path is awkward here, so use the equivalent covariance form.
+    P_prev = L_prev @ L_prev.T
+    P_pred_temp = T @ P_prev @ T.T + R @ Q @ R.T
+
+    P_pred_temp = 0.5 * (P_pred_temp + P_pred_temp.T) + jitter * pt.eye(n_state)
+    L_pred = pt.linalg.cholesky(P_pred_temp, lower=True)
+
+    P_pred = L_pred @ L_pred.T  # (n, n)
+
+    v = y_safe - Z @ x_pred  # (m,)
+
+    S = Z @ P_pred @ Z.T + H
+    S = 0.5 * (S + S.T)
+    S = S + jitter * pt.eye(n_obs)
+
+    L_S = pt.linalg.cholesky(S, lower=True)  # (m, m)
+
+    ZP = Z @ P_pred  # (m, n)
+    tmp1 = pt.linalg.solve_triangular(L_S, ZP, lower=True)  # (m, n)
+    tmp2 = pt.linalg.solve_triangular(L_S.T, tmp1, lower=False)  # (m, n)
+    K = tmp2.T  # (n, m)
+
+    x_new = x_pred + K @ v  # (n,)
+
+    I_n = pt.eye(n_state)
+    IKZ = I_n - K @ Z  # (n, n)
+    P_new = IKZ @ P_pred @ IKZ.T + K @ H @ K.T  # (n, n)
+    P_new = 0.5 * (P_new + P_new.T) + jitter * pt.eye(n_state)
+
+    L_new = pt.linalg.cholesky(P_new, lower=True)  # (n, n)
+
+    log_det_S = 2.0 * pt.sum(pt.log(pt.diag(L_S)))
+    Sinv_v = pt.linalg.solve_triangular(L_S, v, lower=True)  # (m,)
+    quad = pt.dot(Sinv_v, Sinv_v)
+    log_lik = -0.5 * (log_det_S + quad + n_obs * pt.log(2.0 * np.pi))
+
+    x_out = pt.switch(any_missing, x_pred, x_new)
+    L_out = pt.switch(any_missing, L_pred, L_new)
+    ll_out = pt.switch(any_missing, pt.as_tensor(0.0, dtype="float64"), log_lik)
+
+    return x_out, L_out, ll_out
+
+
+class CholKalmanUpdateOp(Op):
+    """PyTensor wrapper around one Kalman predict/update step.
+
+    The Op keeps the execution path simple: NumPy for forward evaluation,
+    symbolic reconstruction for gradients.
+
+    The state offset vector ``c`` is not supported at the Op level in Phase 1.
+    Use the NumPy path (``chol_kalman_step_numpy``) directly if ``c`` is needed.
+    """
+
+    __props__ = ("jitter",)
+
+    def __init__(self, jitter: float = 1e-8):
+        if jitter <= 0:
+            raise ValueError(f"jitter must be positive, got {jitter}")
+        self.jitter = float(jitter)
+        super().__init__()
+
+    def make_node(self, x_prev, L_prev, T, R, Q, Z, H, y):
+        x_prev = pt.as_tensor_variable(x_prev).astype("float64")
+        L_prev = pt.as_tensor_variable(L_prev).astype("float64")
+        T = pt.as_tensor_variable(T).astype("float64")
+        R = pt.as_tensor_variable(R).astype("float64")
+        Q = pt.as_tensor_variable(Q).astype("float64")
+        Z = pt.as_tensor_variable(Z).astype("float64")
+        H = pt.as_tensor_variable(H).astype("float64")
+        y = pt.as_tensor_variable(y).astype("float64")
+
+        inputs = [x_prev, L_prev, T, R, Q, Z, H, y]
+
+        if x_prev.ndim != 1:
+            raise TypeError(f"x_prev must be 1-D, got ndim={x_prev.ndim}")
+        if L_prev.ndim != 2:
+            raise TypeError(f"L_prev must be 2-D, got ndim={L_prev.ndim}")
+        if y.ndim != 1:
+            raise TypeError(f"y must be 1-D, got ndim={y.ndim}")
+
+        _validate_static_shapes_make_node(x_prev, L_prev, T, R, Q, Z, H, y)
+
+        x_new_type = pt.dvector()
+        L_new_type = pt.dmatrix()
+        log_lik_type = pt.dscalar()
+
+        return Apply(self, inputs, [x_new_type, L_new_type, log_lik_type])
+
+    def perform(self, node, inputs, outputs):
+        """Run the Op through the NumPy reference implementation."""
+        x_prev, L_prev, T, R, Q, Z, H, y = (np.asarray(a, dtype=np.float64) for a in inputs)
+        _validate_numeric_shapes(x_prev, L_prev, T, R, Q, Z, H, y)
+
+        x_new, L_new, log_lik = chol_kalman_step_numpy(
+            x_prev, L_prev, T, R, Q, Z, H, y, jitter=self.jitter
+        )
+
+        outputs[0][0] = x_new
+        outputs[1][0] = L_new
+        outputs[2][0] = np.array(log_lik, dtype=np.float64)
+
+    def grad(self, inputs, output_grads):
+        """Build the symbolic step and let PyTensor differentiate it."""
+        x_prev, L_prev, T, R, Q, Z, H, y = inputs
+        g_x_new, g_L_new, g_ell = output_grads
+
+        x_new_sym, L_new_sym, log_lik_sym = _chol_kalman_step_symbolic(
+            x_prev, L_prev, T, R, Q, Z, H, y, jitter=self.jitter
+        )
+
+        if isinstance(g_x_new.type, DisconnectedType):
+            g_x_new = pt.zeros_like(x_new_sym)
+
+        if isinstance(g_L_new.type, DisconnectedType):
+            g_L_new = pt.zeros_like(L_new_sym)
+
+        if isinstance(g_ell.type, DisconnectedType):
+            g_ell = pt.zeros_like(log_lik_sym)
+
+        obj = pt.dot(g_x_new, x_new_sym) + pt.sum(g_L_new * L_new_sym) + g_ell * log_lik_sym
+
+        grads = pt.grad(
+            obj,
+            wrt=[x_prev, L_prev, T, R, Q, Z, H, y],
+            disconnected_inputs="zero",
+        )
+        return grads
+
+    def R_op(self, inputs, eval_points):
+        """Forward-mode derivative helper."""
+        x_prev, L_prev, T, R, Q, Z, H, y = inputs
+        ev_x, ev_L, ev_T, ev_R, ev_Q, ev_Z, ev_H, ev_y = eval_points
+
+        def _safe_ev(ev, var):
+            if ev is None:
+                return pt.zeros_like(var)
+            return ev
+
+        ev_x = _safe_ev(ev_x, x_prev)
+        ev_L = _safe_ev(ev_L, L_prev)
+        ev_T = _safe_ev(ev_T, T)
+        ev_R = _safe_ev(ev_R, R)
+        ev_Q = _safe_ev(ev_Q, Q)
+        ev_Z = _safe_ev(ev_Z, Z)
+        ev_H = _safe_ev(ev_H, H)
+        ev_y = _safe_ev(ev_y, y)
+        eval_points_safe = [ev_x, ev_L, ev_T, ev_R, ev_Q, ev_Z, ev_H, ev_y]
+
+        x_new_sym, L_new_sym, log_lik_sym = _chol_kalman_step_symbolic(
+            x_prev, L_prev, T, R, Q, Z, H, y, jitter=self.jitter
+        )
+
+        rop_x = _Rop(x_new_sym, inputs, eval_points_safe, disconnected_outputs="ignore")
+        rop_L = _Rop(L_new_sym, inputs, eval_points_safe, disconnected_outputs="ignore")
+        rop_ll = _Rop(log_lik_sym, inputs, eval_points_safe, disconnected_outputs="ignore")
+
+        return [rop_x, rop_L, rop_ll]
+
+    def infer_shape(self, fgraph, node, input_shapes):
+        n = input_shapes[0][0]
+        return [(n,), (n, n), ()]
+
+    def connection_pattern(self, node):
+        return [[True, True, True]] * 8
+
+    def __repr__(self):
+        return f"CholKalmanUpdateOp(jitter={self.jitter})"
+
+
+def make_chol_kalman_op(jitter: float = 1e-8) -> CholKalmanUpdateOp:
+    """Create a `CholKalmanUpdateOp` with the jitter."""
+    return CholKalmanUpdateOp(jitter=jitter)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,9 @@ allow-direct-references = true
 [tool.pytest.ini_options]
 minversion = "6.0"
 xfail_strict = true
+markers = [
+  "slow: marks tests as slow-running (deselect with '-m \"not slow\"')",
+]
 addopts = [
   "-v",
   "--doctest-modules",

--- a/tests/statespace/test_chol_kalman.py
+++ b/tests/statespace/test_chol_kalman.py
@@ -1,0 +1,1067 @@
+"""Tests for the Cholesky-form Kalman filter implementation.
+
+This test file is meant to lock down the phase-1 behavior of the filter before
+any backend expansion. The emphasis is on a few concrete things:
+
+- the NumPy reference step should agree with standard Kalman calculations,
+- the Cholesky form should stay positive definite in long or awkward runs,
+- missing observations should follow the documented predict-only behavior,
+- the PyTensor Op should match the NumPy path and support gradients.
+
+The tests are intentionally a mix of small exact checks and longer numerical
+stress cases. That gives us both readable failures for simple bugs and broader
+coverage for the stability claims this implementation is making.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import numpy as np
+import pytensor.tensor as pt
+import pytest
+import scipy.stats
+
+from numpy.testing import assert_allclose
+
+from pymc_extras.statespace.filters.chol_kalman import (
+    CholKalmanUpdateOp,
+    _chol_kalman_update_numpy,
+    _qr_chol_predict_numpy,
+    chol_kalman_step_numpy,
+    run_chol_kalman_filter_numpy,
+)
+
+RNG = np.random.default_rng(42)
+
+
+def make_local_level_model(sigma_obs=1.0, sigma_state=0.5):
+    """Return a tiny 1D local-level model used throughout the tests."""
+    T = np.eye(1)
+    R = np.eye(1)
+    Q = np.array([[sigma_state**2]])
+    Z = np.eye(1)
+    H = np.array([[sigma_obs**2]])
+    return T, R, Q, Z, H
+
+
+def make_kinematic_2d_model(dt=1.0, sigma_proc=0.1, sigma_obs=1.0):
+    """Return a small constant-velocity tracking model with position observations."""
+    n, m = 4, 2
+    T = np.array(
+        [
+            [1, 0, dt, 0],
+            [0, 1, 0, dt],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+        ],
+        dtype=float,
+    )
+    R = np.eye(4)
+    Q = (sigma_proc**2) * np.eye(4)
+    Z = np.array([[1, 0, 0, 0], [0, 1, 0, 0]], dtype=float)
+    H = (sigma_obs**2) * np.eye(2)
+    return T, R, Q, Z, H
+
+
+def standard_kalman_filter(x0, P0, T, R, Q, Z, H, observations):
+    """Reference Kalman filter used to cross-check the Cholesky version.
+
+    This is intentionally plain and works with full covariance matrices so the
+    tests have a simple baseline to compare against.
+    """
+    n = x0.shape[0]
+    T_steps = observations.shape[0]
+    means = np.zeros((T_steps, n))
+    covs = np.zeros((T_steps, n, n))
+    lls = np.zeros(T_steps)
+
+    x, P = x0.copy(), P0.copy()
+    for t in range(T_steps):
+        x_pred = T @ x
+        P_pred = T @ P @ T.T + R @ Q @ R.T
+
+        y = observations[t]
+        if np.isnan(y).any():
+            x, P = x_pred, P_pred
+            lls[t] = 0.0
+        else:
+            m = y.shape[0]
+            v = y - Z @ x_pred
+            S = Z @ P_pred @ Z.T + H
+            S_sym = 0.5 * (S + S.T)
+            K = P_pred @ Z.T @ np.linalg.solve(S_sym, np.eye(m))
+            x = x_pred + K @ v
+            P_new = (np.eye(n) - K @ Z) @ P_pred
+            P = 0.5 * (P_new + P_new.T)
+
+            log_det = np.linalg.slogdet(S_sym)[1]
+            quad = float(v @ np.linalg.solve(S_sym, v))
+            lls[t] = -0.5 * (log_det + quad + m * np.log(2.0 * np.pi))
+
+        means[t] = x
+        covs[t] = P
+
+    return means, covs, lls
+
+
+class TestQRPredict:
+    """Tests for _qr_chol_predict_numpy."""
+
+    def test_matches_direct_propagation(self):
+        """L_pred L_pred^T must equal T P T^T + R Q R^T."""
+        rng = np.random.default_rng(0)
+        n, q = 4, 3
+        T = rng.standard_normal((n, n))
+        R = rng.standard_normal((n, q))
+        P = rng.standard_normal((n, n))
+        P = P @ P.T + np.eye(n)
+        Q = rng.standard_normal((q, q))
+        Q = Q @ Q.T + 0.1 * np.eye(q)
+
+        L_prev = np.linalg.cholesky(P)
+        L_Q = np.linalg.cholesky(Q)
+        L_pred = _qr_chol_predict_numpy(L_prev, T, R, L_Q)
+
+        P_pred_qr = L_pred @ L_pred.T
+        P_pred_direct = T @ P @ T.T + R @ Q @ R.T
+
+        assert_allclose(P_pred_qr, P_pred_direct, rtol=1e-10, atol=1e-12)
+
+    def test_output_is_lower_triangular(self):
+        """L_pred must be lower-triangular."""
+        rng = np.random.default_rng(1)
+        n, q = 3, 2
+        T = rng.standard_normal((n, n))
+        R = rng.standard_normal((n, q))
+        L_prev = np.tril(rng.standard_normal((n, n)))
+        L_prev[np.diag_indices(n)] = np.abs(np.diag(L_prev)) + 0.1
+        L_Q = np.tril(np.eye(q) + 0.1 * rng.standard_normal((q, q)))
+        L_Q[np.diag_indices(q)] = np.abs(np.diag(L_Q)) + 0.1
+
+        L_pred = _qr_chol_predict_numpy(L_prev, T, R, L_Q)
+
+        assert_allclose(np.triu(L_pred, k=1), 0.0, atol=1e-14)
+
+    def test_positive_diagonal(self):
+        """Cholesky convention: diagonal must be strictly positive."""
+        rng = np.random.default_rng(2)
+        n, q = 5, 3
+        T = rng.standard_normal((n, n))
+        R = rng.standard_normal((n, q))
+        P = np.eye(n) + 0.1 * rng.standard_normal((n, n)) @ rng.standard_normal((n, n)).T
+        Q = 0.1 * np.eye(q)
+        L_prev = np.linalg.cholesky(P)
+        L_Q = np.linalg.cholesky(Q)
+
+        L_pred = _qr_chol_predict_numpy(L_prev, T, R, L_Q)
+        assert np.all(np.diag(L_pred) > 0), "Diagonal of L_pred must be positive."
+
+    def test_scalar_system(self):
+        """1-D sanity check: L_pred = sqrt(T^2 P + Q)."""
+        T = np.array([[2.0]])
+        R = np.array([[1.0]])
+        P = np.array([[3.0]])
+        Q = np.array([[1.0]])
+        L_prev = np.linalg.cholesky(P)
+        L_Q = np.linalg.cholesky(Q)
+        L_pred = _qr_chol_predict_numpy(L_prev, T, R, L_Q)
+        expected = np.sqrt(4 * 3 + 1)
+        assert_allclose(L_pred[0, 0], expected, rtol=1e-12)
+
+
+class TestCholKalmanUpdate:
+    """Tests for _chol_kalman_update_numpy."""
+
+    def test_missing_observation_predict_only(self):
+        """All-NaN y must return x_pred, L_pred unchanged with log_lik = 0."""
+        n, m = 3, 2
+        x_pred = np.array([1.0, 2.0, 3.0])
+        L_pred = np.tril(np.ones((n, n)))
+        L_pred[np.diag_indices(n)] += 1.0
+        Z = RNG.standard_normal((m, n))
+        H = np.eye(m)
+        y = np.full(m, np.nan)
+
+        x_new, L_new, ll = _chol_kalman_update_numpy(x_pred, L_pred, Z, H, y)
+
+        assert_allclose(x_new, x_pred)
+        assert_allclose(L_new, L_pred)
+        assert ll == 0.0
+
+    def test_posterior_tighter_than_prior(self):
+        """After a real observation the posterior variance must shrink."""
+        T, R, Q, Z, H = make_local_level_model(sigma_obs=0.5, sigma_state=0.1)
+        n = 1
+        x_pred = np.array([0.0])
+        P_pred = np.eye(n) * 2.0
+        L_pred = np.linalg.cholesky(P_pred)
+        y = np.array([0.5])
+
+        x_new, L_new, ll = _chol_kalman_update_numpy(x_pred, L_pred, Z, H, y)
+        P_new = L_new @ L_new.T
+
+        assert P_new[0, 0] < P_pred[0, 0], "Posterior variance must be less than prior."
+
+    def test_log_lik_matches_scipy_1d(self):
+        """1-D Gaussian log-likelihood must match scipy.stats.norm."""
+        sigma_obs, sigma_state = 1.0, 0.5
+        T, R, Q, Z, H = make_local_level_model(sigma_obs, sigma_state)
+        x_pred = np.array([0.0])
+        P_pred = np.array([[1.0]])  # unit prior variance
+        L_pred = np.linalg.cholesky(P_pred)
+        y = np.array([1.5])
+
+        _, _, ll = _chol_kalman_update_numpy(x_pred, L_pred, Z, H, y, jitter=0.0)
+
+        # Predictive is N(Z x_pred, Z P Z^T + H) = N(0, 1 + sigma_obs^2)
+        pred_var = float((Z @ P_pred @ Z.T + H)[0, 0])
+        expected = float(scipy.stats.norm.logpdf(y[0], loc=0.0, scale=np.sqrt(pred_var)))
+
+        assert_allclose(ll, expected, atol=1e-10)
+
+    def test_posterior_covariance_spd(self):
+        """L_new L_new^T must be symmetric positive-definite."""
+        rng = np.random.default_rng(5)
+        n, m = 4, 2
+        P_pred = rng.standard_normal((n, n))
+        P_pred = P_pred @ P_pred.T + np.eye(n)
+        L_pred = np.linalg.cholesky(P_pred)
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        x_pred = rng.standard_normal(n)
+        y = rng.standard_normal(m)
+
+        x_new, L_new, ll = _chol_kalman_update_numpy(x_pred, L_pred, Z, H, y)
+        P_new = L_new @ L_new.T
+        eigs = np.linalg.eigvalsh(P_new)
+        assert np.all(eigs > 0), f"Posterior covariance not SPD. Min eigenvalue: {eigs.min():.3e}"
+
+
+class TestPositiveDefiniteness:
+    """Stress tests that make sure the covariance stays positive definite."""
+
+    def _run_pd_stress(self, n_steps: int, sigma_proc: float, sigma_obs: float, seed: int):
+        rng = np.random.default_rng(seed)
+        T, R, Q, Z, H = make_local_level_model(sigma_obs=sigma_obs, sigma_state=sigma_proc)
+        x0 = np.array([0.0])
+        P0 = np.eye(1)
+        observations = rng.standard_normal((n_steps, 1))
+
+        _, chols, _ = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, observations)
+
+        min_eigvals = []
+        for L in chols:
+            P = L @ L.T
+            eigs = np.linalg.eigvalsh(P)
+            min_eigvals.append(eigs.min())
+
+        return np.array(min_eigvals)
+
+    def test_pd_1000_steps_standard(self):
+        """1,000 steps: all posteriors must have min eigenvalue > 1e-10."""
+        min_eigvals = self._run_pd_stress(1000, sigma_proc=0.5, sigma_obs=1.0, seed=7)
+        assert np.all(
+            min_eigvals > 1e-10
+        ), f"PD violation detected. Min eigenvalue across run: {min_eigvals.min():.3e}"
+
+    def test_pd_1000_steps_small_noise(self):
+        """Near-degenerate Q: min eigenvalue must remain above threshold."""
+        min_eigvals = self._run_pd_stress(1000, sigma_proc=1e-5, sigma_obs=1.0, seed=8)
+        assert np.all(
+            min_eigvals > 1e-12
+        ), f"PD violation with small process noise. Min eigenvalue: {min_eigvals.min():.3e}"
+
+    @pytest.mark.slow
+    def test_pd_100k_steps(self):
+        """Full proposal spec: 10^5 steps, min eigenvalue > 1e-10."""
+        min_eigvals = self._run_pd_stress(100_000, sigma_proc=0.5, sigma_obs=1.0, seed=9)
+        assert np.all(min_eigvals > 1e-10)
+
+
+class TestMissingData:
+    def test_all_nan_sequence(self):
+        """Run with all observations NaN: state must remain at prior."""
+        T, R, Q, Z, H = make_local_level_model()
+        x0 = np.array([5.0])
+        P0 = np.eye(1) * 2.0
+
+        obs = np.full((50, 1), np.nan)
+        means, chols, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+
+        assert_allclose(lls, 0.0)
+
+    def test_mixed_nan_sequence_log_lik(self):
+        """NaN steps contribute 0 to log-lik; observed steps contribute nonzero."""
+        rng = np.random.default_rng(10)
+        T, R, Q, Z, H = make_local_level_model()
+        x0 = np.array([0.0])
+        P0 = np.eye(1)
+
+        obs = rng.standard_normal((20, 1))
+        obs[::3] = np.nan
+
+        _, _, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+
+        nan_steps = np.arange(0, 20, 3)
+        obs_steps = np.setdiff1d(np.arange(20), nan_steps)
+
+        assert_allclose(lls[nan_steps], 0.0, atol=0.0)
+        assert np.all(lls[obs_steps] < 0.0), "Observed log-likelihoods must be negative."
+
+    def test_mixed_nan_state_continuity(self):
+        """NaN steps must not reset or corrupt the state estimate."""
+        T, R, Q, Z, H = make_local_level_model(sigma_state=0.0, sigma_obs=1e-6)
+        x0 = np.array([10.0])
+        P0 = np.eye(1) * 1e-4
+
+        obs = np.array([[10.0]] * 5 + [[np.nan]] * 5 + [[10.0]] * 5)
+        means, _, _ = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs, jitter=1e-12)
+
+        assert_allclose(means, 10.0, atol=0.01)
+
+    def test_partial_nan_treated_as_predict_only(self):
+        """Any NaN in y is conservatively treated as full missing in phase 1."""
+        rng = np.random.default_rng(99)
+        T, R, Q, Z, H = make_kinematic_2d_model()
+        x0 = np.zeros(4)
+        P0 = np.eye(4)
+
+        obs_full = rng.standard_normal((6, 2))
+        obs_partial = obs_full.copy()
+        obs_partial[3, 0] = np.nan
+        obs_full_missing = obs_full.copy()
+        obs_full_missing[3] = np.array([np.nan, np.nan])
+
+        means_partial, chols_partial, lls_partial = run_chol_kalman_filter_numpy(
+            x0, P0, T, R, Q, Z, H, obs_partial
+        )
+        means_missing, chols_missing, lls_missing = run_chol_kalman_filter_numpy(
+            x0, P0, T, R, Q, Z, H, obs_full_missing
+        )
+
+        assert_allclose(means_partial, means_missing, rtol=1e-12, atol=1e-12)
+        assert_allclose(chols_partial, chols_missing, rtol=1e-12, atol=1e-12)
+        assert_allclose(lls_partial, lls_missing, rtol=1e-12, atol=1e-12)
+
+
+class TestLogLikelihood:
+    def test_total_log_lik_matches_standard_filter(self):
+        """Total log-likelihood should match the standard filter."""
+        rng = np.random.default_rng(11)
+        T, R, Q, Z, H = make_kinematic_2d_model()
+        n, m = 4, 2
+        x0 = np.zeros(n)
+        P0 = np.eye(n)
+        obs = rng.standard_normal((100, m))
+
+        _, _, lls_chol = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+        _, _, lls_std = standard_kalman_filter(x0, P0, T, R, Q, Z, H, obs)
+
+        assert_allclose(
+            lls_chol.sum(),
+            lls_std.sum(),
+            rtol=1e-7,
+            err_msg="Total log-likelihood mismatch between Cholesky and standard filter.",
+        )
+
+    def test_log_lik_per_step_matches_standard_filter(self):
+        """
+        Per-step log-likelihoods from the Cholesky filter must match the standard
+        filter at every step.
+        """
+        rng = np.random.default_rng(12)
+        T, R, Q, Z, H = make_local_level_model()
+        x0 = np.array([0.0])
+        P0 = np.eye(1) * 2.0
+        obs = rng.standard_normal((50, 1))
+
+        _, _, lls_chol = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+        _, _, lls_std = standard_kalman_filter(x0, P0, T, R, Q, Z, H, obs)
+
+        assert_allclose(lls_chol, lls_std, rtol=1e-6, atol=1e-8)
+
+    def test_log_lik_is_negative(self):
+        """Log-likelihood must be negative for non-degenerate observations."""
+        T, R, Q, Z, H = make_local_level_model()
+        x0 = np.array([0.0])
+        P0 = np.eye(1)
+        obs = np.array([[1.0], [2.0], [-1.0]])
+
+        _, _, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+        assert np.all(lls < 0.0)
+
+
+class TestCholKalmanOp:
+    @pytest.fixture(autouse=True)
+    def op(self):
+        self.op = CholKalmanUpdateOp(jitter=1e-8)
+
+    def _make_inputs(self, n=4, m=2, q=4, seed=20):
+        """Return concrete numpy arrays for a valid Kalman step."""
+        rng = np.random.default_rng(seed)
+        x_prev = rng.standard_normal(n)
+        A = rng.standard_normal((n, n))
+        P_prev = A @ A.T + np.eye(n) * 2.0
+        L_prev = np.linalg.cholesky(P_prev)
+        T, R, Q, Z, H = make_kinematic_2d_model()
+        y = rng.standard_normal(m)
+        return x_prev, L_prev, T, R, Q, Z, H, y
+
+    def test_perform_matches_numpy_reference(self):
+        """Op.perform() must produce identical output to chol_kalman_step_numpy."""
+        x_prev, L_prev, T, R, Q, Z, H, y = self._make_inputs()
+
+        x_ref, L_ref, ll_ref = chol_kalman_step_numpy(x_prev, L_prev, T, R, Q, Z, H, y)
+
+        import pytensor.tensor as pt
+
+        out = self.op(
+            pt.as_tensor(x_prev),
+            pt.as_tensor(L_prev),
+            pt.as_tensor(T),
+            pt.as_tensor(R),
+            pt.as_tensor(Q),
+            pt.as_tensor(Z),
+            pt.as_tensor(H),
+            pt.as_tensor(y),
+        )
+        x_op, L_op, ll_op = (o.eval() for o in out)
+
+        assert_allclose(x_op, x_ref, rtol=1e-12, err_msg="x_new mismatch")
+        assert_allclose(L_op, L_ref, rtol=1e-12, err_msg="L_new mismatch")
+        assert_allclose(ll_op, ll_ref, rtol=1e-12, err_msg="log_lik mismatch")
+
+    def test_perform_nan_observation(self):
+        """Op.perform() with all-NaN y must return x_pred, L_pred unchanged."""
+        import pytensor.tensor as pt
+
+        x_prev, L_prev, T, R, Q, Z, H, _ = self._make_inputs()
+        y_nan = np.full(2, np.nan)
+
+        out = self.op(
+            pt.as_tensor(x_prev),
+            pt.as_tensor(L_prev),
+            pt.as_tensor(T),
+            pt.as_tensor(R),
+            pt.as_tensor(Q),
+            pt.as_tensor(Z),
+            pt.as_tensor(H),
+            pt.as_tensor(y_nan),
+        )
+        _, _, ll_op = (o.eval() for o in out)
+        assert_allclose(ll_op, 0.0, atol=1e-15)
+
+    def test_perform_partial_nan_observation(self):
+        """A partially missing y must also trigger predict-only in phase 1."""
+        x_prev, L_prev, T, R, Q, Z, H, y = self._make_inputs()
+        y_partial = y.copy()
+        y_partial[0] = np.nan
+        y_full_missing = np.full_like(y, np.nan)
+
+        x_partial, L_partial, ll_partial = (
+            o.eval()
+            for o in self.op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                pt.as_tensor(Z),
+                pt.as_tensor(H),
+                pt.as_tensor(y_partial),
+            )
+        )
+        x_missing, L_missing, ll_missing = (
+            o.eval()
+            for o in self.op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                pt.as_tensor(Z),
+                pt.as_tensor(H),
+                pt.as_tensor(y_full_missing),
+            )
+        )
+
+        assert_allclose(x_partial, x_missing, atol=1e-14)
+        assert_allclose(L_partial, L_missing, atol=1e-14)
+        assert_allclose(ll_partial, ll_missing, atol=1e-14)
+
+    def test_op_output_cholesky_is_lower_triangular(self):
+        """L_new from the Op must be lower-triangular with positive diagonal."""
+        import pytensor.tensor as pt
+
+        x_prev, L_prev, T, R, Q, Z, H, y = self._make_inputs()
+
+        out = self.op(
+            pt.as_tensor(x_prev),
+            pt.as_tensor(L_prev),
+            pt.as_tensor(T),
+            pt.as_tensor(R),
+            pt.as_tensor(Q),
+            pt.as_tensor(Z),
+            pt.as_tensor(H),
+            pt.as_tensor(y),
+        )
+        L_op = out[1].eval()
+
+        assert_allclose(
+            np.triu(L_op, k=1), 0.0, atol=1e-14, err_msg="L_new upper triangle not zero."
+        )
+        assert np.all(np.diag(L_op) > 0), "L_new diagonal must be positive."
+
+    def test_gradient_check_log_lik_wrt_Z(self):
+        """Check the gradient of log_lik with respect to Z."""
+        from pytensor.gradient import verify_grad
+
+        rng = np.random.default_rng(30)
+        n, m, q = 2, 1, 2
+        x_prev = rng.standard_normal(n)
+        A = rng.standard_normal((n, n))
+        P_prev = A @ A.T + np.eye(n) * 3.0
+        L_prev = np.linalg.cholesky(P_prev)
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        op = CholKalmanUpdateOp(jitter=1e-6)
+
+        def log_lik_fn(Z_var):
+            outputs = op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                Z_var,
+                pt.as_tensor(H),
+                pt.as_tensor(y),
+            )
+            return outputs[2]
+
+        verify_grad(
+            log_lik_fn,
+            pt=[Z],
+            rng=np.random.default_rng(31),
+            eps=1e-5,
+            rel_tol=1e-4,
+            abs_tol=1e-5,
+        )
+
+    def test_gradient_check_log_lik_wrt_H(self):
+        """Verify gradient of log_lik w.r.t. H via finite differences."""
+        from pytensor.gradient import verify_grad
+
+        rng = np.random.default_rng(32)
+        n, m, q = 2, 2, 2
+        x_prev = rng.standard_normal(n)
+        P_prev = np.eye(n)
+        L_prev = np.linalg.cholesky(P_prev)
+        T = np.eye(n)
+        R = np.eye(n)
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        op = CholKalmanUpdateOp(jitter=1e-6)
+
+        def log_lik_fn(H_var):
+            outputs = op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                pt.as_tensor(Z),
+                H_var,
+                pt.as_tensor(y),
+            )
+            return outputs[2]
+
+        verify_grad(
+            log_lik_fn,
+            pt=[H],
+            rng=np.random.default_rng(33),
+            eps=1e-5,
+            rel_tol=1e-4,
+            abs_tol=1e-5,
+        )
+
+    def test_gradient_check_x_new_wrt_T(self):
+        """Verify gradient of x_new[0] w.r.t. T via finite differences."""
+        from pytensor.gradient import verify_grad
+
+        rng = np.random.default_rng(34)
+        n, m, q = 2, 1, 2
+        x_prev = rng.standard_normal(n)
+        L_prev = np.linalg.cholesky(np.eye(n))
+        T = np.eye(n) * 0.8
+        R = np.eye(n)
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        op = CholKalmanUpdateOp(jitter=1e-6)
+
+        def x0_fn(T_var):
+            outputs = op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                T_var,
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                pt.as_tensor(Z),
+                pt.as_tensor(H),
+                pt.as_tensor(y),
+            )
+            return outputs[0][0]
+
+        verify_grad(
+            x0_fn,
+            pt=[T],
+            rng=np.random.default_rng(35),
+            eps=1e-5,
+            rel_tol=1e-4,
+            abs_tol=1e-5,
+        )
+
+    def test_symbolic_missing_data_grad_is_finite(self):
+        """Gradients through missing-data branch should be finite (and zero here)."""
+        rng = np.random.default_rng(77)
+        n, m, q = 2, 2, 2
+        x_prev = rng.standard_normal(n)
+        P_prev = np.eye(n) * 2.0
+        L_prev = np.linalg.cholesky(P_prev)
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y_nan = np.array([np.nan, 0.0])
+
+        Z_sym = pt.dmatrix("Z_sym")
+        outputs = self.op(
+            pt.as_tensor(x_prev),
+            pt.as_tensor(L_prev),
+            pt.as_tensor(T),
+            pt.as_tensor(R),
+            pt.as_tensor(Q),
+            Z_sym,
+            pt.as_tensor(H),
+            pt.as_tensor(y_nan),
+        )
+        grad_Z = pt.grad(outputs[2], Z_sym)
+        grad_val = grad_Z.eval({Z_sym: Z})
+
+        assert np.all(np.isfinite(grad_val))
+        assert_allclose(grad_val, 0.0, atol=1e-12)
+
+    def test_infer_shape(self):
+        """infer_shape must return (n,), (n, n), () for the three outputs."""
+        n, m = 3, 2
+        x_sym = pt.dvector("x")
+        L_sym = pt.dmatrix("L")
+        T_sym = pt.dmatrix("T")
+        R_sym = pt.dmatrix("R")
+        Q_sym = pt.dmatrix("Q")
+        Z_sym = pt.dmatrix("Z")
+        H_sym = pt.dmatrix("H")
+        y_sym = pt.dvector("y")
+
+        outs = self.op(x_sym, L_sym, T_sym, R_sym, Q_sym, Z_sym, H_sym, y_sym)
+
+        # Build a concrete test case to evaluate the shape graph
+        rng = np.random.default_rng(90)
+        x = rng.standard_normal(n)
+        L = np.linalg.cholesky(np.eye(n))
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        Q = np.eye(n) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m)
+        y = rng.standard_normal(m)
+
+        feed = {x_sym: x, L_sym: L, T_sym: T, R_sym: R, Q_sym: Q, Z_sym: Z, H_sym: H, y_sym: y}
+
+        x_out, L_out, ll_out = (o.eval(feed) for o in outs)
+        assert x_out.shape == (n,)
+        assert L_out.shape == (n, n)
+        assert ll_out.shape == ()
+
+    def test_connection_pattern(self):
+        """All 8 inputs should connect to all 3 outputs."""
+        op = CholKalmanUpdateOp(jitter=1e-8)
+        pattern = op.connection_pattern(node=None)
+        assert len(pattern) == 8
+        for row in pattern:
+            assert row == [True, True, True]
+
+    def test_r_op_produces_finite_output(self):
+        """R_op should return finite values for a standard input."""
+        rng = np.random.default_rng(91)
+        n, m = 2, 1
+        x_prev = rng.standard_normal(n)
+        P_prev = np.eye(n) * 2.0
+        L_prev = np.linalg.cholesky(P_prev)
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        Q = np.eye(n) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        inputs = [
+            pt.as_tensor(x_prev),
+            pt.as_tensor(L_prev),
+            pt.as_tensor(T),
+            pt.as_tensor(R),
+            pt.as_tensor(Q),
+            pt.as_tensor(Z),
+            pt.as_tensor(H),
+            pt.as_tensor(y),
+        ]
+        # Tangent vectors: small perturbation in x_prev direction only
+        eval_points = [
+            pt.as_tensor(np.ones(n) * 0.01),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ]
+
+        rop_x, rop_L, rop_ll = self.op.R_op(inputs, eval_points)
+        vals = [rop_x.eval(), rop_L.eval(), rop_ll.eval()]
+        for v in vals:
+            assert np.all(np.isfinite(v)), f"R_op output not finite: {v}"
+
+    def test_make_node_rejects_bad_static_shapes(self):
+        """make_node should raise TypeError when static shapes conflict."""
+        op = CholKalmanUpdateOp(jitter=1e-8)
+
+        # L_prev not square
+        x = pt.dvector("x")
+        L_bad = pt.tensor("L_bad", shape=(3, 4), dtype="float64")
+        T = pt.dmatrix("T")
+        R = pt.dmatrix("R")
+        Q = pt.dmatrix("Q")
+        Z = pt.dmatrix("Z")
+        H = pt.dmatrix("H")
+        y = pt.dvector("y")
+
+        with pytest.raises(TypeError, match="L_prev must be square"):
+            op(x, L_bad, T, R, Q, Z, H, y)
+
+        # H not square
+        H_bad = pt.tensor("H_bad", shape=(2, 3), dtype="float64")
+        with pytest.raises(TypeError, match="H must be square"):
+            op(x, pt.dmatrix("L"), T, R, Q, Z, H_bad, y)
+
+        # T not square
+        T_bad = pt.tensor("T_bad", shape=(3, 4), dtype="float64")
+        with pytest.raises(TypeError, match="T must be square"):
+            op(x, pt.dmatrix("L2"), T_bad, R, Q, Z, pt.dmatrix("H2"), y)
+
+    def test_gradient_check_log_lik_wrt_Q(self):
+        """Verify gradient of log_lik w.r.t. Q via finite differences.
+
+        Q is a covariance matrix (symmetric), but verify_grad perturbs elements
+        independently. The NumPy path takes cholesky(Q) which only reads the
+        lower triangle, so we parameterize Q = L_Q L_Q^T and test the gradient
+        w.r.t. L_Q instead to avoid the asymmetry.
+        """
+        from pytensor.gradient import verify_grad
+
+        rng = np.random.default_rng(40)
+        n, m, q = 2, 1, 2
+        x_prev = rng.standard_normal(n)
+        L_prev = np.linalg.cholesky(np.eye(n) * 2.0)
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        L_Q = np.linalg.cholesky(np.eye(q) * 0.3)
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        op = CholKalmanUpdateOp(jitter=1e-6)
+
+        def log_lik_fn(L_Q_var):
+            Q_var = L_Q_var @ L_Q_var.T
+            outputs = op(
+                pt.as_tensor(x_prev),
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                Q_var,
+                pt.as_tensor(Z),
+                pt.as_tensor(H),
+                pt.as_tensor(y),
+            )
+            return outputs[2]
+
+        verify_grad(
+            log_lik_fn,
+            pt=[L_Q],
+            rng=np.random.default_rng(41),
+            eps=1e-5,
+            rel_tol=1e-4,
+            abs_tol=1e-5,
+        )
+
+    def test_gradient_check_log_lik_wrt_x_prev(self):
+        """Verify gradient of log_lik w.r.t. x_prev via finite differences."""
+        from pytensor.gradient import verify_grad
+
+        rng = np.random.default_rng(45)
+        n, m, q = 2, 1, 2
+        x_prev = rng.standard_normal(n)
+        L_prev = np.linalg.cholesky(np.eye(n) * 2.0)
+        T = np.eye(n) * 0.9
+        R = np.eye(n)
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        y = rng.standard_normal(m)
+
+        op = CholKalmanUpdateOp(jitter=1e-6)
+
+        def log_lik_fn(x_var):
+            outputs = op(
+                x_var,
+                pt.as_tensor(L_prev),
+                pt.as_tensor(T),
+                pt.as_tensor(R),
+                pt.as_tensor(Q),
+                pt.as_tensor(Z),
+                pt.as_tensor(H),
+                pt.as_tensor(y),
+            )
+            return outputs[2]
+
+        verify_grad(
+            log_lik_fn,
+            pt=[x_prev],
+            rng=np.random.default_rng(46),
+            eps=1e-5,
+            rel_tol=1e-4,
+            abs_tol=1e-5,
+        )
+
+
+class TestBatchVsOnlineEquivalence:
+    """Check that online filtering agrees with the batch-style reference."""
+
+    def test_kinematic_2d_final_state(self):
+        """The final filtered state should match the standard filter."""
+        rng = np.random.default_rng(42)
+        T_mat, R, Q, Z, H = make_kinematic_2d_model(dt=1.0, sigma_proc=0.1, sigma_obs=1.0)
+        n, m = 4, 2
+
+        x_true = np.array([0.0, 0.0, 1.0, 0.5])
+        obs = []
+        for _ in range(200):
+            x_true = T_mat @ x_true + rng.multivariate_normal(np.zeros(n), Q)
+            obs.append(Z @ x_true + rng.multivariate_normal(np.zeros(m), H))
+        obs = np.array(obs)
+
+        x0 = np.zeros(n)
+        P0 = np.eye(n)
+
+        means_chol, _, lls_chol = run_chol_kalman_filter_numpy(x0, P0, T_mat, R, Q, Z, H, obs)
+
+        means_std, _, lls_std = standard_kalman_filter(x0, P0, T_mat, R, Q, Z, H, obs)
+
+        assert_allclose(
+            means_chol[-1],
+            means_std[-1],
+            rtol=1e-5,
+            err_msg="Final state mismatch: online vs batch.",
+        )
+
+        assert_allclose(
+            lls_chol.sum(), lls_std.sum(), rtol=1e-7, err_msg="Total log-likelihood mismatch."
+        )
+
+    def test_per_step_state_agreement(self):
+        """The filtered means should match the standard filter step by step."""
+        rng = np.random.default_rng(43)
+        T_mat, R, Q, Z, H = make_local_level_model(sigma_obs=1.0, sigma_state=0.5)
+        x0 = np.array([0.0])
+        P0 = np.eye(1) * 2.0
+        obs = rng.standard_normal((200, 1))
+
+        means_chol, _, _ = run_chol_kalman_filter_numpy(x0, P0, T_mat, R, Q, Z, H, obs)
+        means_std, _, _ = standard_kalman_filter(x0, P0, T_mat, R, Q, Z, H, obs)
+
+        assert_allclose(
+            means_chol, means_std, rtol=1e-6, atol=1e-8, err_msg="Per-step state mismatch."
+        )
+
+    def test_jitter_sensitivity(self):
+        """Changing jitter in a stable regime should not move results much."""
+        rng = np.random.default_rng(44)
+        T_mat, R, Q, Z, H = make_kinematic_2d_model()
+        x0 = np.zeros(4)
+        P0 = np.eye(4)
+        obs = rng.standard_normal((100, 2))
+
+        means_hi, _, lls_hi = run_chol_kalman_filter_numpy(
+            x0, P0, T_mat, R, Q, Z, H, obs, jitter=1e-8
+        )
+        means_lo, _, lls_lo = run_chol_kalman_filter_numpy(
+            x0, P0, T_mat, R, Q, Z, H, obs, jitter=1e-12
+        )
+
+        assert_allclose(
+            means_hi,
+            means_lo,
+            atol=1e-5,
+            err_msg="State estimates should be insensitive to jitter in stable regime.",
+        )
+        assert_allclose(lls_hi.sum(), lls_lo.sum(), atol=1e-5)
+
+    def test_chol_vs_standard_with_mixed_nans(self):
+        """Both filters must agree when observations contain scattered NaNs."""
+        rng = np.random.default_rng(55)
+        T_mat, R, Q, Z, H = make_kinematic_2d_model()
+        x0 = np.zeros(4)
+        P0 = np.eye(4)
+        obs = rng.standard_normal((80, 2))
+        # Knock out some observations
+        obs[5] = np.nan
+        obs[20] = np.nan
+        obs[21, 0] = np.nan  # partial NaN → both filters should treat as full missing
+
+        means_chol, _, lls_chol = run_chol_kalman_filter_numpy(x0, P0, T_mat, R, Q, Z, H, obs)
+        means_std, _, lls_std = standard_kalman_filter(x0, P0, T_mat, R, Q, Z, H, obs)
+
+        assert_allclose(
+            lls_chol,
+            lls_std,
+            rtol=1e-6,
+            atol=1e-8,
+            err_msg="Per-step log-lik mismatch with NaN observations.",
+        )
+        # Cholesky and covariance forms accumulate different rounding errors,
+        # especially after predict-only recovery steps, so use looser tolerance.
+        assert_allclose(
+            means_chol,
+            means_std,
+            rtol=5e-4,
+            atol=1e-6,
+            err_msg="State estimate mismatch with NaN observations.",
+        )
+
+
+class TestEdgeCases:
+    """Small defensive checks around shapes, jitter, and awkward numerics."""
+
+    def test_invalid_jitter_raises(self):
+        with pytest.raises(ValueError, match="jitter must be positive"):
+            CholKalmanUpdateOp(jitter=0.0)
+        with pytest.raises(ValueError, match="jitter must be positive"):
+            CholKalmanUpdateOp(jitter=-1e-8)
+
+    def test_1d_1d_system(self):
+        """Minimal system: n=1, m=1, q=1."""
+        T = np.array([[0.9]])
+        R = np.array([[1.0]])
+        Q = np.array([[0.1]])
+        Z = np.array([[1.0]])
+        H = np.array([[1.0]])
+        x0 = np.array([0.0])
+        P0 = np.array([[1.0]])
+        obs = np.array([[1.0], [2.0], [1.5]])
+
+        means, chols, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+        assert means.shape == (3, 1)
+        assert chols.shape == (3, 1, 1)
+        assert np.all(lls < 0)
+
+    def test_high_dimensional_state(self):
+        """n=20, m=5: ensure no shape or numerical errors."""
+        rng = np.random.default_rng(50)
+        n, m, q = 20, 5, 10
+        T = 0.9 * np.eye(n)
+        R = rng.standard_normal((n, q))
+        Q = np.eye(q) * 0.1
+        Z = rng.standard_normal((m, n))
+        H = np.eye(m) * 0.5
+        x0 = np.zeros(n)
+        P0 = np.eye(n)
+        obs = rng.standard_normal((10, m))
+
+        means, chols, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs)
+        assert means.shape == (10, n)
+        for L in chols:
+            eigs = np.linalg.eigvalsh(L @ L.T)
+            assert np.all(eigs > 0), f"Not PD. Min eig: {eigs.min():.3e}"
+
+    def test_repr_op(self):
+        op = CholKalmanUpdateOp(jitter=1e-6)
+        assert "CholKalmanUpdateOp" in repr(op)
+        assert "1e-06" in repr(op)
+
+    def test_chol_step_shape_mismatch_raises_cleanly(self):
+        """Input shape mismatches should raise clear ValueError messages."""
+        T, R, Q, Z, H = make_local_level_model()
+        x_prev = np.zeros(2)
+        L_prev = np.eye(2)
+        y = np.zeros(1)
+
+        with pytest.raises(ValueError, match=r"T must have shape \(2, 2\)"):
+            chol_kalman_step_numpy(x_prev, L_prev, T, R, Q, Z, H, y)
+
+    def test_chol_step_nonzero_c_offset(self):
+        """Non-zero c branch should shift predict-only state by c."""
+        x_prev = np.array([1.0, -2.0])
+        L_prev = np.linalg.cholesky(np.eye(2))
+        T = np.array([[1.0, 0.0], [0.0, 1.0]])
+        R = np.eye(2)
+        Q = np.eye(2) * 0.1
+        Z = np.eye(2)
+        H = np.eye(2)
+        y = np.array([np.nan, np.nan])
+        c = np.array([0.25, -0.75])
+
+        x_new, _, ll = chol_kalman_step_numpy(x_prev, L_prev, T, R, Q, Z, H, y, c=c)
+        assert_allclose(x_new, x_prev + c, atol=1e-12)
+        assert_allclose(ll, 0.0, atol=0.0)
+
+    def test_ill_conditioned_q_h_remains_pd(self):
+        """Nearly singular process/observation noise should remain numerically stable."""
+        rng = np.random.default_rng(123)
+        n, m, q = 3, 2, 3
+        T = np.eye(n)
+        R = np.eye(n)
+        Q = np.diag([1e-12, 1e-10, 1e-8])
+        Z = rng.standard_normal((m, n))
+        H = np.diag([1e-12, 1e-9])
+        x0 = np.zeros(n)
+        P0 = np.eye(n)
+        obs = rng.standard_normal((40, m))
+
+        means, chols, lls = run_chol_kalman_filter_numpy(x0, P0, T, R, Q, Z, H, obs, jitter=1e-12)
+
+        assert means.shape == (40, n)
+        assert np.all(np.isfinite(lls))
+        for L in chols:
+            eigs = np.linalg.eigvalsh(L @ L.T)
+            assert np.all(eigs > 0), f"Not PD under ill-conditioned Q/H. Min eig: {eigs.min():.3e}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])


### PR DESCRIPTION
## ENH: Cholesky-form Kalman filter Op — Phase 1 (GSoC 2026)

**cc @jessegrabowski** — Would appreciate your review when you get a chance. This is Phase 1 of the [Scalable Online Bayesian State Space Models](https://colab.research.google.com/drive/1meuQCj9j-xsYX3haq6FFOXhIt_8H5c3S) project from my [PyMc Discourse thread](https://discourse.pymc.io/t/potential-approach-towards-scalable-online-bayesian-ssms-project-gsoc-2026/).

---

### What this PR adds

A numerically stable, square-root (Cholesky-form) Kalman filter implementation with a PyTensor Op that supports NUTS gradient flow. This is the foundational kernel that the rest of the online state-space pipeline (sliding-window likelihood, `OnlineStateSpace` API, JAX/Numba backends) will build on.

#### New files

| File | Description |
|------|-------------|
| `pymc_extras/statespace/filters/chol_kalman.py` (~500 lines) | NumPy reference filter + `CholKalmanUpdateOp` |
| `tests/statespace/test_chol_kalman.py` (~1060 lines) | 43 tests across 8 test classes |

---

### Implementation details

#### NumPy reference path
- **QR-based predict step**: Forms `[T @ L_prev, R @ L_Q]` and extracts the predicted Cholesky factor via QR decomposition — avoids squaring the condition number compared to the standard `T P T' + R Q R'` propagation.
- **Triangular-solve update**: Kalman gain `K` is computed via `scipy.linalg.solve_triangular` against the Cholesky factor of `S`. No explicit matrix inverse is ever formed.
- **Joseph-form covariance update**: `P_new = (I - KZ) P_pred (I - KZ)' + K H K'` maintains positive semi-definiteness under floating-point arithmetic.
- **Diagonal jitter**: Small `εI` is added to `S` and `P_new` before Cholesky factorization to guard near-singular cases.
- **Log-likelihood**: Computed as `−½(log|S| + v'S⁻¹v + m·log(2π))` using the Cholesky diagonal for `log|S|` and a triangular solve for the quadratic form.
- **State offset `c`**: The NumPy path supports an optional state intercept vector `c` in the predict step (`x_pred = T @ x + c`).

#### Missing-data contract
Any NaN in the observation vector `y` triggers a **full predict-only step**: `x_new = x_pred`, `L_new = L_pred`, `log_lik = 0`. This is a conservative Phase 1 policy — partial observation masking (reduced-rank update on observed components only) is deferred to a follow-on PR to satisfy XLA static-shape constraints.

#### PyTensor Op (`CholKalmanUpdateOp`)
- **Inputs**: `x_prev` (n,), `L_prev` (n,n), `T` (n,n), `R` (n,q), `Q` (q,q), `Z` (m,n), `H` (m,m), `y` (m,)
- **Outputs**: `x_new` (n,), `L_new` (n,n), `log_lik` (scalar)
- **`perform()`**: Delegates to the NumPy reference implementation.
- **`grad()`**: Rebuilds the step symbolically via `_chol_kalman_step_symbolic()` and lets PyTensor autodiff through it. Handles `DisconnectedType` output gradients.
- **`R_op()`**: Forward-mode derivative via `pytensor.gradient.Rop`, with `disconnected_outputs='ignore'`.
- **`infer_shape()`**: Returns `(n,)`, `(n, n)`, `()`.
- **`connection_pattern()`**: All 8 inputs connect to all 3 outputs.
- **`make_node()`**: Static shape validation at graph-construction time — rejects non-square `L_prev`, `T`, `H`, and dimension mismatches when shape info is available.

#### Known asymmetries (documented, intentional)
1. **Symbolic path uses covariance-form predict, not QR.** PyTensor's QR gradient support is incomplete, so the symbolic graph used by `grad()` computes `T P T' + R Q R'` directly. The two forms are mathematically equivalent; only the numeric conditioning differs, and the forward path (which determines actual filter output) uses QR.
2. **State offset `c` is NumPy-only.** The Op does not accept `c` as an input in Phase 1. This will be added when the `OnlineStateSpace` API is built in Phase 2.

---

### Test coverage (43 tests, all passing)

| Test class | Tests | What it covers |
|---|---|---|
| `TestQRPredict` | 4 | QR predict matches direct propagation, lower-triangular output, positive diagonal, scalar system |
| `TestCholKalmanUpdate` | 4 | Missing obs → predict-only, posterior tighter than prior, scipy loglik match, SPD check |
| `TestPositiveDefiniteness` | 3 | 1,000-step standard, 1,000-step near-degenerate Q, 100k-step stress test |
| `TestMissingData` | 4 | All-NaN sequence, mixed NaN log-lik, state continuity through NaN gaps, partial NaN = full missing |
| `TestLogLikelihood` | 3 | Total loglik vs standard filter, per-step match, negativity |
| `TestCholKalmanOp` | 13 | `perform()` vs NumPy, NaN handling, partial NaN, lower-triangular output, `verify_grad` for Z/H/T/Q/x_prev, missing-data grad is finite, `infer_shape`, `connection_pattern`, `R_op`, static shape rejection |
| `TestBatchVsOnlineEquivalence` | 4 | Final state match, per-step agreement, jitter sensitivity, Cholesky vs standard filter with mixed NaNs |
| `TestEdgeCases` | 8 | Invalid jitter, 1D system, n=20 high-dim, `__repr__`, shape mismatch errors, `c` offset, ill-conditioned Q/H |

The test file includes a standalone `standard_kalman_filter()` reference that uses full covariance matrices, serving as an independent cross-check. Its missing-data semantics match the implementation's `any`-NaN-triggers-predict-only contract.

---

### How to run

```bash
pytest tests/statespace/test_chol_kalman.py -v           # 42 tests (~40s)
pytest tests/statespace/test_chol_kalman.py -v --runslow  # 43 tests, includes 100k-step PD stress test
```

---

### What's next (Phase 2 and beyond)

Per my [GSoC proposal timeline](https://discourse.pymc.io/t/potential-approach-towards-scalable-online-bayesian-ssms-project-gsoc-2026/):

| Phase | Weeks | Deliverable | Status |
|---|---|---|---|
| **Phase 1** | 1–3 | NumPy reference + `CholKalmanUpdateOp` + tests | **This PR** |
| Phase 2 | 4–5 | `sliding_window_loglik()`, `OnlineStateSpace` API, `.update()` with warm-start MCMC, ArviZ I/O | Next |
| Phase 3 | 6–7 | JAX backend — `jit`, chunked `vmap`, adaptive `chunk_size`, x64, PRNG management | Planned |
| Phase 4a | 8 | Numba CPU backend — `@numba.njit` kernel, PyTensor COp dispatch | Planned |
| Phase 4b | 9 | Ray distributed layer — `KalmanActor`, `ActorPool`, warm-pool init | Planned |
| Phase 5 | 10–11 | Hardening, 10⁵-step CI stress tests, cross-backend parity, NUTS warm-start shim | Planned |
| Phase 6 | 12–13 | Benchmarks (JAX/Numba/Stan/TFP), tutorial notebook, docs, final PRs | Planned |

**Immediate Phase 2 work** will build `sliding_window_loglik()` on top of this Op — evaluating the marginal likelihood over the most recent `W` observations using the stored Cholesky belief state as a warm start, making each MCMC gradient evaluation O(W) regardless of total stream length T.

---

### Related

- **Proposal**: [GSoC 2026 — Scalable Online Bayesian State Space Models](https://discourse.pymc.io/t/potential-approach-towards-scalable-online-bayesian-ssms-project-gsoc-2026/)
- **Proof-of-concept**: [Colab notebook](https://colab.research.google.com/drive/1meuQCj9j-xsYX3haq6FFOXhIt_8H5c3S) — empirically validates O(1) vs O(T) scaling
- **Discourse thread**: [Potential Approach Towards Scalable Online Bayesian SSMs](https://discourse.pymc.io/t/potential-approach-towards-scalable-online-bayesian-ssms-project-gsoc-2026/)

