### PR TITLE
Fix for divide by zero in psislw call from Pathfinder

### DIFF
--- a/pymc_extras/inference/pathfinder/importance_sampling.py
+++ b/pymc_extras/inference/pathfinder/importance_sampling.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 import arviz as az
 import numpy as np
+import xarray as xr
 
 from numpy.typing import NDArray
 from scipy.special import logsumexp
@@ -99,12 +100,11 @@ def importance_sampling(
                 "ignore", category=RuntimeWarning, message="overflow encountered in exp"
             )
             match method:
-                case "psis":
-                    replace = False
-                    logiw, pareto_k = az.psislw(logiw)
-                case "psir":
-                    replace = True
-                    logiw, pareto_k = az.psislw(logiw)
+                case "psis" | "psir":
+                    replace = method == "psir"
+                    logiw_da, pareto_k_da = az.psislw(xr.DataArray(logiw, dims="__sample__"))
+                    logiw = logiw_da.values
+                    pareto_k = float(pareto_k_da)
                 case "identity":
                     replace = False
                     pareto_k = None

--- a/tests/pathfinder/test_pathfinder.py
+++ b/tests/pathfinder/test_pathfinder.py
@@ -237,6 +237,10 @@ def test_pathfinder_importance_sampling(importance_sampling):
         assert idata.posterior["tau"].shape == (1, num_draws)
         assert idata.posterior["theta"].shape == (1, num_draws, 8)
 
+    if importance_sampling in ("psis", "psir"):
+        pareto_k = idata.sample_stats["pareto_k"].item()
+        assert isinstance(pareto_k, float) and np.isfinite(pareto_k)
+
 
 def test_pathfinder_initvals():
     # Run a model with an ordered transform that will fail unless initvals are in place


### PR DESCRIPTION
This is intended to fix the divide by zero issue by wrapping `logiw` in `xr.DataArray` with `dims="__sample__"` before calling `psislw`. This is  the documented-recommended input form per arviz's own `psislw` docstring. 

Regression test added. 