### PR TITLE
DADVI: initialise variational means from model initial point, not zeros

### DIFF
--- a/pymc_extras/inference/dadvi/dadvi.py
+++ b/pymc_extras/inference/dadvi/dadvi.py
@@ -143,7 +143,8 @@ def fit_dadvi(
     )
 
     dadvi_initial_point = {
-        f"{var_name}_mu": np.zeros_like(value).ravel()
+        f"{var_name}_mu": np.asarray(value).ravel()
+
         for var_name, value in initial_point_dict.items()
     }
     dadvi_initial_point.update(

--- a/pymc_extras/inference/dadvi/dadvi.py
+++ b/pymc_extras/inference/dadvi/dadvi.py
@@ -144,7 +144,6 @@ def fit_dadvi(
 
     dadvi_initial_point = {
         f"{var_name}_mu": np.asarray(value).ravel()
-
         for var_name, value in initial_point_dict.items()
     }
     dadvi_initial_point.update(


### PR DESCRIPTION
`fit_dadvi` constructs its starting optimisation point `x0` by setting all
variational means (`{var}_mu`) to zero. For models with non-zero prior
means in unconstrained space, this places the fixed DADVI draws far from the
region of positive likelihood. The result is that many of the 30 fixed draws
produce `logp = -inf`, the mean DADVI objective is `+inf`, and the optimiser
fails immediately with:

```
ValueError: array must not contain infs or NaNs
```

This error was hit when using fit_dadvi(gradient_backend = "jax"). PyTensor may handle the NaN values gracefully.

The same model samples successfully with NUTS.

Please note that I used AI to trace and patch this problem.

### Cause

```python
dadvi_initial_point = {
    f"{var_name}_mu": np.zeros_like(value).ravel()   # always zeros
    for var_name, value in initial_point_dict.items()
}
```

`initial_point_dict` already contains the prior means in unconstrained space.
`np.zeros_like` discards that information.

### Minimal reproduction

```python
import numpy as np
import pymc as pm
from pymc_extras.inference import fit_dadvi

with pm.Model() as model:
    mu = pm.LogNormal("mu", mu=np.log(4.5), sigma=0.5)
    obs = pm.Normal("obs", mu=mu, sigma=1.0, observed=np.array([4.0, 5.0, 4.5]))
    idata = fit_dadvi(gradient_backend="jax")
    # → ValueError: array must not contain infs or NaNs
```

With 30 N(0, 1) draws centred at zero rather than at `log(4.5) ≈ 1.5`, many draws
map to `mu ≈ exp(-2)` to `exp(-3)`, producing near-zero model predictions and
`logp = -inf`. In the real-world case that exposed this bug (a 3-compartment PK
model with proportional error, 48 subjects, 107 unconstrained parameters),
**15 out of 30** fixed draws gave `logp = -inf` at `x0`.

### Notes

The DADVI paper (Giordano, Ingram & Broderick, 2024) provides no basis for
initialising at zero.

Algorithm 2 states:
> *procedure DADVI  
> t ← 0 / Fix N / Draw 𝒵 / while Not converged do …*

The starting value of η = (μ, ξ) is left unspecified.
