### PR TITLE
Add ConvergentFilter

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -39,6 +39,7 @@ from pymc_extras.statespace.core.properties import (
 )
 from pymc_extras.statespace.core.representation import PytensorRepresentation
 from pymc_extras.statespace.filters import (
+    ConvergentFilter,
     KalmanSmoother,
     SquareRootFilter,
     StandardFilter,
@@ -65,6 +66,7 @@ FILTER_FACTORY = {
     "standard": StandardFilter,
     "univariate": UnivariateFilter,
     "cholesky": SquareRootFilter,
+    "convergent": ConvergentFilter,
 }
 
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -39,6 +39,7 @@ from pymc_extras.statespace.core.properties import (
 )
 from pymc_extras.statespace.core.representation import PytensorRepresentation
 from pymc_extras.statespace.filters import (
+    ConvergentFilter,
     KalmanSmoother,
     SquareRootFilter,
     StandardFilter,
@@ -71,6 +72,7 @@ FILTER_FACTORY = {
     "standard": StandardFilter,
     "univariate": UnivariateFilter,
     "cholesky": SquareRootFilter,
+    "convergent": ConvergentFilter,
 }
 
 

--- a/pymc_extras/statespace/filters/__init__.py
+++ b/pymc_extras/statespace/filters/__init__.py
@@ -3,6 +3,7 @@ from pymc_extras.statespace.filters.distributions import (
     SimulationSmoother,
 )
 from pymc_extras.statespace.filters.kalman_filter import (
+    ConvergentFilter,
     SquareRootFilter,
     StandardFilter,
     UnivariateFilter,
@@ -10,6 +11,7 @@ from pymc_extras.statespace.filters.kalman_filter import (
 from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
 
 __all__ = [
+    "ConvergentFilter",
     "KalmanSmoother",
     "LinearGaussianStateSpace",
     "SimulationSmoother",

--- a/pymc_extras/statespace/filters/__init__.py
+++ b/pymc_extras/statespace/filters/__init__.py
@@ -1,5 +1,6 @@
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
 from pymc_extras.statespace.filters.kalman_filter import (
+    ConvergentFilter,
     SquareRootFilter,
     StandardFilter,
     UnivariateFilter,
@@ -7,6 +8,7 @@ from pymc_extras.statespace.filters.kalman_filter import (
 from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
 
 __all__ = [
+    "ConvergentFilter",
     "KalmanSmoother",
     "LinearGaussianStateSpace",
     "SquareRootFilter",

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -845,7 +845,9 @@ class UnivariateFilter(BaseFilter):
 class ConvergentFilter(StandardFilter):
     """Kalman filter that exploits Riccati convergence to a fixed-gain steady state.
 
-    For a stationary observable system with no missing data, the predicted-covariance Riccati recursion
+    For a time-invariant system whose Riccati recursion reaches a steady state -- detectability and
+    stabilizability are sufficient, which is weaker than stationarity and admits unit-root models such
+    as the local level -- the predicted-covariance recursion
     ``P_{t+1|t} = T (P_{t|t-1} - K_t F_t K_t^T) T^T + R Q R^T`` is data-independent and converges to the
     discrete algebraic Riccati equation (DARE) fixed point ``P_star``. Once converged, the Kalman gain
     ``K_t = P_{t|t-1} Z^T F_t^{-1}`` and innovation covariance ``F_t = Z P_{t|t-1} Z^T + H`` are constant
@@ -878,7 +880,11 @@ class ConvergentFilter(StandardFilter):
     Constraints (validated at graph build time):
 
     - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
-      :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
+      :class:`ValueError`: a constant steady-state gain only exists when the system matrices are
+      constant. This is a statement about time-invariance, not stationarity -- a time-invariant model
+      whose Riccati recursion never settles within the series simply never triggers the ``until``
+      clause, so ``k = n``, the post-convergence tail is empty, and the result reduces to
+      :class:`StandardFilter`.
     - ``data`` must contain no missing values. A masked observation changes the effective ``Z_t`` (and
       so ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. The statespace core replaces
       ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -870,7 +870,7 @@ class ConvergentFilter(StandardFilter):
 
     2. **Speed.** In the post-convergence tail, per-step Cholesky and the full Joseph-form backward are
        unnecessary because ``K``, ``F``, and ``P`` are constant. The custom pullback hoists
-       ``F^{-1}, H^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
+       ``F^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
        backward reduces to matvec and outer products. On typical state-space cells
        (m=10..50, p=3..10, n=2000..10000) this gives a ~1.8--2.9x speedup on ``logp + grad``
        versus :class:`StandardFilter` autodiff, on top of a ~7--12x forward speedup.
@@ -884,6 +884,9 @@ class ConvergentFilter(StandardFilter):
       ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are
       rejected. For :class:`SharedVariable` or :class:`TensorConstant` data the check runs at build
       time; fully symbolic data gets an :class:`~pytensor.raise_op.Assert` that fires at runtime.
+
+    Measurement-error-free models (singular or zero ``H``) are fully supported, gradients included;
+    the tail backward avoids forming ``H^{-1}``.
 
     Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
     disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
@@ -1026,7 +1029,6 @@ class ConvergentFilter(StandardFilter):
         d,
         T,
         Z,
-        H,
         K_star,
         F_star,
         F_chol_star,
@@ -1035,7 +1037,7 @@ class ConvergentFilter(StandardFilter):
     ):
         """Analytic backward pass over the post-convergence segment.
 
-        Runs a backward scan on the post-convergence data with ``F_inv, H_inv, A = T (I - K_star Z),
+        Runs a backward scan on the post-convergence data with ``F_inv, A = T (I - K_star Z),
         I - K_star Z`` hoisted out as non-sequences. Each step is closed-form (no Cholesky or solve in
         the body; only matvecs and outer products). Returns:
 
@@ -1062,9 +1064,8 @@ class ConvergentFilter(StandardFilter):
         I_KZ = pt.eye(m) - K_star @ Z
         A = T @ I_KZ
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
-        H_inv = pt.linalg.inv(stabilize(H, self.cov_jitter))
 
-        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, H_inv_, A_, I_KZ_):
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_):
             v = y - Z_ @ a_prev - d_
             Finv_v = F_inv_ @ v
             a_filt = a_prev + K_ @ v
@@ -1078,11 +1079,13 @@ class ConvergentFilter(StandardFilter):
             # length grows it converges to the solution of the Lyapunov equation X = A^T X A + C, which
             # is the steady-state P-adjoint. Because A is constant in the post-convergence segment,
             # we can hoist it; the per-step work is the two correction terms (cross_a and direct_C)
-            # which still depend on y_t and a_prev.
-            row = (v[None, :] @ H_inv_) @ Z_
-            M = I_KZ_.T @ (T_r_next[:, None] @ row) @ I_KZ_
-            cross_a = 0.5 * (M + M.T)
-            Zt_Finv_v = (Z_.T @ Finv_v)[:, None]
+            # which still depend on y_t and a_prev. cross_a uses the identity Z(I - K Z) = H F^{-1} Z
+            # to express what is naturally an H^{-1} term through F^{-1} instead, which stays finite for
+            # singular H (a measurement-error-free model).
+            u = I_KZ_.T @ T_r_next
+            w = Z_.T @ Finv_v
+            cross_a = 0.5 * (pt.outer(u, w) + pt.outer(w, u))
+            Zt_Finv_v = w[:, None]
             direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
 
@@ -1109,7 +1112,7 @@ class ConvergentFilter(StandardFilter):
                 None,
                 None,
             ],
-            non_sequences=[c, d, T, Z, K_star, F_inv, H_inv, A, I_KZ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ],
             go_backwards=True,
             strict=False,
             return_updates=False,
@@ -1252,7 +1255,6 @@ class ConvergentFilter(StandardFilter):
                 d_,
                 T_,
                 Z_,
-                H_,
                 K_star,
                 F_star,
                 F_chol,
@@ -1343,6 +1345,9 @@ class ConvergentFilter(StandardFilter):
                 dQ_tr + d_Q_P,
             ]
 
+        # inline=True folds the forward into the surrounding graph, but the custom pullback still
+        # wins: pt.grad builds the gradient graph before the inline rewrite runs, so the analytic
+        # backward is what gets differentiated.
         return OpFromGraph(
             inputs=inputs_s,
             outputs=outputs,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -7,7 +7,7 @@ import pytensor
 import pytensor.tensor as pt
 
 from pymc.pytensorf import constant_fold
-from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.builders import SymbolicOp
 from pytensor.compile.sharedvalue import SharedVariable
 from pytensor.gradient import disconnected_grad
 from pytensor.graph.basic import Variable
@@ -27,7 +27,6 @@ from pymc_extras.statespace.utils.constants import (
     LONG_NAME_TO_SHORT,
     MATRIX_NAMES,
     MISSING_FILL,
-    static_matrix_shapes,
 )
 
 MVN_CONST = pt.log(2 * pt.constant(np.pi, dtype="float64"))
@@ -859,7 +858,7 @@ class ConvergentFilter(StandardFilter):
       ``K_star``, ``F_star``, ``log det F_star``. No per-step Cholesky; loss is ``log det F_star + v_t^T F_star^{-1} v_t``
       evaluated via a pre-computed Cholesky of ``F_star`` and a per-step triangular solve.
 
-    The gradient is delivered via a custom pullback on an :class:`~pytensor.compile.builders.OpFromGraph`
+    The gradient is delivered via a custom pullback on a :class:`~pytensor.compile.builders.SymbolicOp`
     rather than via autodiff. Two reasons:
 
     1. **Correctness.** Autodiff through the two-scan forward gives *incorrect* gradients when the ``until``
@@ -1188,179 +1187,171 @@ class ConvergentFilter(StandardFilter):
         # rule step for (K_star, F_star) -> (P_star, Z, H) using the analytic definitions, and an
         # autodiff backward on the pre-convergence segment with the handoff adjoints as its terminal
         # condition (the plain Kalman iterations).
-        op = self._make_ofg()
+        op = ConvergentKalmanOp(filt=self)
         a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, _k = op(data, a0, P0, c, d, T, Z, R, H, Q)
         n = data.type.shape[0]
         return self._postprocess_scan_results(
             (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll[..., None]), a0, P0, n=n
         )
 
-    def _make_ofg(self):
-        m, p, r_ = self.n_states, self.n_endog, self.n_shocks
-        cov_jitter = self.cov_jitter
 
-        sym = {
-            "data": pt.tensor("data", dtype="float64", shape=(None, p)),
-            **{
-                name: pt.tensor(name, dtype="float64", shape=shape)
-                for name, shape in static_matrix_shapes(m, p, r_).items()
-            },
-        }
-        in_order = ["data", "a0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
-        inputs_s = [sym[k] for k in in_order]
-        outputs = list(self._convergent_forward(*inputs_s))
-        filt_self = self
+class ConvergentKalmanOp(SymbolicOp):
+    """Wrap :meth:`ConvergentFilter._convergent_forward` with its analytic pullback.
 
-        def pullback(inputs, outputs, out_grads):
-            # `outputs` are the 8 forward outputs of `_convergent_forward`:
-            # (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, k). Only the sequences we need for the
-            # backward are bound; the rest are `_`. Similarly, `out_grads[6]` is the adjoint on `ll`;
-            # all other output adjoints are assumed disconnected (see class docstring).
-            data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = inputs
-            _, a_hat_sym, _, _, P_hat_sym, _, _, k_sym = outputs
-            dll = out_grads[6]
+    The inner graph is built from the caller's input types, so dtype and static shapes follow the
+    surrounding model rather than being fixed here.
+    """
 
-            # Split the recorded per-step sequences at the convergence step `k_sym`. The
-            # pre-convergence slice is `[:k_sym]` and the post-convergence slice is `[k_sym:]`;
-            # a_star and P_star are the handoff values flowing between them (a_{k|k-1}, P_{k|k-1}).
-            a_hat_tr, P_hat_tr = a_hat_sym[:k_sym], P_hat_sym[:k_sym]
-            data_tr, data_fx = data_[:k_sym], data_[k_sym:]
-            a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
-            a_hat_fx = a_hat_sym[k_sym:]
-            # Reduce the per-step ll adjoint to a scalar by averaging. This is correct for the
-            # standard use case loss = ll.sum() (dll is a broadcast of ones, average is 1.0) and
-            # punts on the more general case of per-step weights.
-            dlogp_up = dll.sum() / dll.shape[0]
+    inline = True
 
-            # Pre-compute tail constants for readability.
-            F_star = Z_ @ P_star @ Z_.mT + stabilize(H_, cov_jitter)
-            F_chol = pt.linalg.cholesky(F_star, lower=True)
-            K_star = pt.linalg.solve(
-                F_star.mT, (P_star @ Z_.mT).mT, assume_a="pos", check_finite=False
-            ).mT
-            F_inv = pt.linalg.cho_solve((F_chol, True), pt.eye(F_chol.shape[0]))
+    def __init__(self, input_types=None, *, filt, **kwargs):
+        self._filt = filt
+        kwargs.setdefault("name", "convergent_kf")
+        super().__init__(input_types=input_types, **kwargs)
+        self._init_kwargs["filt"] = filt
 
-            # Post-convergence backward. This is the source of the speedup: K, F, and P are constant
-            # across the segment, so the per-step backward drops to matvec/outer-product work.
-            # The factor of -0.5 on dlogp_up is a convention adjustment: the analytic formulas in
-            # `_fixed_k_tail_backward` are derived for ll = log |F| + v^T F^{-1} v (the "2 * negative
-            # log-likelihood" form), while our per-step ll is -0.5 * (MVN_CONST + log |F| + v^T F^{-1} v).
-            # So the caller's dlogp_up needs a -0.5 factor before being fed into the analytic formulas.
-            (
-                dd_fx,
-                da_star,
-                dP_star_ric,
-                dT_a,
-                dc_t,
-                dZ_dir,
-                dd_t,
-                dK_s,
-                dF_s,
-                S,
-            ) = filt_self._fixed_k_tail_backward(
-                data_fx,
-                a_star,
-                c_,
-                d_,
-                T_,
-                Z_,
-                K_star,
-                F_star,
-                F_chol,
-                a_hat_fx,
-                -0.5 * dlogp_up,
-            )
+    def build_inner_graph(self, *inputs):
+        return list(self._filt._convergent_forward(*inputs))
 
-            # Use chain rule to recover dZ and dH from dK*, dF*. Fully analytic.
-            dK, dF = disconnected_grad(dK_s), disconnected_grad(dF_s)
-            P_filt_s = (pt.eye(m) - K_star @ Z_) @ P_star
-            d_Z_chain = (
-                F_inv @ dK.mT @ P_filt_s - K_star.mT @ dK @ K_star.mT + (dF + dF.mT) @ Z_ @ P_star
-            )
-            X = K_star.mT @ dK @ F_inv
-            d_H_chain = dF - 0.5 * (X + X.mT)
+    def pullback(self, inputs, outputs, output_grads):
+        # `outputs` are the 8 forward outputs of `_convergent_forward`:
+        # (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, k). Only the sequences we need for the
+        # backward are bound; the rest are `_`. Similarly, `output_grads[6]` is the adjoint on `ll`;
+        # all other output adjoints are assumed disconnected (see class docstring).
+        data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = inputs
+        _, a_hat_sym, _, _, P_hat_sym, _, _, k_sym = outputs
+        dll = output_grads[6]
 
-            # P-path contributions to d_T, d_Z, d_H. Because P_t is the constant P_star across the
-            # post-convergence segment, each step's contribution is linear in d_P_hat_t, so the sum
-            # over the segment is obtained by substituting S = sum_t d_P_hat_t into the formulas.
-            TtST = T_.mT @ S @ T_
-            KtPg = K_star.mT @ TtST
-            FinvZP = F_inv @ Z_ @ P_star
-            KZP = (K_star @ Z_) @ P_star
-            d_T_P = (S @ T_) @ P_filt_s.mT + (S.mT @ T_) @ P_filt_s
-            d_Z_P = (
-                -FinvZP @ TtST.mT @ P_star
-                + KtPg @ P_star.mT @ Z_.mT @ K_star.mT
-                + FinvZP @ TtST.mT @ KZP
-                - KtPg @ P_star.mT
-            )
-            d_H_P = KtPg @ K_star
-            # Chain S through W = R Q R^T for (d_R, d_Q).
-            d_R_P = (S + S.mT) @ R_ @ Q_
-            d_Q_P = R_.mT @ S @ R_
+        # Split the recorded per-step sequences at the convergence step `k_sym`. The
+        # pre-convergence slice is `[:k_sym]` and the post-convergence slice is `[k_sym:]`;
+        # a_star and P_star are the handoff values flowing between them (a_{k|k-1}, P_{k|k-1}).
+        a_hat_tr, P_hat_tr = a_hat_sym[:k_sym], P_hat_sym[:k_sym]
+        data_tr, data_fx = data_[:k_sym], data_[k_sym:]
+        a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+        a_hat_fx = a_hat_sym[k_sym:]
+        # Reduce the per-step ll adjoint to a scalar by averaging. This is correct for the
+        # standard use case loss = ll.sum() (dll is a broadcast of ones, average is 1.0) and
+        # punts on the more general case of per-step weights.
+        dlogp_up = dll.sum() / dll.shape[0]
 
-            # Pre-convergence backward. We rebuild the Kalman scan on the sliced pre-convergence data
-            # (data[:k_sym]) and autodiff through it. The surrogate loss has three parts: the
-            # pre-convergence log-likelihood itself, plus two inner products that encode the handoff
-            # adjoints (da_star for the last predicted state, dP_star_ric for the last predicted
-            # covariance). disconnected_grad on the adjoints keeps pt.grad from trying to chase their
-            # own parameter dependence (they are outputs of the post-convergence backward and are
-            # treated as constants here. If we connect their gradients we would be double-counting).
-            _, a_hat_rb, _, _, P_hat_rb, _, ll_rb = filt_self._full_kalman_scan(
-                data_tr,
-                a0_,
-                P0_,
-                c_,
-                d_,
-                T_,
-                Z_,
-                R_,
-                H_,
-                Q_,
-                stop_early=False,
-            )
-            loss_tr = (
-                dlogp_up * ll_rb.sum()
-                + (a_hat_rb[-1] * disconnected_grad(da_star)).sum()
-                + (P_hat_rb[-1] * disconnected_grad(dP_star_ric)).sum()
-            )
-            (
-                dd_full,
-                da0,
-                dP0,
-                dc_tr,
-                dd_tr,
-                dT_tr,
-                dZ_tr,
-                dR_tr,
-                dH_tr,
-                dQ_tr,
-            ) = pt.grad(
-                loss_tr,
-                [data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_],
-                disconnected_inputs="ignore",
-            )
+        # Pre-compute tail constants for readability.
+        F_star = Z_ @ P_star @ Z_.mT + stabilize(H_, self._filt.cov_jitter)
+        F_chol = pt.linalg.cholesky(F_star, lower=True)
+        K_star = pt.linalg.solve(
+            F_star.mT, (P_star @ Z_.mT).mT, assume_a="pos", check_finite=False
+        ).mT
+        F_inv = pt.linalg.cho_solve((F_chol, True), pt.eye(F_chol.shape[0]))
 
-            return [
-                pt.concatenate([dd_full[:k_sym], dd_fx], axis=0),
-                da0,
-                dP0,
-                dc_tr + dc_t,
-                dd_tr + dd_t,
-                dT_tr + dT_a + d_T_P,
-                dZ_tr + dZ_dir + d_Z_chain + d_Z_P,
-                dR_tr + d_R_P,
-                dH_tr + d_H_chain + d_H_P,
-                dQ_tr + d_Q_P,
-            ]
-
-        # inline=True folds the forward into the surrounding graph, but the custom pullback still
-        # wins: pt.grad builds the gradient graph before the inline rewrite runs, so the analytic
-        # backward is what gets differentiated.
-        return OpFromGraph(
-            inputs=inputs_s,
-            outputs=outputs,
-            pullback=pullback,
-            inline=True,
-            name="convergent_kf",
+        # Post-convergence backward. This is the source of the speedup: K, F, and P are constant
+        # across the segment, so the per-step backward drops to matvec/outer-product work.
+        # The factor of -0.5 on dlogp_up is a convention adjustment: the analytic formulas in
+        # `_fixed_k_tail_backward` are derived for ll = log |F| + v^T F^{-1} v (the "2 * negative
+        # log-likelihood" form), while our per-step ll is -0.5 * (MVN_CONST + log |F| + v^T F^{-1} v).
+        # So the caller's dlogp_up needs a -0.5 factor before being fed into the analytic formulas.
+        (
+            dd_fx,
+            da_star,
+            dP_star_ric,
+            dT_a,
+            dc_t,
+            dZ_dir,
+            dd_t,
+            dK_s,
+            dF_s,
+            S,
+        ) = self._filt._fixed_k_tail_backward(
+            data_fx,
+            a_star,
+            c_,
+            d_,
+            T_,
+            Z_,
+            K_star,
+            F_star,
+            F_chol,
+            a_hat_fx,
+            -0.5 * dlogp_up,
         )
+
+        # Use chain rule to recover dZ and dH from dK*, dF*. Fully analytic.
+        dK, dF = disconnected_grad(dK_s), disconnected_grad(dF_s)
+        P_filt_s = (pt.eye(self._filt.n_states) - K_star @ Z_) @ P_star
+        d_Z_chain = (
+            F_inv @ dK.mT @ P_filt_s - K_star.mT @ dK @ K_star.mT + (dF + dF.mT) @ Z_ @ P_star
+        )
+        X = K_star.mT @ dK @ F_inv
+        d_H_chain = dF - 0.5 * (X + X.mT)
+
+        # P-path contributions to d_T, d_Z, d_H. Because P_t is the constant P_star across the
+        # post-convergence segment, each step's contribution is linear in d_P_hat_t, so the sum
+        # over the segment is obtained by substituting S = sum_t d_P_hat_t into the formulas.
+        TtST = T_.mT @ S @ T_
+        KtPg = K_star.mT @ TtST
+        FinvZP = F_inv @ Z_ @ P_star
+        KZP = (K_star @ Z_) @ P_star
+        d_T_P = (S @ T_) @ P_filt_s.mT + (S.mT @ T_) @ P_filt_s
+        d_Z_P = (
+            -FinvZP @ TtST.mT @ P_star
+            + KtPg @ P_star.mT @ Z_.mT @ K_star.mT
+            + FinvZP @ TtST.mT @ KZP
+            - KtPg @ P_star.mT
+        )
+        d_H_P = KtPg @ K_star
+        # Chain S through W = R Q R^T for (d_R, d_Q).
+        d_R_P = (S + S.mT) @ R_ @ Q_
+        d_Q_P = R_.mT @ S @ R_
+
+        # Pre-convergence backward. We rebuild the Kalman scan on the sliced pre-convergence data
+        # (data[:k_sym]) and autodiff through it. The surrogate loss has three parts: the
+        # pre-convergence log-likelihood itself, plus two inner products that encode the handoff
+        # adjoints (da_star for the last predicted state, dP_star_ric for the last predicted
+        # covariance). disconnected_grad on the adjoints keeps pt.grad from trying to chase their
+        # own parameter dependence (they are outputs of the post-convergence backward and are
+        # treated as constants here. If we connect their gradients we would be double-counting).
+        _, a_hat_rb, _, _, P_hat_rb, _, ll_rb = self._filt._full_kalman_scan(
+            data_tr,
+            a0_,
+            P0_,
+            c_,
+            d_,
+            T_,
+            Z_,
+            R_,
+            H_,
+            Q_,
+            stop_early=False,
+        )
+        loss_tr = (
+            dlogp_up * ll_rb.sum()
+            + (a_hat_rb[-1] * disconnected_grad(da_star)).sum()
+            + (P_hat_rb[-1] * disconnected_grad(dP_star_ric)).sum()
+        )
+        (
+            dd_full,
+            da0,
+            dP0,
+            dc_tr,
+            dd_tr,
+            dT_tr,
+            dZ_tr,
+            dR_tr,
+            dH_tr,
+            dQ_tr,
+        ) = pt.grad(
+            loss_tr,
+            [data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_],
+            disconnected_inputs="ignore",
+        )
+
+        return [
+            pt.concatenate([dd_full[:k_sym], dd_fx], axis=0),
+            da0,
+            dP0,
+            dc_tr + dc_t,
+            dd_tr + dd_t,
+            dT_tr + dT_a + d_T_P,
+            dZ_tr + dZ_dir + d_Z_chain + d_Z_P,
+            dR_tr + d_R_P,
+            dH_tr + d_H_chain + d_H_P,
+            dQ_tr + d_Q_P,
+        ]

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -974,8 +974,10 @@ class ConvergentFilter(StandardFilter):
             data, a0, P0, c, d, T, Z, R, H, Q, stop_early=True
         )
 
-        k = a_filt_tr.shape[0]
-        a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+        # Cap the split one step short of the series so the post-convergence tail always has at least
+        # one step.
+        k = pt.minimum(a_filt_tr.shape[0], n - 1)
+        a_star, P_star = a_hat_tr[k - 1], P_hat_tr[k - 1]
 
         # Tail constants from P*. Computed once here to make the tail function prettier.
         F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
@@ -1017,13 +1019,13 @@ class ConvergentFilter(StandardFilter):
             return pt.concatenate([a, b], axis=0)
 
         return (
-            cat(a_filt_tr, a_filt_fx),
-            cat(a_hat_tr, a_hat_fx),
-            cat(y_hat_tr, y_hat_fx),
-            cat(P_filt_tr, P_filt_fx),
-            cat(P_hat_tr, P_hat_fx),
-            cat(F_tr, F_fx),
-            cat(ll_tr, ll_fx),
+            cat(a_filt_tr[:k], a_filt_fx),
+            cat(a_hat_tr[:k], a_hat_fx),
+            cat(y_hat_tr[:k], y_hat_fx),
+            cat(P_filt_tr[:k], P_filt_fx),
+            cat(P_hat_tr[:k], P_hat_fx),
+            cat(F_tr[:k], F_fx),
+            cat(ll_tr[:k], ll_fx),
             k,
         )
 

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -879,10 +879,11 @@ class ConvergentFilter(StandardFilter):
 
     - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
       :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
-    - ``data`` must contain no ``NaN`` values. A masked observation changes the effective ``Z_t`` (and so
-      ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. For :class:`SharedVariable` or
-      :class:`TensorConstant` data the check runs at build time; fully symbolic data gets an
-      :class:`~pytensor.raise_op.Assert` that fires at runtime.
+    - ``data`` must contain no missing values. A masked observation changes the effective ``Z_t`` (and
+      so ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. The statespace core replaces
+      ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are
+      rejected. For :class:`SharedVariable` or :class:`TensorConstant` data the check runs at build
+      time; fully symbolic data gets an :class:`~pytensor.raise_op.Assert` that fires at runtime.
 
     Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
     disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
@@ -894,9 +895,9 @@ class ConvergentFilter(StandardFilter):
         scan. The scan stops the first time this drops below ``tol``. Default ``1e-10``.
     """
 
-    _NAN_MSG = (
-        "ConvergentFilter does not support missing data (NaN) in the observation "
-        "series. Use StandardFilter for data with missing values."
+    _MISSING_DATA_MSG = (
+        "ConvergentFilter does not support missing data in the observation series. "
+        "Use StandardFilter for data with missing values."
     )
 
     def __init__(self, tol: float = 1e-10):
@@ -904,16 +905,20 @@ class ConvergentFilter(StandardFilter):
         self.tol = tol
 
     def _check_data(self, data):
-        """Reject NaN at build time for concrete data; insert an Assert op otherwise."""
-        if isinstance(data, SharedVariable):
-            if np.isnan(data.get_value()).any():
-                raise ValueError(self._NAN_MSG)
+        """Reject data containing NaN or the missing-value sentinel.
+
+        The statespace core replaces NaN with ``missing_fill_value`` before the filter runs, so the
+        sentinel must be rejected alongside NaN. Concrete data (shared/constant) is checked at build
+        time; fully symbolic data gets a runtime :class:`~pytensor.raise_op.Assert`.
+        """
+        sentinel = self.missing_fill_value
+        if isinstance(data, SharedVariable | TensorConstant):
+            arr = data.get_value() if isinstance(data, SharedVariable) else data.data
+            if np.isnan(arr).any() or (arr == sentinel).any():
+                raise ValueError(self._MISSING_DATA_MSG)
             return data
-        if isinstance(data, TensorConstant):
-            if np.isnan(data.data).any():
-                raise ValueError(self._NAN_MSG)
-            return data
-        return Assert(self._NAN_MSG)(data, pt.all(pt.bitwise_not(pt.isnan(data))))
+        missing = pt.or_(pt.isnan(data), pt.eq(data, sentinel))
+        return Assert(self._MISSING_DATA_MSG)(data, pt.all(pt.bitwise_not(missing)))
 
     def _kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
         a_filt, P_filt, y_hat, F, ll = self.update(

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -858,23 +858,10 @@ class ConvergentFilter(StandardFilter):
       ``K_star``, ``F_star``, ``log det F_star``. No per-step Cholesky; loss is ``log det F_star + v_t^T F_star^{-1} v_t``
       evaluated via a pre-computed Cholesky of ``F_star`` and a per-step triangular solve.
 
-    The gradient is delivered via a custom pullback on a :class:`~pytensor.compile.builders.SymbolicOp`
-    rather than via autodiff. Two reasons:
-
-    1. **Correctness.** Autodiff through the two-scan forward gives *incorrect* gradients when the ``until``
-       clause on the pre-convergence scan actually fires. The forward value is fine, and one scan in
-       isolation autodiffs correctly -- but the combination of an ``until``-scan followed by a second scan
-       that depends on quantities derived from the first scan's *last* outputs (our case: ``K_star``,
-       ``F_star`` derived from ``P_hat_tr[-1]``) produces parameter gradients that are wrong by 5--100%
-       relative error even though the likelihood value matches to machine precision. With ``tol`` set so
-       the until never fires, autodiff is exact; with a real post-convergence tail it is not.
-
-    2. **Speed.** In the post-convergence tail, per-step Cholesky and the full Joseph-form backward are
-       unnecessary because ``K``, ``F``, and ``P`` are constant. The custom pullback hoists
-       ``F^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
-       backward reduces to matvec and outer products. On typical state-space cells
-       (m=10..50, p=3..10, n=2000..10000) this gives a ~1.8--2.9x speedup on ``logp + grad``
-       versus :class:`StandardFilter` autodiff, on top of a ~7--12x forward speedup.
+    The gradient comes from a custom pullback on a :class:`~pytensor.compile.builders.SymbolicOp`
+    rather than from autodiff. Autodiff is not merely slower here, it is wrong: an ``until``-scan
+    followed by a second scan depending on the first scan's *last* outputs yields incorrect parameter
+    gradients whenever the ``until`` clause fires, even though the likelihood itself is exact.
 
     Constraints (validated at graph build time):
 
@@ -953,20 +940,32 @@ class ConvergentFilter(StandardFilter):
         )
 
     def _convergent_forward(self, data, a0, P0, c, d, T, Z, R, H, Q):
-        """Two-phase forward pass.
+        """
+        Run the two-phase forward pass.
 
-        Phase 1 (pre-convergence): a standard Kalman scan with an ``until`` clause that stops once the Riccati
-        recursion has converged (``||P_{t+1|t} - P_{t|t-1}||_F < tol``). At the stopping step ``k`` we have the DARE
-        fixed point estimate ``P_star = P_hat_tr[-1]``.
+        Phase 1 stops a standard Kalman scan once the Riccati recursion converges
+        (``||P_{t+1|t} - P_{t|t-1}||_F < tol``), fixing the DARE estimate ``P_star`` at step ``k``. Phase 2
+        reuses the constants derived from ``P_star`` in a cheaper scan whose step is one triangular solve
+        against ``F_chol_star`` plus two matvecs.
 
-        Phase 2 (post-convergence): ``K_star, F_star, F_chol_star, log det F_star, P_filt_star`` are computed once from
-         ``P_star`` and plugged into a cheaper scan whose step only does ``v_t = y_t - Z a_prev - d``, a triangular
-         solve against ``F_chol_star`` for the loss, a matvec ``a_filt = a_prev + K_star v_t``, and one matvec for
-         the state predict ``a_hat = T a_filt + c``.
-
-        Outputs are the 7 per-step sequences produced by :class:`StandardFilter` plus the convergence step ``k``
-        (a symbolic integer). The pullback uses ``k`` to split the adjoint computation. In the post-convergence segment
-        the sequences ``P_filt``, ``P_hat``, and ``F`` are broadcasts of constants.
+        Returns
+        -------
+        a_filt : TensorVariable
+            Filtered states, shape ``(n, m)``.
+        a_hat : TensorVariable
+            Predicted states, shape ``(n, m)``.
+        y_hat : TensorVariable
+            Predicted observations, shape ``(n, p)``.
+        P_filt : TensorVariable
+            Filtered state covariances, shape ``(n, m, m)``. Constant from step ``k`` on.
+        P_hat : TensorVariable
+            Predicted state covariances, shape ``(n, m, m)``. Constant from step ``k`` on.
+        F : TensorVariable
+            Innovation covariances, shape ``(n, p, p)``. Constant from step ``k`` on.
+        loglike_obs : TensorVariable
+            Per-timestep log-likelihood, shape ``(n,)``.
+        k : TensorVariable
+            Scalar integer convergence step. The pullback splits the adjoint on it.
         """
         n = data.shape[0]
         (a_filt_tr, a_hat_tr, y_hat_tr, P_filt_tr, P_hat_tr, F_tr, ll_tr) = self._full_kalman_scan(
@@ -978,7 +977,7 @@ class ConvergentFilter(StandardFilter):
         k = pt.minimum(a_filt_tr.shape[0], n - 1)
         a_star, P_star = a_hat_tr[k - 1], P_hat_tr[k - 1]
 
-        # Tail constants from P*. Computed once here to make the tail function prettier.
+        # Tail constants from P*, hoisted so the tail scan body carries no Cholesky or solve.
         F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
         F_chol_star = pt.linalg.cholesky(F_star, lower=True)
         logdet_F_star = 2 * pt.log(pt.diag(F_chol_star)).sum()
@@ -1042,25 +1041,42 @@ class ConvergentFilter(StandardFilter):
         a_hat_fx,
         dlogp,
     ):
-        """Analytic backward pass over the post-convergence segment.
+        """
+        Run the analytic backward pass over the post-convergence segment.
 
-        Runs a backward scan on the post-convergence data with ``F_inv, A = T (I - K_star Z),
-        I - K_star Z`` hoisted out as non-sequences. Each step is closed-form (no Cholesky or solve in
-        the body; only matvecs and outer products). Returns:
+        The scan body is closed form -- matvecs and outer products only, no Cholesky or solve -- because
+        ``F^{-1}`` and the closed-loop transition ``A = T (I - K_star Z)`` are constant once the Riccati
+        recursion has converged.
 
-        - ``d_data, d_a_star``: ordinary adjoints flowing backward out of the segment.
-        - ``d_P_star``: Riccati-style adjoint at the segment's entry. Used as the terminal condition for
-          the pre-convergence backward (the transient's ``P_hat_grad`` at step ``k-1``).
-        - ``d_T_alpha, d_c, d_Z_direct, d_d``: per-step contributions summed across post-convergence.
-          These are the alpha-path (mean of the latent states) contributions; P-path contributions to d_T / d_Z
-          come from the ``S`` aggregate below.
-        - ``d_K_star, d_F_star``: adjoints treating ``K_star, F_star`` as if they were independent
-          inputs to the post-convergence forward. The caller chains these to ``(P_star, Z, H)`` via the
-          analytic definitions ``K_star = P_star Z^T F_star^{-1}`` and ``F_star = Z P_star Z^T + H``.
-        - ``S = sum_t d_P_hat_t``: aggregate P-adjoint across the post-convergence segment. In the
-          post-convergence segment ``P_t`` is the constant ``P_star``, so P-path contributions to
-          d_T, d_Z, d_H, d_R, d_Q are linear in ``d_P_hat_t``. These aggregate into formulas that use
-          ``S`` (rather than needing a separate per-step scan).
+        Returns
+        -------
+        d_data : TensorVariable
+            Adjoint of the observations over the segment.
+        d_a_star : TensorVariable
+            Adjoint of the state entering the segment.
+        d_P_star : TensorVariable
+            Riccati adjoint at the segment entry, used as the terminal condition for the pre-convergence
+            backward.
+        d_T_alpha : TensorVariable
+            Alpha-path contribution to ``d_T``, summed over the segment. Its P-path contribution comes
+            from ``S``.
+        d_c : TensorVariable
+            Contribution to ``d_c``, summed over the segment.
+        d_Z_direct : TensorVariable
+            Alpha-path contribution to ``d_Z``, summed over the segment. Its P-path contribution comes
+            from ``S``.
+        d_d : TensorVariable
+            Contribution to ``d_d``, summed over the segment.
+        d_K_star : TensorVariable
+            Adjoint of ``K_star`` treated as an independent input. The caller chains it to
+            ``(P_star, Z, H)`` through ``K_star = P_star Z^T F_star^{-1}``.
+        d_F_star : TensorVariable
+            Adjoint of ``F_star`` treated as an independent input. The caller chains it through
+            ``F_star = Z P_star Z^T + H``.
+        S : TensorVariable
+            ``sum_t d_P_hat_t`` over the segment. ``P_t`` is the constant ``P_star`` there, so the P-path
+            contributions to ``d_T``, ``d_Z``, ``d_H``, ``d_R`` and ``d_Q`` are linear in it and can be
+            aggregated instead of scanned.
         """
         m = a_star.shape[0]
         p_dim = F_chol_star.shape[0]
@@ -1071,7 +1087,7 @@ class ConvergentFilter(StandardFilter):
         I_KZ = pt.eye(m) - K_star @ Z
         A = T @ I_KZ
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
-        ZtFinvZ = Z.T @ F_inv @ Z  # the data-independent half of direct_C, lifted out of the scan
+        ZtFinvZ = Z.T @ F_inv @ Z  # the data-independent half of direct_C
 
         def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, ZtFinvZ_):
             v = y - Z_ @ a_prev - d_
@@ -1084,15 +1100,10 @@ class ConvergentFilter(StandardFilter):
             dL_dv = K_.T @ T_r_next + 2 * Finv_v
             r_t = A_r_next - 2 * Zt_Finv_v
 
-            # P-adjoint recursion: d_P_prev = A^T @ d_P_hat_next @ A + cross_a + direct_C,
-            # where A = T (I - K_star Z) is the closed-loop transition. The homogeneous part
-            # d_P_prev = A^T @ d_P_hat_next @ A is the backward Lyapunov recursion: as the segment
-            # length grows it converges to the solution of the Lyapunov equation X = A^T X A + C, which
-            # is the steady-state P-adjoint. Because A is constant in the post-convergence segment,
-            # we can hoist it; the per-step work is the two correction terms (cross_a and direct_C)
-            # which still depend on y_t and a_prev. cross_a uses the identity Z(I - K Z) = H F^{-1} Z
-            # to express what is naturally an H^{-1} term through F^{-1} instead, which stays finite for
-            # singular H (a measurement-error-free model).
+            # P-adjoint recursion, where A = T (I - K_star Z) is the closed-loop transition. The
+            # homogeneous part is a backward Lyapunov recursion; only the two correction terms depend
+            # on y_t and a_prev. cross_a routes what is naturally an H^{-1} term through F^{-1} via the
+            # identity Z(I - K Z) = H F^{-1} Z, which stays finite when H is singular.
             cross_a = 0.5 * (pt.outer(A_r_next, Zt_Finv_v) + pt.outer(Zt_Finv_v, A_r_next))
             direct_C = ZtFinvZ_ - pt.outer(Zt_Finv_v, Zt_Finv_v)
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
@@ -1179,14 +1190,6 @@ class ConvergentFilter(StandardFilter):
         self.seq_names = []
         self.non_seq_names = list(PARAM_NAMES)
 
-        # The forward is two scans chained through derived quantities (K_star, F_star, log det F_star
-        # and P_filt_star all depend on the first scan's last output). Autodiff gives incorrect
-        # gradients on this structure once the `until` clause fires with a non-trivial post-convergence
-        # segment. We wrap in an OFG and supply a custom pullback that splits the backward
-        # into: an analytic backward on the post-convergence segment (cheap, closed form), a chain
-        # rule step for (K_star, F_star) -> (P_star, Z, H) using the analytic definitions, and an
-        # autodiff backward on the pre-convergence segment with the handoff adjoints as its terminal
-        # condition (the plain Kalman iterations).
         op = ConvergentKalmanOp(filt=self)
         a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, _k = op(data, a0, P0, c, d, T, Z, R, H, Q)
         n = data.type.shape[0]

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -7,9 +7,13 @@ import pytensor
 import pytensor.tensor as pt
 
 from pymc.pytensorf import constant_fold
+from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.sharedvalue import SharedVariable
+from pytensor.gradient import disconnected_grad
 from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
-from pytensor.tensor import TensorVariable
+from pytensor.scan.utils import until
+from pytensor.tensor import TensorConstant, TensorVariable
 from pytensor.tensor.linalg import solve_triangular
 
 from pymc_extras.statespace.filters.utilities import (
@@ -23,6 +27,7 @@ from pymc_extras.statespace.utils.constants import (
     LONG_NAME_TO_SHORT,
     MATRIX_NAMES,
     MISSING_FILL,
+    static_matrix_shapes,
 )
 
 MVN_CONST = pt.log(2 * pt.constant(np.pi, dtype="float64"))
@@ -835,3 +840,508 @@ class UnivariateFilter(BaseFilter):
         )
 
         return a_filtered, a_hat, obs_mu, P_filtered, P_hat, obs_cov, ll
+
+
+class ConvergentFilter(StandardFilter):
+    """Kalman filter that exploits Riccati convergence to a fixed-gain steady state.
+
+    For a stationary observable system with no missing data, the predicted-covariance Riccati recursion
+    ``P_{t+1|t} = T (P_{t|t-1} - K_t F_t K_t^T) T^T + R Q R^T`` is data-independent and converges to the
+    discrete algebraic Riccati equation (DARE) fixed point ``P_star``. Once converged, the Kalman gain
+    ``K_t = P_{t|t-1} Z^T F_t^{-1}`` and innovation covariance ``F_t = Z P_{t|t-1} Z^T + H`` are constant
+    (``K_star``, ``F_star``) and the filter becomes a linear time-invariant recursion on the predicted
+    state ``a_{t|t-1}`` alone. ``ConvergentFilter`` splits the forward pass at the convergence step ``k``:
+
+    - **pre-convergence steps** (``t = 0..k-1``, the "transient"): full Kalman with update + Riccati predict.
+    - **post-convergence steps** (``t = k..n-1``, the "tail"): linear recursion on ``a`` with cached
+      ``K_star``, ``F_star``, ``log det F_star``. No per-step Cholesky; loss is ``log det F_star + v_t^T F_star^{-1} v_t``
+      evaluated via a pre-computed Cholesky of ``F_star`` and a per-step triangular solve.
+
+    The gradient is delivered via a custom pullback on an :class:`~pytensor.compile.builders.OpFromGraph`
+    rather than via autodiff. Two reasons:
+
+    1. **Correctness.** Autodiff through the two-scan forward gives *incorrect* gradients when the ``until``
+       clause on the pre-convergence scan actually fires. The forward value is fine, and one scan in
+       isolation autodiffs correctly -- but the combination of an ``until``-scan followed by a second scan
+       that depends on quantities derived from the first scan's *last* outputs (our case: ``K_star``,
+       ``F_star`` derived from ``P_hat_tr[-1]``) produces parameter gradients that are wrong by 5--100%
+       relative error even though the likelihood value matches to machine precision. With ``tol`` set so
+       the until never fires, autodiff is exact; with a real post-convergence tail it is not.
+
+    2. **Speed.** In the post-convergence tail, per-step Cholesky and the full Joseph-form backward are
+       unnecessary because ``K``, ``F``, and ``P`` are constant. The custom pullback hoists
+       ``F^{-1}, H^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
+       backward reduces to matvec and outer products. On typical state-space cells
+       (m=10..50, p=3..10, n=2000..10000) this gives a ~1.8--2.9x speedup on ``logp + grad``
+       versus :class:`StandardFilter` autodiff, on top of a ~7--12x forward speedup.
+
+    Constraints (validated at graph build time):
+
+    - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
+      :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
+    - ``data`` must contain no ``NaN`` values. A masked observation changes the effective ``Z_t`` (and so
+      ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. For :class:`SharedVariable` or
+      :class:`TensorConstant` data the check runs at build time; fully symbolic data gets an
+      :class:`~pytensor.raise_op.Assert` that fires at runtime.
+
+    Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
+    disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
+
+    Parameters
+    ----------
+    tol : float, optional
+        Convergence tolerance on the Frobenius norm of ``P_{t+1|t} - P_{t|t-1}`` in the pre-convergence
+        scan. The scan stops the first time this drops below ``tol``. Default ``1e-10``.
+    """
+
+    _NAN_MSG = (
+        "ConvergentFilter does not support missing data (NaN) in the observation "
+        "series. Use StandardFilter for data with missing values."
+    )
+
+    def __init__(self, tol: float = 1e-10):
+        super().__init__()
+        self.tol = tol
+
+    def _check_data(self, data):
+        """Reject NaN at build time for concrete data; insert an Assert op otherwise."""
+        if isinstance(data, SharedVariable):
+            if np.isnan(data.get_value()).any():
+                raise ValueError(self._NAN_MSG)
+            return data
+        if isinstance(data, TensorConstant):
+            if np.isnan(data.data).any():
+                raise ValueError(self._NAN_MSG)
+            return data
+        return Assert(self._NAN_MSG)(data, pt.all(pt.bitwise_not(pt.isnan(data))))
+
+    def _kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
+        a_filt, P_filt, y_hat, F, ll = self.update(
+            a=a, P=P, y=y, d=d, Z=Z, H=H, all_nan_flag=pt.constant(0.0)
+        )
+        P_filt = stabilize(P_filt, self.cov_jitter)
+        a_hat, P_hat = self.predict(a=a_filt, P=P_filt, c=c, T=T, R=R, Q=Q)
+        return a_filt, a_hat, y_hat, P_filt, P_hat, F, ll
+
+    def _full_kalman_scan(self, data, a0, P0, c, d, T, Z, R, H, Q, stop_early):
+        def body(y, a_prev, P_prev, *params):
+            out = self._kalman_step(y, a_prev, P_prev, *params)
+            if stop_early:
+                return out, until(pt.sqrt(((out[4] - P_prev) ** 2).sum()) < self.tol)
+            return out
+
+        return pytensor.scan(
+            body,
+            sequences=[data],
+            outputs_info=[None, a0, None, None, P0, None, None],
+            non_sequences=[c, d, T, Z, R, H, Q],
+            strict=False,
+            return_updates=False,
+        )
+
+    def _convergent_forward(self, data, a0, P0, c, d, T, Z, R, H, Q):
+        """Two-phase forward pass.
+
+        Phase 1 (pre-convergence): a standard Kalman scan with an ``until`` clause that stops once the Riccati
+        recursion has converged (``||P_{t+1|t} - P_{t|t-1}||_F < tol``). At the stopping step ``k`` we have the DARE
+        fixed point estimate ``P_star = P_hat_tr[-1]``.
+
+        Phase 2 (post-convergence): ``K_star, F_star, F_chol_star, log det F_star, P_filt_star`` are computed once from
+         ``P_star`` and plugged into a cheaper scan whose step only does ``v_t = y_t - Z a_prev - d``, a triangular
+         solve against ``F_chol_star`` for the loss, a matvec ``a_filt = a_prev + K_star v_t``, and one matvec for
+         the state predict ``a_hat = T a_filt + c``.
+
+        Outputs are the 7 per-step sequences produced by :class:`StandardFilter` plus the convergence step ``k``
+        (a symbolic integer). The pullback uses ``k`` to split the adjoint computation. In the post-convergence segment
+        the sequences ``P_filt``, ``P_hat``, and ``F`` are broadcasts of constants.
+        """
+        n = data.shape[0]
+        (a_filt_tr, a_hat_tr, y_hat_tr, P_filt_tr, P_hat_tr, F_tr, ll_tr) = self._full_kalman_scan(
+            data, a0, P0, c, d, T, Z, R, H, Q, stop_early=True
+        )
+
+        k = a_filt_tr.shape[0]
+        a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+
+        # Tail constants from P*. Computed once here to make the tail function prettier.
+        F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
+        F_chol_star = pt.linalg.cholesky(F_star, lower=True)
+        logdet_F_star = 2 * pt.log(pt.diag(F_chol_star)).sum()
+        K_star = pt.linalg.solve(
+            F_star.mT, (P_star @ Z.mT).mT, assume_a="pos", check_finite=False
+        ).mT
+        I_KZ_star = pt.eye(self.n_states) - K_star @ Z
+        P_filt_star = stabilize(
+            quad_form_sym(I_KZ_star, P_star) + quad_form_sym(K_star, H), self.cov_jitter
+        )
+
+        # Tail scan: fixed K*, F* (no per-step Cholesky). Recurrent slot is a_hat.
+        def tail_body(y, a_prev):
+            y_hat = d + Z @ a_prev
+            v = y - y_hat
+            solved = solve_triangular(F_chol_star, v, lower=True)
+            ll = -0.5 * (MVN_CONST + logdet_F_star + (solved * solved).sum())
+            a_filt = a_prev + K_star @ v
+            return a_filt, T @ a_filt + c, y_hat, ll
+
+        a_filt_fx, a_hat_fx, y_hat_fx, ll_fx = pytensor.scan(
+            tail_body,
+            sequences=[data[k:]],
+            outputs_info=[None, a_star, None, None],
+            strict=False,
+            return_updates=False,
+        )
+
+        # Stitch: in the tail, P_filt, P_hat, F are constants (broadcast).
+        n_fx = n - k
+        m_shape = (n_fx, self.n_states, self.n_states)
+        P_filt_fx = pt.broadcast_to(P_filt_star, m_shape)
+        P_hat_fx = pt.broadcast_to(P_star, m_shape)
+        F_fx = pt.broadcast_to(F_star, (n_fx, self.n_endog, self.n_endog))
+
+        def cat(a, b):
+            return pt.concatenate([a, b], axis=0)
+
+        return (
+            cat(a_filt_tr, a_filt_fx),
+            cat(a_hat_tr, a_hat_fx),
+            cat(y_hat_tr, y_hat_fx),
+            cat(P_filt_tr, P_filt_fx),
+            cat(P_hat_tr, P_hat_fx),
+            cat(F_tr, F_fx),
+            cat(ll_tr, ll_fx),
+            k,
+        )
+
+    def _fixed_k_tail_backward(
+        self,
+        data,
+        a_star,
+        c,
+        d,
+        T,
+        Z,
+        H,
+        K_star,
+        F_star,
+        F_chol_star,
+        a_hat_fx,
+        dlogp,
+    ):
+        """Analytic backward pass over the post-convergence segment.
+
+        Runs a backward scan on the post-convergence data with ``F_inv, H_inv, A = T (I - K_star Z),
+        I - K_star Z`` hoisted out as non-sequences. Each step is closed-form (no Cholesky or solve in
+        the body; only matvecs and outer products). Returns:
+
+        - ``d_data, d_a_star``: ordinary adjoints flowing backward out of the segment.
+        - ``d_P_star``: Riccati-style adjoint at the segment's entry. Used as the terminal condition for
+          the pre-convergence backward (the transient's ``P_hat_grad`` at step ``k-1``).
+        - ``d_T_alpha, d_c, d_Z_direct, d_d``: per-step contributions summed across post-convergence.
+          These are the alpha-path (mean of the latent states) contributions; P-path contributions to d_T / d_Z
+          come from the ``S`` aggregate below.
+        - ``d_K_star, d_F_star``: adjoints treating ``K_star, F_star`` as if they were independent
+          inputs to the post-convergence forward. The caller chains these to ``(P_star, Z, H)`` via the
+          analytic definitions ``K_star = P_star Z^T F_star^{-1}`` and ``F_star = Z P_star Z^T + H``.
+        - ``S = sum_t d_P_hat_t``: aggregate P-adjoint across the post-convergence segment. In the
+          post-convergence segment ``P_t`` is the constant ``P_star``, so P-path contributions to
+          d_T, d_Z, d_H, d_R, d_Q are linear in ``d_P_hat_t``. These aggregate into formulas that use
+          ``S`` (rather than needing a separate per-step scan).
+        """
+        m = a_star.shape[0]
+        p_dim = F_chol_star.shape[0]
+        n_tail = data.shape[0]
+        a_prev_seq = pt.concatenate([a_star[None, :], a_hat_fx[:-1]], axis=0)
+
+        # Hoisted constants.
+        I_KZ = pt.eye(m) - K_star @ Z
+        A = T @ I_KZ
+        F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
+        H_inv = pt.linalg.inv(stabilize(H, self.cov_jitter))
+
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, H_inv_, A_, I_KZ_):
+            v = y - Z_ @ a_prev - d_
+            Finv_v = F_inv_ @ v
+            a_filt = a_prev + K_ @ v
+            T_r_next = T_.T @ r_next
+            dL_dv = K_.T @ T_r_next + 2 * Finv_v
+            r_t = A_.T @ r_next - 2 * Z_.T @ Finv_v
+
+            # P-adjoint recursion: d_P_prev = A^T @ d_P_hat_next @ A + cross_a + direct_C,
+            # where A = T (I - K_star Z) is the closed-loop transition. The homogeneous part
+            # d_P_prev = A^T @ d_P_hat_next @ A is the backward Lyapunov recursion: as the segment
+            # length grows it converges to the solution of the Lyapunov equation X = A^T X A + C, which
+            # is the steady-state P-adjoint. Because A is constant in the post-convergence segment,
+            # we can hoist it; the per-step work is the two correction terms (cross_a and direct_C)
+            # which still depend on y_t and a_prev.
+            row = (v[None, :] @ H_inv_) @ Z_
+            M = I_KZ_.T @ (T_r_next[:, None] @ row) @ I_KZ_
+            cross_a = 0.5 * (M + M.T)
+            Zt_Finv_v = (Z_.T @ Finv_v)[:, None]
+            direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
+            d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
+
+            dL_dT = pt.outer(r_next, a_filt)
+            dL_dc = r_next
+            dL_dZ = -pt.outer(dL_dv, a_prev)
+            dL_dd = -dL_dv
+            dL_dK = pt.outer(T_r_next, v)
+            vvT = pt.outer(v, v)
+
+            return r_t, d_P_prev, dL_dv, dL_dT, dL_dc, dL_dZ, dL_dd, dL_dK, vvT
+
+        (r_seq, dPp_seq, dy_seq, dT_seq, dc_seq, dZ_seq, dd_seq, dK_seq, vvT_seq) = pytensor.scan(
+            bwd,
+            sequences=[data, a_prev_seq],
+            outputs_info=[
+                pt.zeros_like(a_star),
+                pt.zeros((m, m), dtype="float64"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, H_inv, A, I_KZ],
+            go_backwards=True,
+            strict=False,
+            return_updates=False,
+        )
+
+        # d_P_prev_seq in go_backwards order is [d_P_hat_{n-2}, ..., d_P_hat_{k-1}]; the last
+        # element is d_P_star (the handoff fed to the pre-convergence backward), so the aggregate
+        # S = sum_t d_P_hat_t over the post-convergence segment excludes it.
+        S = dlogp * dPp_seq[:-1].sum(axis=0)
+        sum_vvT = vvT_seq.sum(axis=0)
+        return (
+            dlogp * dy_seq[::-1],  # d_data
+            dlogp * r_seq[-1],  # d_a_star
+            dlogp * dPp_seq[-1],  # d_P_star (Riccati)
+            dlogp * dT_seq.sum(axis=0),  # d_T alpha-path
+            dlogp * dc_seq.sum(axis=0),  # d_c
+            dlogp * dZ_seq.sum(axis=0),  # d_Z direct
+            dlogp * dd_seq.sum(axis=0),  # d_d
+            dlogp * dK_seq.sum(axis=0),  # d_K_star
+            dlogp * (n_tail * F_inv - F_inv @ sum_vvT @ F_inv),  # d_F_star
+            S,
+        )
+
+    def build_graph(
+        self,
+        data,
+        a0,
+        P0,
+        c,
+        d,
+        T,
+        Z,
+        R,
+        H,
+        Q,
+        missing_fill_value=None,
+        cov_jitter=None,
+        time_varying_names=(),
+    ):
+        if time_varying_names:
+            raise ValueError(
+                "ConvergentFilter requires time-invariant matrices; got time-varying: "
+                f"{sorted(time_varying_names)}. Use StandardFilter instead."
+            )
+        self.missing_fill_value = MISSING_FILL if missing_fill_value is None else missing_fill_value
+        self.cov_jitter = JITTER_DEFAULT if cov_jitter is None else cov_jitter
+
+        [R_shape] = constant_fold([R.shape], raise_not_constant=False)
+        [Z_shape] = constant_fold([Z.shape], raise_not_constant=False)
+        self.n_states, self.n_shocks = R_shape[-2:]
+        self.n_endog = Z_shape[-2]
+
+        data = self._check_data(data)
+        data, a0, P0, c, d, T, Z, R, H, Q = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)
+        data = pt.specify_shape(data, (data.type.shape[0], self.n_endog))
+        self.seq_names = []
+        self.non_seq_names = list(PARAM_NAMES)
+
+        # The forward is two scans chained through derived quantities (K_star, F_star, log det F_star
+        # and P_filt_star all depend on the first scan's last output). Autodiff gives incorrect
+        # gradients on this structure once the `until` clause fires with a non-trivial post-convergence
+        # segment. We wrap in an OFG and supply a custom pullback that splits the backward
+        # into: an analytic backward on the post-convergence segment (cheap, closed form), a chain
+        # rule step for (K_star, F_star) -> (P_star, Z, H) using the analytic definitions, and an
+        # autodiff backward on the pre-convergence segment with the handoff adjoints as its terminal
+        # condition (the plain Kalman iterations).
+        op = self._make_ofg()
+        a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, _k = op(data, a0, P0, c, d, T, Z, R, H, Q)
+        n = data.type.shape[0]
+        return self._postprocess_scan_results(
+            (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll[..., None]), a0, P0, n=n
+        )
+
+    def _make_ofg(self):
+        m, p, r_ = self.n_states, self.n_endog, self.n_shocks
+        cov_jitter = self.cov_jitter
+
+        sym = {
+            "data": pt.tensor("data", dtype="float64", shape=(None, p)),
+            **{
+                name: pt.tensor(name, dtype="float64", shape=shape)
+                for name, shape in static_matrix_shapes(m, p, r_).items()
+            },
+        }
+        in_order = ["data", "a0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
+        inputs_s = [sym[k] for k in in_order]
+        outputs = list(self._convergent_forward(*inputs_s))
+        filt_self = self
+
+        def pullback(inputs, outputs, out_grads):
+            # `outputs` are the 8 forward outputs of `_convergent_forward`:
+            # (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, k). Only the sequences we need for the
+            # backward are bound; the rest are `_`. Similarly, `out_grads[6]` is the adjoint on `ll`;
+            # all other output adjoints are assumed disconnected (see class docstring).
+            data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = inputs
+            _, a_hat_sym, _, _, P_hat_sym, _, _, k_sym = outputs
+            dll = out_grads[6]
+
+            # Split the recorded per-step sequences at the convergence step `k_sym`. The
+            # pre-convergence slice is `[:k_sym]` and the post-convergence slice is `[k_sym:]`;
+            # a_star and P_star are the handoff values flowing between them (a_{k|k-1}, P_{k|k-1}).
+            a_hat_tr, P_hat_tr = a_hat_sym[:k_sym], P_hat_sym[:k_sym]
+            data_tr, data_fx = data_[:k_sym], data_[k_sym:]
+            a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+            a_hat_fx = a_hat_sym[k_sym:]
+            # Reduce the per-step ll adjoint to a scalar by averaging. This is correct for the
+            # standard use case loss = ll.sum() (dll is a broadcast of ones, average is 1.0) and
+            # punts on the more general case of per-step weights.
+            dlogp_up = dll.sum() / dll.shape[0]
+
+            # Pre-compute tail constants for readability.
+            F_star = Z_ @ P_star @ Z_.mT + stabilize(H_, cov_jitter)
+            F_chol = pt.linalg.cholesky(F_star, lower=True)
+            K_star = pt.linalg.solve(
+                F_star.mT, (P_star @ Z_.mT).mT, assume_a="pos", check_finite=False
+            ).mT
+            F_inv = pt.linalg.cho_solve((F_chol, True), pt.eye(F_chol.shape[0]))
+
+            # Post-convergence backward. This is the source of the speedup: K, F, and P are constant
+            # across the segment, so the per-step backward drops to matvec/outer-product work.
+            # The factor of -0.5 on dlogp_up is a convention adjustment: the analytic formulas in
+            # `_fixed_k_tail_backward` are derived for ll = log |F| + v^T F^{-1} v (the "2 * negative
+            # log-likelihood" form), while our per-step ll is -0.5 * (MVN_CONST + log |F| + v^T F^{-1} v).
+            # So the caller's dlogp_up needs a -0.5 factor before being fed into the analytic formulas.
+            (
+                dd_fx,
+                da_star,
+                dP_star_ric,
+                dT_a,
+                dc_t,
+                dZ_dir,
+                dd_t,
+                dK_s,
+                dF_s,
+                S,
+            ) = filt_self._fixed_k_tail_backward(
+                data_fx,
+                a_star,
+                c_,
+                d_,
+                T_,
+                Z_,
+                H_,
+                K_star,
+                F_star,
+                F_chol,
+                a_hat_fx,
+                -0.5 * dlogp_up,
+            )
+
+            # Use chain rule to recover dZ and dH from dK*, dF*. Fully analytic.
+            dK, dF = disconnected_grad(dK_s), disconnected_grad(dF_s)
+            P_filt_s = (pt.eye(m) - K_star @ Z_) @ P_star
+            d_Z_chain = (
+                F_inv @ dK.mT @ P_filt_s - K_star.mT @ dK @ K_star.mT + (dF + dF.mT) @ Z_ @ P_star
+            )
+            X = K_star.mT @ dK @ F_inv
+            d_H_chain = dF - 0.5 * (X + X.mT)
+
+            # P-path contributions to d_T, d_Z, d_H. Because P_t is the constant P_star across the
+            # post-convergence segment, each step's contribution is linear in d_P_hat_t, so the sum
+            # over the segment is obtained by substituting S = sum_t d_P_hat_t into the formulas.
+            TtST = T_.mT @ S @ T_
+            KtPg = K_star.mT @ TtST
+            FinvZP = F_inv @ Z_ @ P_star
+            KZP = (K_star @ Z_) @ P_star
+            d_T_P = (S @ T_) @ P_filt_s.mT + (S.mT @ T_) @ P_filt_s
+            d_Z_P = (
+                -FinvZP @ TtST.mT @ P_star
+                + KtPg @ P_star.mT @ Z_.mT @ K_star.mT
+                + FinvZP @ TtST.mT @ KZP
+                - KtPg @ P_star.mT
+            )
+            d_H_P = KtPg @ K_star
+            # Chain S through W = R Q R^T for (d_R, d_Q).
+            d_R_P = (S + S.mT) @ R_ @ Q_
+            d_Q_P = R_.mT @ S @ R_
+
+            # Pre-convergence backward. We rebuild the Kalman scan on the sliced pre-convergence data
+            # (data[:k_sym]) and autodiff through it. The surrogate loss has three parts: the
+            # pre-convergence log-likelihood itself, plus two inner products that encode the handoff
+            # adjoints (da_star for the last predicted state, dP_star_ric for the last predicted
+            # covariance). disconnected_grad on the adjoints keeps pt.grad from trying to chase their
+            # own parameter dependence (they are outputs of the post-convergence backward and are
+            # treated as constants here. If we connect their gradients we would be double-counting).
+            _, a_hat_rb, _, _, P_hat_rb, _, ll_rb = filt_self._full_kalman_scan(
+                data_tr,
+                a0_,
+                P0_,
+                c_,
+                d_,
+                T_,
+                Z_,
+                R_,
+                H_,
+                Q_,
+                stop_early=False,
+            )
+            loss_tr = (
+                dlogp_up * ll_rb.sum()
+                + (a_hat_rb[-1] * disconnected_grad(da_star)).sum()
+                + (P_hat_rb[-1] * disconnected_grad(dP_star_ric)).sum()
+            )
+            (
+                dd_full,
+                da0,
+                dP0,
+                dc_tr,
+                dd_tr,
+                dT_tr,
+                dZ_tr,
+                dR_tr,
+                dH_tr,
+                dQ_tr,
+            ) = pt.grad(
+                loss_tr,
+                [data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_],
+                disconnected_inputs="ignore",
+            )
+
+            return [
+                pt.concatenate([dd_full[:k_sym], dd_fx], axis=0),
+                da0,
+                dP0,
+                dc_tr + dc_t,
+                dd_tr + dd_t,
+                dT_tr + dT_a + d_T_P,
+                dZ_tr + dZ_dir + d_Z_chain + d_Z_P,
+                dR_tr + d_R_P,
+                dH_tr + d_H_chain + d_H_P,
+                dQ_tr + d_Q_P,
+            ]
+
+        return OpFromGraph(
+            inputs=inputs_s,
+            outputs=outputs,
+            pullback=pullback,
+            inline=True,
+            name="convergent_kf",
+        )

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -1074,13 +1074,16 @@ class ConvergentFilter(StandardFilter):
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
         ZtFinvZ = Z.T @ F_inv @ Z  # the data-independent half of direct_C, lifted out of the scan
 
-        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_, ZtFinvZ_):
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, ZtFinvZ_):
             v = y - Z_ @ a_prev - d_
             Finv_v = F_inv_ @ v
             a_filt = a_prev + K_ @ v
             T_r_next = T_.T @ r_next
+            A_r_next = A_.T @ r_next
+            Zt_Finv_v = Z_.T @ Finv_v
+
             dL_dv = K_.T @ T_r_next + 2 * Finv_v
-            r_t = A_.T @ r_next - 2 * Z_.T @ Finv_v
+            r_t = A_r_next - 2 * Zt_Finv_v
 
             # P-adjoint recursion: d_P_prev = A^T @ d_P_hat_next @ A + cross_a + direct_C,
             # where A = T (I - K_star Z) is the closed-loop transition. The homogeneous part
@@ -1091,11 +1094,8 @@ class ConvergentFilter(StandardFilter):
             # which still depend on y_t and a_prev. cross_a uses the identity Z(I - K Z) = H F^{-1} Z
             # to express what is naturally an H^{-1} term through F^{-1} instead, which stays finite for
             # singular H (a measurement-error-free model).
-            u = I_KZ_.T @ T_r_next
-            w = Z_.T @ Finv_v
-            cross_a = 0.5 * (pt.outer(u, w) + pt.outer(w, u))
-            Zt_Finv_v = w[:, None]
-            direct_C = ZtFinvZ_ - Zt_Finv_v @ Zt_Finv_v.T
+            cross_a = 0.5 * (pt.outer(A_r_next, Zt_Finv_v) + pt.outer(Zt_Finv_v, A_r_next))
+            direct_C = ZtFinvZ_ - pt.outer(Zt_Finv_v, Zt_Finv_v)
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
 
             dL_dT = pt.outer(r_next, a_filt)
@@ -1121,7 +1121,7 @@ class ConvergentFilter(StandardFilter):
                 None,
                 None,
             ],
-            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ, ZtFinvZ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, A, ZtFinvZ],
             go_backwards=True,
             strict=False,
             return_updates=False,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -1064,8 +1064,9 @@ class ConvergentFilter(StandardFilter):
         I_KZ = pt.eye(m) - K_star @ Z
         A = T @ I_KZ
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
+        ZtFinvZ = Z.T @ F_inv @ Z  # the data-independent half of direct_C, lifted out of the scan
 
-        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_):
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_, ZtFinvZ_):
             v = y - Z_ @ a_prev - d_
             Finv_v = F_inv_ @ v
             a_filt = a_prev + K_ @ v
@@ -1086,7 +1087,7 @@ class ConvergentFilter(StandardFilter):
             w = Z_.T @ Finv_v
             cross_a = 0.5 * (pt.outer(u, w) + pt.outer(w, u))
             Zt_Finv_v = w[:, None]
-            direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
+            direct_C = ZtFinvZ_ - Zt_Finv_v @ Zt_Finv_v.T
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
 
             dL_dT = pt.outer(r_next, a_filt)
@@ -1112,7 +1113,7 @@ class ConvergentFilter(StandardFilter):
                 None,
                 None,
             ],
-            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ, ZtFinvZ],
             go_backwards=True,
             strict=False,
             return_updates=False,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -1058,8 +1058,9 @@ class ConvergentFilter(StandardFilter):
         I_KZ = pt.eye(m) - K_star @ Z
         A = T @ I_KZ
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
+        ZtFinvZ = Z.T @ F_inv @ Z  # the data-independent half of direct_C, lifted out of the scan
 
-        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_):
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_, ZtFinvZ_):
             v = y - Z_ @ a_prev - d_
             Finv_v = F_inv_ @ v
             a_filt = a_prev + K_ @ v
@@ -1080,7 +1081,7 @@ class ConvergentFilter(StandardFilter):
             w = Z_.T @ Finv_v
             cross_a = 0.5 * (pt.outer(u, w) + pt.outer(w, u))
             Zt_Finv_v = w[:, None]
-            direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
+            direct_C = ZtFinvZ_ - Zt_Finv_v @ Zt_Finv_v.T
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
 
             dL_dT = pt.outer(r_next, a_filt)
@@ -1106,7 +1107,7 @@ class ConvergentFilter(StandardFilter):
                 None,
                 None,
             ],
-            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ, ZtFinvZ],
             go_backwards=True,
             strict=False,
             return_updates=False,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -968,8 +968,10 @@ class ConvergentFilter(StandardFilter):
             data, a0, P0, c, d, T, Z, R, H, Q, stop_early=True
         )
 
-        k = a_filt_tr.shape[0]
-        a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+        # Cap the split one step short of the series so the post-convergence tail always has at least
+        # one step.
+        k = pt.minimum(a_filt_tr.shape[0], n - 1)
+        a_star, P_star = a_hat_tr[k - 1], P_hat_tr[k - 1]
 
         # Tail constants from P*. Computed once here to make the tail function prettier.
         F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
@@ -1011,13 +1013,13 @@ class ConvergentFilter(StandardFilter):
             return pt.concatenate([a, b], axis=0)
 
         return (
-            cat(a_filt_tr, a_filt_fx),
-            cat(a_hat_tr, a_hat_fx),
-            cat(y_hat_tr, y_hat_fx),
-            cat(P_filt_tr, P_filt_fx),
-            cat(P_hat_tr, P_hat_fx),
-            cat(F_tr, F_fx),
-            cat(ll_tr, ll_fx),
+            cat(a_filt_tr[:k], a_filt_fx),
+            cat(a_hat_tr[:k], a_hat_fx),
+            cat(y_hat_tr[:k], y_hat_fx),
+            cat(P_filt_tr[:k], P_filt_fx),
+            cat(P_hat_tr[:k], P_hat_fx),
+            cat(F_tr[:k], F_fx),
+            cat(ll_tr[:k], ll_fx),
             k,
         )
 

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -864,7 +864,7 @@ class ConvergentFilter(StandardFilter):
 
     2. **Speed.** In the post-convergence tail, per-step Cholesky and the full Joseph-form backward are
        unnecessary because ``K``, ``F``, and ``P`` are constant. The custom pullback hoists
-       ``F^{-1}, H^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
+       ``F^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
        backward reduces to matvec and outer products. On typical state-space cells
        (m=10..50, p=3..10, n=2000..10000) this gives a ~1.8--2.9x speedup on ``logp + grad``
        versus :class:`StandardFilter` autodiff, on top of a ~7--12x forward speedup.
@@ -878,6 +878,9 @@ class ConvergentFilter(StandardFilter):
       ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are
       rejected. For :class:`SharedVariable` or :class:`TensorConstant` data the check runs at build
       time; fully symbolic data gets an :class:`~pytensor.raise_op.Assert` that fires at runtime.
+
+    Measurement-error-free models (singular or zero ``H``) are fully supported, gradients included;
+    the tail backward avoids forming ``H^{-1}``.
 
     Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
     disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
@@ -1020,7 +1023,6 @@ class ConvergentFilter(StandardFilter):
         d,
         T,
         Z,
-        H,
         K_star,
         F_star,
         F_chol_star,
@@ -1029,7 +1031,7 @@ class ConvergentFilter(StandardFilter):
     ):
         """Analytic backward pass over the post-convergence segment.
 
-        Runs a backward scan on the post-convergence data with ``F_inv, H_inv, A = T (I - K_star Z),
+        Runs a backward scan on the post-convergence data with ``F_inv, A = T (I - K_star Z),
         I - K_star Z`` hoisted out as non-sequences. Each step is closed-form (no Cholesky or solve in
         the body; only matvecs and outer products). Returns:
 
@@ -1056,9 +1058,8 @@ class ConvergentFilter(StandardFilter):
         I_KZ = pt.eye(m) - K_star @ Z
         A = T @ I_KZ
         F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
-        H_inv = pt.linalg.inv(stabilize(H, self.cov_jitter))
 
-        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, H_inv_, A_, I_KZ_):
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, A_, I_KZ_):
             v = y - Z_ @ a_prev - d_
             Finv_v = F_inv_ @ v
             a_filt = a_prev + K_ @ v
@@ -1072,11 +1073,13 @@ class ConvergentFilter(StandardFilter):
             # length grows it converges to the solution of the Lyapunov equation X = A^T X A + C, which
             # is the steady-state P-adjoint. Because A is constant in the post-convergence segment,
             # we can hoist it; the per-step work is the two correction terms (cross_a and direct_C)
-            # which still depend on y_t and a_prev.
-            row = (v[None, :] @ H_inv_) @ Z_
-            M = I_KZ_.T @ (T_r_next[:, None] @ row) @ I_KZ_
-            cross_a = 0.5 * (M + M.T)
-            Zt_Finv_v = (Z_.T @ Finv_v)[:, None]
+            # which still depend on y_t and a_prev. cross_a uses the identity Z(I - K Z) = H F^{-1} Z
+            # to express what is naturally an H^{-1} term through F^{-1} instead, which stays finite for
+            # singular H (a measurement-error-free model).
+            u = I_KZ_.T @ T_r_next
+            w = Z_.T @ Finv_v
+            cross_a = 0.5 * (pt.outer(u, w) + pt.outer(w, u))
+            Zt_Finv_v = w[:, None]
             direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
             d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
 
@@ -1103,7 +1106,7 @@ class ConvergentFilter(StandardFilter):
                 None,
                 None,
             ],
-            non_sequences=[c, d, T, Z, K_star, F_inv, H_inv, A, I_KZ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, A, I_KZ],
             go_backwards=True,
             strict=False,
             return_updates=False,
@@ -1246,7 +1249,6 @@ class ConvergentFilter(StandardFilter):
                 d_,
                 T_,
                 Z_,
-                H_,
                 K_star,
                 F_star,
                 F_chol,
@@ -1337,6 +1339,9 @@ class ConvergentFilter(StandardFilter):
                 dQ_tr + d_Q_P,
             ]
 
+        # inline=True folds the forward into the surrounding graph, but the custom pullback still
+        # wins: pt.grad builds the gradient graph before the inline rewrite runs, so the analytic
+        # backward is what gets differentiated.
         return OpFromGraph(
             inputs=inputs_s,
             outputs=outputs,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -839,7 +839,9 @@ class UnivariateFilter(BaseFilter):
 class ConvergentFilter(StandardFilter):
     """Kalman filter that exploits Riccati convergence to a fixed-gain steady state.
 
-    For a stationary observable system with no missing data, the predicted-covariance Riccati recursion
+    For a time-invariant system whose Riccati recursion reaches a steady state -- detectability and
+    stabilizability are sufficient, which is weaker than stationarity and admits unit-root models such
+    as the local level -- the predicted-covariance recursion
     ``P_{t+1|t} = T (P_{t|t-1} - K_t F_t K_t^T) T^T + R Q R^T`` is data-independent and converges to the
     discrete algebraic Riccati equation (DARE) fixed point ``P_star``. Once converged, the Kalman gain
     ``K_t = P_{t|t-1} Z^T F_t^{-1}`` and innovation covariance ``F_t = Z P_{t|t-1} Z^T + H`` are constant
@@ -872,7 +874,11 @@ class ConvergentFilter(StandardFilter):
     Constraints (validated at graph build time):
 
     - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
-      :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
+      :class:`ValueError`: a constant steady-state gain only exists when the system matrices are
+      constant. This is a statement about time-invariance, not stationarity -- a time-invariant model
+      whose Riccati recursion never settles within the series simply never triggers the ``until``
+      clause, so ``k = n``, the post-convergence tail is empty, and the result reduces to
+      :class:`StandardFilter`.
     - ``data`` must contain no missing values. A masked observation changes the effective ``Z_t`` (and
       so ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. The statespace core replaces
       ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -5,9 +5,13 @@ import pytensor
 import pytensor.tensor as pt
 
 from pymc.pytensorf import constant_fold
+from pytensor.compile.builders import OpFromGraph
+from pytensor.compile.sharedvalue import SharedVariable
+from pytensor.gradient import disconnected_grad
 from pytensor.graph.basic import Variable
 from pytensor.raise_op import Assert
-from pytensor.tensor import TensorVariable
+from pytensor.scan.utils import until
+from pytensor.tensor import TensorConstant, TensorVariable
 from pytensor.tensor.linalg import solve_triangular
 
 from pymc_extras.statespace.filters.utilities import (
@@ -21,6 +25,7 @@ from pymc_extras.statespace.utils.constants import (
     LONG_NAME_TO_SHORT,
     MATRIX_NAMES,
     MISSING_FILL,
+    static_matrix_shapes,
 )
 
 MVN_CONST = pt.log(2 * pt.constant(np.pi, dtype="float64"))
@@ -829,3 +834,508 @@ class UnivariateFilter(BaseFilter):
         )
 
         return a_filtered, a_hat, obs_mu, P_filtered, P_hat, obs_cov, ll
+
+
+class ConvergentFilter(StandardFilter):
+    """Kalman filter that exploits Riccati convergence to a fixed-gain steady state.
+
+    For a stationary observable system with no missing data, the predicted-covariance Riccati recursion
+    ``P_{t+1|t} = T (P_{t|t-1} - K_t F_t K_t^T) T^T + R Q R^T`` is data-independent and converges to the
+    discrete algebraic Riccati equation (DARE) fixed point ``P_star``. Once converged, the Kalman gain
+    ``K_t = P_{t|t-1} Z^T F_t^{-1}`` and innovation covariance ``F_t = Z P_{t|t-1} Z^T + H`` are constant
+    (``K_star``, ``F_star``) and the filter becomes a linear time-invariant recursion on the predicted
+    state ``a_{t|t-1}`` alone. ``ConvergentFilter`` splits the forward pass at the convergence step ``k``:
+
+    - **pre-convergence steps** (``t = 0..k-1``, the "transient"): full Kalman with update + Riccati predict.
+    - **post-convergence steps** (``t = k..n-1``, the "tail"): linear recursion on ``a`` with cached
+      ``K_star``, ``F_star``, ``log det F_star``. No per-step Cholesky; loss is ``log det F_star + v_t^T F_star^{-1} v_t``
+      evaluated via a pre-computed Cholesky of ``F_star`` and a per-step triangular solve.
+
+    The gradient is delivered via a custom pullback on an :class:`~pytensor.compile.builders.OpFromGraph`
+    rather than via autodiff. Two reasons:
+
+    1. **Correctness.** Autodiff through the two-scan forward gives *incorrect* gradients when the ``until``
+       clause on the pre-convergence scan actually fires. The forward value is fine, and one scan in
+       isolation autodiffs correctly -- but the combination of an ``until``-scan followed by a second scan
+       that depends on quantities derived from the first scan's *last* outputs (our case: ``K_star``,
+       ``F_star`` derived from ``P_hat_tr[-1]``) produces parameter gradients that are wrong by 5--100%
+       relative error even though the likelihood value matches to machine precision. With ``tol`` set so
+       the until never fires, autodiff is exact; with a real post-convergence tail it is not.
+
+    2. **Speed.** In the post-convergence tail, per-step Cholesky and the full Joseph-form backward are
+       unnecessary because ``K``, ``F``, and ``P`` are constant. The custom pullback hoists
+       ``F^{-1}, H^{-1}, A = T (I - K_star Z), I - K_star Z`` out of the scan body and the per-step
+       backward reduces to matvec and outer products. On typical state-space cells
+       (m=10..50, p=3..10, n=2000..10000) this gives a ~1.8--2.9x speedup on ``logp + grad``
+       versus :class:`StandardFilter` autodiff, on top of a ~7--12x forward speedup.
+
+    Constraints (validated at graph build time):
+
+    - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
+      :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
+    - ``data`` must contain no ``NaN`` values. A masked observation changes the effective ``Z_t`` (and so
+      ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. For :class:`SharedVariable` or
+      :class:`TensorConstant` data the check runs at build time; fully symbolic data gets an
+      :class:`~pytensor.raise_op.Assert` that fires at runtime.
+
+    Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
+    disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
+
+    Parameters
+    ----------
+    tol : float, optional
+        Convergence tolerance on the Frobenius norm of ``P_{t+1|t} - P_{t|t-1}`` in the pre-convergence
+        scan. The scan stops the first time this drops below ``tol``. Default ``1e-10``.
+    """
+
+    _NAN_MSG = (
+        "ConvergentFilter does not support missing data (NaN) in the observation "
+        "series. Use StandardFilter for data with missing values."
+    )
+
+    def __init__(self, tol: float = 1e-10):
+        super().__init__()
+        self.tol = tol
+
+    def _check_data(self, data):
+        """Reject NaN at build time for concrete data; insert an Assert op otherwise."""
+        if isinstance(data, SharedVariable):
+            if np.isnan(data.get_value()).any():
+                raise ValueError(self._NAN_MSG)
+            return data
+        if isinstance(data, TensorConstant):
+            if np.isnan(data.data).any():
+                raise ValueError(self._NAN_MSG)
+            return data
+        return Assert(self._NAN_MSG)(data, pt.all(pt.bitwise_not(pt.isnan(data))))
+
+    def _kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
+        a_filt, P_filt, y_hat, F, ll = self.update(
+            a=a, P=P, y=y, d=d, Z=Z, H=H, all_nan_flag=pt.constant(0.0)
+        )
+        P_filt = stabilize(P_filt, self.cov_jitter)
+        a_hat, P_hat = self.predict(a=a_filt, P=P_filt, c=c, T=T, R=R, Q=Q)
+        return a_filt, a_hat, y_hat, P_filt, P_hat, F, ll
+
+    def _full_kalman_scan(self, data, a0, P0, c, d, T, Z, R, H, Q, stop_early):
+        def body(y, a_prev, P_prev, *params):
+            out = self._kalman_step(y, a_prev, P_prev, *params)
+            if stop_early:
+                return out, until(pt.sqrt(((out[4] - P_prev) ** 2).sum()) < self.tol)
+            return out
+
+        return pytensor.scan(
+            body,
+            sequences=[data],
+            outputs_info=[None, a0, None, None, P0, None, None],
+            non_sequences=[c, d, T, Z, R, H, Q],
+            strict=False,
+            return_updates=False,
+        )
+
+    def _convergent_forward(self, data, a0, P0, c, d, T, Z, R, H, Q):
+        """Two-phase forward pass.
+
+        Phase 1 (pre-convergence): a standard Kalman scan with an ``until`` clause that stops once the Riccati
+        recursion has converged (``||P_{t+1|t} - P_{t|t-1}||_F < tol``). At the stopping step ``k`` we have the DARE
+        fixed point estimate ``P_star = P_hat_tr[-1]``.
+
+        Phase 2 (post-convergence): ``K_star, F_star, F_chol_star, log det F_star, P_filt_star`` are computed once from
+         ``P_star`` and plugged into a cheaper scan whose step only does ``v_t = y_t - Z a_prev - d``, a triangular
+         solve against ``F_chol_star`` for the loss, a matvec ``a_filt = a_prev + K_star v_t``, and one matvec for
+         the state predict ``a_hat = T a_filt + c``.
+
+        Outputs are the 7 per-step sequences produced by :class:`StandardFilter` plus the convergence step ``k``
+        (a symbolic integer). The pullback uses ``k`` to split the adjoint computation. In the post-convergence segment
+        the sequences ``P_filt``, ``P_hat``, and ``F`` are broadcasts of constants.
+        """
+        n = data.shape[0]
+        (a_filt_tr, a_hat_tr, y_hat_tr, P_filt_tr, P_hat_tr, F_tr, ll_tr) = self._full_kalman_scan(
+            data, a0, P0, c, d, T, Z, R, H, Q, stop_early=True
+        )
+
+        k = a_filt_tr.shape[0]
+        a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+
+        # Tail constants from P*. Computed once here to make the tail function prettier.
+        F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
+        F_chol_star = pt.linalg.cholesky(F_star, lower=True)
+        logdet_F_star = 2 * pt.log(pt.diag(F_chol_star)).sum()
+        K_star = pt.linalg.solve(
+            F_star.mT, (P_star @ Z.mT).mT, assume_a="pos", check_finite=False
+        ).mT
+        I_KZ_star = pt.eye(self.n_states) - K_star @ Z
+        P_filt_star = stabilize(
+            quad_form_sym(I_KZ_star, P_star) + quad_form_sym(K_star, H), self.cov_jitter
+        )
+
+        # Tail scan: fixed K*, F* (no per-step Cholesky). Recurrent slot is a_hat.
+        def tail_body(y, a_prev):
+            y_hat = d + Z @ a_prev
+            v = y - y_hat
+            solved = solve_triangular(F_chol_star, v, lower=True)
+            ll = -0.5 * (MVN_CONST + logdet_F_star + (solved * solved).sum())
+            a_filt = a_prev + K_star @ v
+            return a_filt, T @ a_filt + c, y_hat, ll
+
+        a_filt_fx, a_hat_fx, y_hat_fx, ll_fx = pytensor.scan(
+            tail_body,
+            sequences=[data[k:]],
+            outputs_info=[None, a_star, None, None],
+            strict=False,
+            return_updates=False,
+        )
+
+        # Stitch: in the tail, P_filt, P_hat, F are constants (broadcast).
+        n_fx = n - k
+        m_shape = (n_fx, self.n_states, self.n_states)
+        P_filt_fx = pt.broadcast_to(P_filt_star, m_shape)
+        P_hat_fx = pt.broadcast_to(P_star, m_shape)
+        F_fx = pt.broadcast_to(F_star, (n_fx, self.n_endog, self.n_endog))
+
+        def cat(a, b):
+            return pt.concatenate([a, b], axis=0)
+
+        return (
+            cat(a_filt_tr, a_filt_fx),
+            cat(a_hat_tr, a_hat_fx),
+            cat(y_hat_tr, y_hat_fx),
+            cat(P_filt_tr, P_filt_fx),
+            cat(P_hat_tr, P_hat_fx),
+            cat(F_tr, F_fx),
+            cat(ll_tr, ll_fx),
+            k,
+        )
+
+    def _fixed_k_tail_backward(
+        self,
+        data,
+        a_star,
+        c,
+        d,
+        T,
+        Z,
+        H,
+        K_star,
+        F_star,
+        F_chol_star,
+        a_hat_fx,
+        dlogp,
+    ):
+        """Analytic backward pass over the post-convergence segment.
+
+        Runs a backward scan on the post-convergence data with ``F_inv, H_inv, A = T (I - K_star Z),
+        I - K_star Z`` hoisted out as non-sequences. Each step is closed-form (no Cholesky or solve in
+        the body; only matvecs and outer products). Returns:
+
+        - ``d_data, d_a_star``: ordinary adjoints flowing backward out of the segment.
+        - ``d_P_star``: Riccati-style adjoint at the segment's entry. Used as the terminal condition for
+          the pre-convergence backward (the transient's ``P_hat_grad`` at step ``k-1``).
+        - ``d_T_alpha, d_c, d_Z_direct, d_d``: per-step contributions summed across post-convergence.
+          These are the alpha-path (mean of the latent states) contributions; P-path contributions to d_T / d_Z
+          come from the ``S`` aggregate below.
+        - ``d_K_star, d_F_star``: adjoints treating ``K_star, F_star`` as if they were independent
+          inputs to the post-convergence forward. The caller chains these to ``(P_star, Z, H)`` via the
+          analytic definitions ``K_star = P_star Z^T F_star^{-1}`` and ``F_star = Z P_star Z^T + H``.
+        - ``S = sum_t d_P_hat_t``: aggregate P-adjoint across the post-convergence segment. In the
+          post-convergence segment ``P_t`` is the constant ``P_star``, so P-path contributions to
+          d_T, d_Z, d_H, d_R, d_Q are linear in ``d_P_hat_t``. These aggregate into formulas that use
+          ``S`` (rather than needing a separate per-step scan).
+        """
+        m = a_star.shape[0]
+        p_dim = F_chol_star.shape[0]
+        n_tail = data.shape[0]
+        a_prev_seq = pt.concatenate([a_star[None, :], a_hat_fx[:-1]], axis=0)
+
+        # Hoisted constants.
+        I_KZ = pt.eye(m) - K_star @ Z
+        A = T @ I_KZ
+        F_inv = pt.linalg.cho_solve((F_chol_star, True), pt.eye(p_dim))
+        H_inv = pt.linalg.inv(stabilize(H, self.cov_jitter))
+
+        def bwd(y, a_prev, r_next, P_hat_next, c_, d_, T_, Z_, K_, F_inv_, H_inv_, A_, I_KZ_):
+            v = y - Z_ @ a_prev - d_
+            Finv_v = F_inv_ @ v
+            a_filt = a_prev + K_ @ v
+            T_r_next = T_.T @ r_next
+            dL_dv = K_.T @ T_r_next + 2 * Finv_v
+            r_t = A_.T @ r_next - 2 * Z_.T @ Finv_v
+
+            # P-adjoint recursion: d_P_prev = A^T @ d_P_hat_next @ A + cross_a + direct_C,
+            # where A = T (I - K_star Z) is the closed-loop transition. The homogeneous part
+            # d_P_prev = A^T @ d_P_hat_next @ A is the backward Lyapunov recursion: as the segment
+            # length grows it converges to the solution of the Lyapunov equation X = A^T X A + C, which
+            # is the steady-state P-adjoint. Because A is constant in the post-convergence segment,
+            # we can hoist it; the per-step work is the two correction terms (cross_a and direct_C)
+            # which still depend on y_t and a_prev.
+            row = (v[None, :] @ H_inv_) @ Z_
+            M = I_KZ_.T @ (T_r_next[:, None] @ row) @ I_KZ_
+            cross_a = 0.5 * (M + M.T)
+            Zt_Finv_v = (Z_.T @ Finv_v)[:, None]
+            direct_C = Z_.T @ (F_inv_ @ Z_) - Zt_Finv_v @ Zt_Finv_v.T
+            d_P_prev = A_.T @ P_hat_next @ A_ + cross_a + direct_C
+
+            dL_dT = pt.outer(r_next, a_filt)
+            dL_dc = r_next
+            dL_dZ = -pt.outer(dL_dv, a_prev)
+            dL_dd = -dL_dv
+            dL_dK = pt.outer(T_r_next, v)
+            vvT = pt.outer(v, v)
+
+            return r_t, d_P_prev, dL_dv, dL_dT, dL_dc, dL_dZ, dL_dd, dL_dK, vvT
+
+        (r_seq, dPp_seq, dy_seq, dT_seq, dc_seq, dZ_seq, dd_seq, dK_seq, vvT_seq) = pytensor.scan(
+            bwd,
+            sequences=[data, a_prev_seq],
+            outputs_info=[
+                pt.zeros_like(a_star),
+                pt.zeros((m, m), dtype="float64"),
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+            ],
+            non_sequences=[c, d, T, Z, K_star, F_inv, H_inv, A, I_KZ],
+            go_backwards=True,
+            strict=False,
+            return_updates=False,
+        )
+
+        # d_P_prev_seq in go_backwards order is [d_P_hat_{n-2}, ..., d_P_hat_{k-1}]; the last
+        # element is d_P_star (the handoff fed to the pre-convergence backward), so the aggregate
+        # S = sum_t d_P_hat_t over the post-convergence segment excludes it.
+        S = dlogp * dPp_seq[:-1].sum(axis=0)
+        sum_vvT = vvT_seq.sum(axis=0)
+        return (
+            dlogp * dy_seq[::-1],  # d_data
+            dlogp * r_seq[-1],  # d_a_star
+            dlogp * dPp_seq[-1],  # d_P_star (Riccati)
+            dlogp * dT_seq.sum(axis=0),  # d_T alpha-path
+            dlogp * dc_seq.sum(axis=0),  # d_c
+            dlogp * dZ_seq.sum(axis=0),  # d_Z direct
+            dlogp * dd_seq.sum(axis=0),  # d_d
+            dlogp * dK_seq.sum(axis=0),  # d_K_star
+            dlogp * (n_tail * F_inv - F_inv @ sum_vvT @ F_inv),  # d_F_star
+            S,
+        )
+
+    def build_graph(
+        self,
+        data,
+        a0,
+        P0,
+        c,
+        d,
+        T,
+        Z,
+        R,
+        H,
+        Q,
+        missing_fill_value=None,
+        cov_jitter=None,
+        time_varying_names=(),
+    ):
+        if time_varying_names:
+            raise ValueError(
+                "ConvergentFilter requires time-invariant matrices; got time-varying: "
+                f"{sorted(time_varying_names)}. Use StandardFilter instead."
+            )
+        self.missing_fill_value = MISSING_FILL if missing_fill_value is None else missing_fill_value
+        self.cov_jitter = JITTER_DEFAULT if cov_jitter is None else cov_jitter
+
+        [R_shape] = constant_fold([R.shape], raise_not_constant=False)
+        [Z_shape] = constant_fold([Z.shape], raise_not_constant=False)
+        self.n_states, self.n_shocks = R_shape[-2:]
+        self.n_endog = Z_shape[-2]
+
+        data = self._check_data(data)
+        data, a0, P0, c, d, T, Z, R, H, Q = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)
+        data = pt.specify_shape(data, (data.type.shape[0], self.n_endog))
+        self.seq_names = []
+        self.non_seq_names = list(PARAM_NAMES)
+
+        # The forward is two scans chained through derived quantities (K_star, F_star, log det F_star
+        # and P_filt_star all depend on the first scan's last output). Autodiff gives incorrect
+        # gradients on this structure once the `until` clause fires with a non-trivial post-convergence
+        # segment. We wrap in an OFG and supply a custom pullback that splits the backward
+        # into: an analytic backward on the post-convergence segment (cheap, closed form), a chain
+        # rule step for (K_star, F_star) -> (P_star, Z, H) using the analytic definitions, and an
+        # autodiff backward on the pre-convergence segment with the handoff adjoints as its terminal
+        # condition (the plain Kalman iterations).
+        op = self._make_ofg()
+        a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, _k = op(data, a0, P0, c, d, T, Z, R, H, Q)
+        n = data.type.shape[0]
+        return self._postprocess_scan_results(
+            (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll[..., None]), a0, P0, n=n
+        )
+
+    def _make_ofg(self):
+        m, p, r_ = self.n_states, self.n_endog, self.n_shocks
+        cov_jitter = self.cov_jitter
+
+        sym = {
+            "data": pt.tensor("data", dtype="float64", shape=(None, p)),
+            **{
+                name: pt.tensor(name, dtype="float64", shape=shape)
+                for name, shape in static_matrix_shapes(m, p, r_).items()
+            },
+        }
+        in_order = ["data", "a0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
+        inputs_s = [sym[k] for k in in_order]
+        outputs = list(self._convergent_forward(*inputs_s))
+        filt_self = self
+
+        def pullback(inputs, outputs, out_grads):
+            # `outputs` are the 8 forward outputs of `_convergent_forward`:
+            # (a_filt, a_hat, y_hat, P_filt, P_hat, F, ll, k). Only the sequences we need for the
+            # backward are bound; the rest are `_`. Similarly, `out_grads[6]` is the adjoint on `ll`;
+            # all other output adjoints are assumed disconnected (see class docstring).
+            data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = inputs
+            _, a_hat_sym, _, _, P_hat_sym, _, _, k_sym = outputs
+            dll = out_grads[6]
+
+            # Split the recorded per-step sequences at the convergence step `k_sym`. The
+            # pre-convergence slice is `[:k_sym]` and the post-convergence slice is `[k_sym:]`;
+            # a_star and P_star are the handoff values flowing between them (a_{k|k-1}, P_{k|k-1}).
+            a_hat_tr, P_hat_tr = a_hat_sym[:k_sym], P_hat_sym[:k_sym]
+            data_tr, data_fx = data_[:k_sym], data_[k_sym:]
+            a_star, P_star = a_hat_tr[-1], P_hat_tr[-1]
+            a_hat_fx = a_hat_sym[k_sym:]
+            # Reduce the per-step ll adjoint to a scalar by averaging. This is correct for the
+            # standard use case loss = ll.sum() (dll is a broadcast of ones, average is 1.0) and
+            # punts on the more general case of per-step weights.
+            dlogp_up = dll.sum() / dll.shape[0]
+
+            # Pre-compute tail constants for readability.
+            F_star = Z_ @ P_star @ Z_.mT + stabilize(H_, cov_jitter)
+            F_chol = pt.linalg.cholesky(F_star, lower=True)
+            K_star = pt.linalg.solve(
+                F_star.mT, (P_star @ Z_.mT).mT, assume_a="pos", check_finite=False
+            ).mT
+            F_inv = pt.linalg.cho_solve((F_chol, True), pt.eye(F_chol.shape[0]))
+
+            # Post-convergence backward. This is the source of the speedup: K, F, and P are constant
+            # across the segment, so the per-step backward drops to matvec/outer-product work.
+            # The factor of -0.5 on dlogp_up is a convention adjustment: the analytic formulas in
+            # `_fixed_k_tail_backward` are derived for ll = log |F| + v^T F^{-1} v (the "2 * negative
+            # log-likelihood" form), while our per-step ll is -0.5 * (MVN_CONST + log |F| + v^T F^{-1} v).
+            # So the caller's dlogp_up needs a -0.5 factor before being fed into the analytic formulas.
+            (
+                dd_fx,
+                da_star,
+                dP_star_ric,
+                dT_a,
+                dc_t,
+                dZ_dir,
+                dd_t,
+                dK_s,
+                dF_s,
+                S,
+            ) = filt_self._fixed_k_tail_backward(
+                data_fx,
+                a_star,
+                c_,
+                d_,
+                T_,
+                Z_,
+                H_,
+                K_star,
+                F_star,
+                F_chol,
+                a_hat_fx,
+                -0.5 * dlogp_up,
+            )
+
+            # Use chain rule to recover dZ and dH from dK*, dF*. Fully analytic.
+            dK, dF = disconnected_grad(dK_s), disconnected_grad(dF_s)
+            P_filt_s = (pt.eye(m) - K_star @ Z_) @ P_star
+            d_Z_chain = (
+                F_inv @ dK.mT @ P_filt_s - K_star.mT @ dK @ K_star.mT + (dF + dF.mT) @ Z_ @ P_star
+            )
+            X = K_star.mT @ dK @ F_inv
+            d_H_chain = dF - 0.5 * (X + X.mT)
+
+            # P-path contributions to d_T, d_Z, d_H. Because P_t is the constant P_star across the
+            # post-convergence segment, each step's contribution is linear in d_P_hat_t, so the sum
+            # over the segment is obtained by substituting S = sum_t d_P_hat_t into the formulas.
+            TtST = T_.mT @ S @ T_
+            KtPg = K_star.mT @ TtST
+            FinvZP = F_inv @ Z_ @ P_star
+            KZP = (K_star @ Z_) @ P_star
+            d_T_P = (S @ T_) @ P_filt_s.mT + (S.mT @ T_) @ P_filt_s
+            d_Z_P = (
+                -FinvZP @ TtST.mT @ P_star
+                + KtPg @ P_star.mT @ Z_.mT @ K_star.mT
+                + FinvZP @ TtST.mT @ KZP
+                - KtPg @ P_star.mT
+            )
+            d_H_P = KtPg @ K_star
+            # Chain S through W = R Q R^T for (d_R, d_Q).
+            d_R_P = (S + S.mT) @ R_ @ Q_
+            d_Q_P = R_.mT @ S @ R_
+
+            # Pre-convergence backward. We rebuild the Kalman scan on the sliced pre-convergence data
+            # (data[:k_sym]) and autodiff through it. The surrogate loss has three parts: the
+            # pre-convergence log-likelihood itself, plus two inner products that encode the handoff
+            # adjoints (da_star for the last predicted state, dP_star_ric for the last predicted
+            # covariance). disconnected_grad on the adjoints keeps pt.grad from trying to chase their
+            # own parameter dependence (they are outputs of the post-convergence backward and are
+            # treated as constants here. If we connect their gradients we would be double-counting).
+            _, a_hat_rb, _, _, P_hat_rb, _, ll_rb = filt_self._full_kalman_scan(
+                data_tr,
+                a0_,
+                P0_,
+                c_,
+                d_,
+                T_,
+                Z_,
+                R_,
+                H_,
+                Q_,
+                stop_early=False,
+            )
+            loss_tr = (
+                dlogp_up * ll_rb.sum()
+                + (a_hat_rb[-1] * disconnected_grad(da_star)).sum()
+                + (P_hat_rb[-1] * disconnected_grad(dP_star_ric)).sum()
+            )
+            (
+                dd_full,
+                da0,
+                dP0,
+                dc_tr,
+                dd_tr,
+                dT_tr,
+                dZ_tr,
+                dR_tr,
+                dH_tr,
+                dQ_tr,
+            ) = pt.grad(
+                loss_tr,
+                [data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_],
+                disconnected_inputs="ignore",
+            )
+
+            return [
+                pt.concatenate([dd_full[:k_sym], dd_fx], axis=0),
+                da0,
+                dP0,
+                dc_tr + dc_t,
+                dd_tr + dd_t,
+                dT_tr + dT_a + d_T_P,
+                dZ_tr + dZ_dir + d_Z_chain + d_Z_P,
+                dR_tr + d_R_P,
+                dH_tr + d_H_chain + d_H_P,
+                dQ_tr + d_Q_P,
+            ]
+
+        return OpFromGraph(
+            inputs=inputs_s,
+            outputs=outputs,
+            pullback=pullback,
+            inline=True,
+            name="convergent_kf",
+        )

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -873,10 +873,11 @@ class ConvergentFilter(StandardFilter):
 
     - All model matrices (``c, d, T, Z, R, H, Q``) must be time-invariant. Time-varying inputs raise
       :class:`ValueError`; Riccati convergence is not meaningful for a non-stationary system.
-    - ``data`` must contain no ``NaN`` values. A masked observation changes the effective ``Z_t`` (and so
-      ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. For :class:`SharedVariable` or
-      :class:`TensorConstant` data the check runs at build time; fully symbolic data gets an
-      :class:`~pytensor.raise_op.Assert` that fires at runtime.
+    - ``data`` must contain no missing values. A masked observation changes the effective ``Z_t`` (and
+      so ``K_t`` and ``F_t``), breaking the cached-``K_star`` assumption. The statespace core replaces
+      ``NaN`` with ``missing_fill_value`` before the filter runs, so both ``NaN`` and that sentinel are
+      rejected. For :class:`SharedVariable` or :class:`TensorConstant` data the check runs at build
+      time; fully symbolic data gets an :class:`~pytensor.raise_op.Assert` that fires at runtime.
 
     Only ``d loglike_obs`` is supported as an upstream gradient; other output adjoints are treated as
     disconnected. For gradients of other filter outputs, use :class:`StandardFilter`.
@@ -888,9 +889,9 @@ class ConvergentFilter(StandardFilter):
         scan. The scan stops the first time this drops below ``tol``. Default ``1e-10``.
     """
 
-    _NAN_MSG = (
-        "ConvergentFilter does not support missing data (NaN) in the observation "
-        "series. Use StandardFilter for data with missing values."
+    _MISSING_DATA_MSG = (
+        "ConvergentFilter does not support missing data in the observation series. "
+        "Use StandardFilter for data with missing values."
     )
 
     def __init__(self, tol: float = 1e-10):
@@ -898,16 +899,20 @@ class ConvergentFilter(StandardFilter):
         self.tol = tol
 
     def _check_data(self, data):
-        """Reject NaN at build time for concrete data; insert an Assert op otherwise."""
-        if isinstance(data, SharedVariable):
-            if np.isnan(data.get_value()).any():
-                raise ValueError(self._NAN_MSG)
+        """Reject data containing NaN or the missing-value sentinel.
+
+        The statespace core replaces NaN with ``missing_fill_value`` before the filter runs, so the
+        sentinel must be rejected alongside NaN. Concrete data (shared/constant) is checked at build
+        time; fully symbolic data gets a runtime :class:`~pytensor.raise_op.Assert`.
+        """
+        sentinel = self.missing_fill_value
+        if isinstance(data, SharedVariable | TensorConstant):
+            arr = data.get_value() if isinstance(data, SharedVariable) else data.data
+            if np.isnan(arr).any() or (arr == sentinel).any():
+                raise ValueError(self._MISSING_DATA_MSG)
             return data
-        if isinstance(data, TensorConstant):
-            if np.isnan(data.data).any():
-                raise ValueError(self._NAN_MSG)
-            return data
-        return Assert(self._NAN_MSG)(data, pt.all(pt.bitwise_not(pt.isnan(data))))
+        missing = pt.or_(pt.isnan(data), pt.eq(data, sentinel))
+        return Assert(self._MISSING_DATA_MSG)(data, pt.all(pt.bitwise_not(missing)))
 
     def _kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
         a_filt, P_filt, y_hat, F, ll = self.update(

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -61,6 +61,34 @@ MATRIX_DIMS = {
     "Q": (SHOCK_DIM, SHOCK_AUX_DIM),
 }
 
+
+def static_matrix_shapes(m: int, p: int, r: int) -> dict[str, tuple[int, ...]]:
+    """Concrete shapes of the static (non-time-varying) state-space matrices.
+
+    Keys match the filter's parameter naming (``a0`` rather than ``x0``).
+
+    Parameters
+    ----------
+    m : int
+        State dimension.
+    p : int
+        Observation dimension.
+    r : int
+        Shock dimension.
+    """
+    return {
+        "a0": (m,),
+        "P0": (m, m),
+        "c": (m,),
+        "d": (p,),
+        "T": (m, m),
+        "Z": (p, m),
+        "R": (m, r),
+        "H": (p, p),
+        "Q": (r, r),
+    }
+
+
 FILTER_OUTPUT_DIMS = {
     "filtered_states": (TIME_DIM, ALL_STATE_DIM),
     "smoothed_states": (TIME_DIM, ALL_STATE_DIM),

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -388,3 +388,167 @@ def test_kalman_filter_jax(filter):
 
     for name, jax_res, pt_res in zip(output_names, jax_outputs, pt_outputs):
         assert_allclose(jax_res, pt_res, atol=ATOL, rtol=RTOL, err_msg=f"{name} failed!")
+
+
+# -------------------- ConvergentFilter --------------------
+# Tests comparing ConvergentFilter outputs and gradients to StandardFilter.
+# ConvergentFilter requires stationary parameters and no missing data, so it
+# can't join the shared parametrized suite above.
+
+
+from pymc_extras.statespace.filters import ConvergentFilter
+
+
+def _make_stationary_system(m, p, n_shocks, n, rng):
+    """Build a valid stable stationary system for ConvergentFilter testing."""
+    T_np = rng.standard_normal((m, m)) * 0.3
+    T_np = T_np / (np.abs(np.linalg.eigvals(T_np)).max() * 1.5)
+    Z_np = rng.standard_normal((p, m)) * 0.5
+    H_root = rng.standard_normal((p, p)) * 0.3
+    H_np = H_root @ H_root.T + 0.2 * np.eye(p)
+    Q_root = rng.standard_normal((n_shocks, n_shocks)) * 0.3
+    Q_np = Q_root @ Q_root.T + 0.1 * np.eye(n_shocks)
+    R_np = rng.standard_normal((m, n_shocks)) * 0.5
+    c_np = rng.standard_normal(m) * 0.05
+    d_np = rng.standard_normal(p) * 0.05
+    a0_np = rng.standard_normal(m) * 0.1
+    P0_np = np.eye(m) * 0.5
+    a = rng.multivariate_normal(a0_np, P0_np)
+    data_np = np.empty((n, p), dtype=floatX)
+    for t in range(n):
+        w = R_np @ rng.multivariate_normal(np.zeros(n_shocks), Q_np)
+        eps = rng.multivariate_normal(np.zeros(p), H_np)
+        a = T_np @ a + c_np + w
+        data_np[t] = Z_np @ a + d_np + eps
+    return [
+        data_np.astype(floatX),
+        a0_np.astype(floatX),
+        P0_np.astype(floatX),
+        c_np.astype(floatX),
+        d_np.astype(floatX),
+        T_np.astype(floatX),
+        Z_np.astype(floatX),
+        R_np.astype(floatX),
+        H_np.astype(floatX),
+        Q_np.astype(floatX),
+    ]
+
+
+@pytest.mark.parametrize(
+    "m,p,n_shocks,n",
+    [(5, 2, 5, 100), (10, 3, 10, 200)],
+    ids=["small", "medium"],
+)
+def test_convergent_filter_forward_matches_standard(m, p, n_shocks, n, rng):
+    """ConvergentFilter forward outputs should match StandardFilter to numerical precision."""
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+
+    def build(filter_cls):
+        inputs, outputs = initialize_filter(filter_cls(), p=p, m=m, r=n_shocks, n=n)
+        return pytensor.function(inputs, outputs, on_unused_input="ignore")
+
+    fn_std = build(StandardFilter)
+    fn_conv = build(ConvergentFilter)
+    out_std = fn_std(*vals)
+    out_conv = fn_conv(*vals)
+
+    for name, s, c in zip(output_names, out_std, out_conv):
+        assert_allclose(
+            c,
+            s,
+            atol=ATOL,
+            rtol=RTOL,
+            err_msg=f"ConvergentFilter {name} differs from StandardFilter",
+        )
+
+
+@pytest.mark.parametrize(
+    "m,p,n_shocks,n",
+    [(5, 2, 5, 100), (10, 3, 10, 200)],
+    ids=["small", "medium"],
+)
+def test_convergent_filter_gradient_matches_standard(m, p, n_shocks, n, rng):
+    """ConvergentFilter gradients (via custom OFG split pullback) should match
+    StandardFilter (via autodiff) for every model parameter."""
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+
+    def build(filter_cls):
+        inputs, outputs = initialize_filter(filter_cls(), p=p, m=m, r=n_shocks, n=n)
+        data_, a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = inputs
+        ll_obs = outputs[-1]
+        loss = ll_obs.sum()
+        grads = pt.grad(loss, [a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_])
+        return pytensor.function(inputs, [loss, *grads], on_unused_input="ignore")
+
+    fn_std = build(StandardFilter)
+    fn_conv = build(ConvergentFilter)
+    out_std = fn_std(*vals)
+    out_conv = fn_conv(*vals)
+
+    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
+    symmetric = {"d_P0", "d_H", "d_Q"}
+    for name, s, c in zip(names, out_std, out_conv):
+        s = np.asarray(s)
+        c = np.asarray(c)
+        if name in symmetric:
+            s = 0.5 * (s + s.T)
+            c = 0.5 * (c + c.T)
+        assert_allclose(
+            c,
+            s,
+            atol=ATOL,
+            rtol=RTOL,
+            err_msg=f"ConvergentFilter {name} differs from StandardFilter",
+        )
+
+
+def test_convergent_filter_rejects_time_varying_params():
+    """Declaring any matrix time-varying should raise ValueError at build time."""
+    data = pt.matrix("data")
+    a0 = pt.vector("a0")
+    P0 = pt.matrix("P0")
+    c = pt.vector("c")
+    d = pt.vector("d")
+    T = pt.matrix("T")
+    Z = pt.matrix("Z")
+    R = pt.matrix("R")
+    H = pt.matrix("H")
+    Q = pt.matrix("Q")
+    with pytest.raises(ValueError, match="time-invariant"):
+        ConvergentFilter().build_graph(
+            data, a0, P0, c, d, T, Z, R, H, Q, time_varying_names=["transition"]
+        )
+
+
+def test_convergent_filter_rejects_nan_constant_data():
+    """NaN in a TensorConstant data tensor should raise ValueError at build time."""
+    n, p = 10, 2
+    data_arr = np.zeros((n, p), dtype=floatX)
+    data_arr[3, 0] = np.nan
+    data = pt.as_tensor(data_arr)
+    a0 = pt.vector("a0")
+    P0 = pt.matrix("P0")
+    c = pt.vector("c")
+    d = pt.vector("d")
+    T = pt.matrix("T")
+    Z = pt.matrix("Z")
+    R = pt.matrix("R")
+    H = pt.matrix("H")
+    Q = pt.matrix("Q")
+    with pytest.raises(ValueError, match="missing data"):
+        ConvergentFilter().build_graph(data, a0, P0, c, d, T, Z, R, H, Q)
+
+
+def test_convergent_filter_asserts_nan_symbolic_data(rng):
+    """For fully symbolic data, NaN should be caught by a runtime Assert op."""
+    m, p, n_shocks, n = 3, 2, 3, 30
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+    # Inject NaN at runtime
+    vals[0][5, 0] = np.nan
+
+    inputs, outputs = initialize_filter(ConvergentFilter(), p=p, m=m, r=n_shocks, n=n)
+    fn = pytensor.function(inputs, outputs, on_unused_input="ignore")
+
+    # The Assert op raises AssertionError at evaluation time
+    with pytest.raises(AssertionError):
+        fn(*vals)

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -435,6 +435,22 @@ def _make_stationary_system(m, p, n_shocks, n, rng):
     ]
 
 
+GRAD_NAMES = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
+
+# Gradients of parameters that are themselves symmetric matrices are only determined up to their
+# symmetric part, so the analytic and autodiff versions can differ in the antisymmetric half without
+# actually disagreeing.
+SYMMETRIC_GRADS = {"d_P0", "d_H", "d_Q"}
+
+
+def assert_results_match(out_std, out_conv, names, err_prefix=""):
+    for name, std, conv in zip(names, out_std, out_conv, strict=True):
+        std, conv = np.asarray(std, float), np.asarray(conv, float)
+        if name in SYMMETRIC_GRADS:
+            std, conv = 0.5 * (std + std.T), 0.5 * (conv + conv.T)
+        assert_allclose(conv, std, atol=ATOL, rtol=RTOL, err_msg=f"{err_prefix}{name} mismatch")
+
+
 @pytest.mark.parametrize(
     "m,p,n_shocks,n",
     [(5, 2, 5, 100), (10, 3, 10, 200)],
@@ -453,14 +469,12 @@ def test_convergent_filter_forward_matches_standard(m, p, n_shocks, n, rng):
     out_std = fn_std(*vals)
     out_conv = fn_conv(*vals)
 
-    for name, s, c in zip(output_names, out_std, out_conv):
-        assert_allclose(
-            c,
-            s,
-            atol=ATOL,
-            rtol=RTOL,
-            err_msg=f"ConvergentFilter {name} differs from StandardFilter",
-        )
+    # The tail path only runs once the Riccati recursion converges. Without this the comparison
+    # could pass vacuously, with ConvergentFilter having degenerated into StandardFilter.
+    predicted_covs = out_conv[output_names.index("predicted_covs")]
+    assert_allclose(predicted_covs[-1], predicted_covs[n // 2], atol=ATOL, rtol=RTOL)
+
+    assert_results_match(out_std, out_conv, output_names, err_prefix="ConvergentFilter ")
 
 
 @pytest.mark.parametrize(
@@ -469,8 +483,8 @@ def test_convergent_filter_forward_matches_standard(m, p, n_shocks, n, rng):
     ids=["small", "medium"],
 )
 def test_convergent_filter_gradient_matches_standard(m, p, n_shocks, n, rng):
-    """ConvergentFilter gradients (via custom OFG split pullback) should match
-    StandardFilter (via autodiff) for every model parameter."""
+    """ConvergentFilter's analytic gradients should match StandardFilter's autodiff gradients for
+    every model parameter."""
     vals = _make_stationary_system(m, p, n_shocks, n, rng)
 
     def build(filter_cls):
@@ -486,21 +500,7 @@ def test_convergent_filter_gradient_matches_standard(m, p, n_shocks, n, rng):
     out_std = fn_std(*vals)
     out_conv = fn_conv(*vals)
 
-    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
-    symmetric = {"d_P0", "d_H", "d_Q"}
-    for name, s, c in zip(names, out_std, out_conv):
-        s = np.asarray(s)
-        c = np.asarray(c)
-        if name in symmetric:
-            s = 0.5 * (s + s.T)
-            c = 0.5 * (c + c.T)
-        assert_allclose(
-            c,
-            s,
-            atol=ATOL,
-            rtol=RTOL,
-            err_msg=f"ConvergentFilter {name} differs from StandardFilter",
-        )
+    assert_results_match(out_std, out_conv, GRAD_NAMES, err_prefix="ConvergentFilter ")
 
 
 def test_convergent_filter_rejects_time_varying_params():
@@ -550,8 +550,7 @@ def test_convergent_filter_asserts_nan_symbolic_data(rng):
     inputs, outputs = initialize_filter(ConvergentFilter(), p=p, m=m, r=n_shocks, n=n)
     fn = pytensor.function(inputs, outputs, on_unused_input="ignore")
 
-    # The Assert op raises AssertionError at evaluation time
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="missing data"):
         fn(*vals)
 
 
@@ -590,13 +589,7 @@ def test_convergent_filter_singular_H_gradient_matches_standard(rng):
 
     out_std = build(StandardFilter())(*vals)
     out_conv = build(ConvergentFilter())(*vals)
-    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
-    symmetric = {"d_P0", "d_H", "d_Q"}
-    for name, s, c in zip(names, out_std, out_conv):
-        s, c = np.asarray(s, float), np.asarray(c, float)
-        if name in symmetric:
-            s, c = 0.5 * (s + s.T), 0.5 * (c + c.T)
-        assert_allclose(c, s, atol=ATOL, rtol=RTOL, err_msg=f"{name} mismatch for singular H")
+    assert_results_match(out_std, out_conv, GRAD_NAMES, err_prefix="singular H: ")
 
 
 def _make_local_level_system(n, rng):
@@ -635,8 +628,8 @@ def test_convergent_filter_local_level_matches_standard(rng):
 
     out_std = build(StandardFilter)(*vals)
     out_conv = build(ConvergentFilter)(*vals)
-    for s, c in zip(out_std, out_conv):
-        assert_allclose(np.asarray(c), np.asarray(s), atol=ATOL, rtol=RTOL)
+    for std, conv in zip(out_std, out_conv, strict=True):
+        assert_allclose(np.asarray(conv), np.asarray(std), atol=ATOL, rtol=RTOL)
 
 
 def test_convergent_filter_k_equals_n_gradient_matches_standard(rng):
@@ -654,10 +647,4 @@ def test_convergent_filter_k_equals_n_gradient_matches_standard(rng):
 
     out_std = build(StandardFilter())(*vals)
     out_conv = build(ConvergentFilter(tol=0.0))(*vals)
-    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
-    symmetric = {"d_P0", "d_H", "d_Q"}
-    for name, s, c in zip(names, out_std, out_conv):
-        s, c = np.asarray(s, float), np.asarray(c, float)
-        if name in symmetric:
-            s, c = 0.5 * (s + s.T), 0.5 * (c + c.T)
-        assert_allclose(c, s, atol=ATOL, rtol=RTOL)
+    assert_results_match(out_std, out_conv, GRAD_NAMES, err_prefix="tol=0: ")

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -597,3 +597,67 @@ def test_convergent_filter_singular_H_gradient_matches_standard(rng):
         if name in symmetric:
             s, c = 0.5 * (s + s.T), 0.5 * (c + c.T)
         assert_allclose(c, s, atol=ATOL, rtol=RTOL, err_msg=f"{name} mismatch for singular H")
+
+
+def _make_local_level_system(n, rng):
+    """A unit-root (non-stationary) but observable and controllable local level. Its Riccati
+    recursion still converges to a steady-state gain, so ConvergentFilter applies -- convergence
+    requires detectability and stabilizability, not stationarity."""
+    sigma_level, sigma_obs = 0.4, 0.7
+    T_np = np.array([[1.0]], dtype=floatX)
+    Z_np = np.array([[1.0]], dtype=floatX)
+    R_np = np.array([[1.0]], dtype=floatX)
+    Q_np = np.array([[sigma_level**2]], dtype=floatX)
+    H_np = np.array([[sigma_obs**2]], dtype=floatX)
+    c_np = np.zeros(1, dtype=floatX)
+    d_np = np.zeros(1, dtype=floatX)
+    a0_np = np.zeros(1, dtype=floatX)
+    P0_np = np.array([[1.0]], dtype=floatX)
+    level = rng.standard_normal()
+    data_np = np.empty((n, 1), dtype=floatX)
+    for t in range(n):
+        level = level + sigma_level * rng.standard_normal()
+        data_np[t] = level + sigma_obs * rng.standard_normal()
+    return [data_np, a0_np, P0_np, c_np, d_np, T_np, Z_np, R_np, H_np, Q_np]
+
+
+def test_convergent_filter_local_level_matches_standard(rng):
+    """A unit-root local level converges to a steady-state gain. ConvergentFilter forward outputs
+    and gradients should match StandardFilter even though the system is non-stationary."""
+    n = 250
+    vals = _make_local_level_system(n, rng)
+
+    def build(filter_cls):
+        inputs, outputs = initialize_filter(filter_cls(), p=1, m=1, r=1, n=n)
+        ll_obs = outputs[-1]
+        grads = pt.grad(ll_obs.sum(), inputs[1:])
+        return pytensor.function(inputs, [*outputs, *grads], on_unused_input="ignore")
+
+    out_std = build(StandardFilter)(*vals)
+    out_conv = build(ConvergentFilter)(*vals)
+    for s, c in zip(out_std, out_conv):
+        assert_allclose(np.asarray(c), np.asarray(s), atol=ATOL, rtol=RTOL)
+
+
+def test_convergent_filter_k_equals_n_gradient_matches_standard(rng):
+    """With tol=0 the until clause never fires, so k == n and the post-convergence tail is empty.
+    The forward reduces to a plain Kalman pass and the gradient (an empty tail backward plus the
+    autodiff pre-convergence backward) must still match StandardFilter."""
+    m, p, n_shocks, n = 4, 2, 4, 40
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+
+    def build(kfilter):
+        inputs, outputs = initialize_filter(kfilter, p=p, m=m, r=n_shocks, n=n)
+        loss = outputs[-1].sum()
+        grads = pt.grad(loss, inputs[1:])
+        return pytensor.function(inputs, [loss, *grads], on_unused_input="ignore")
+
+    out_std = build(StandardFilter())(*vals)
+    out_conv = build(ConvergentFilter(tol=0.0))(*vals)
+    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
+    symmetric = {"d_P0", "d_H", "d_Q"}
+    for name, s, c in zip(names, out_std, out_conv):
+        s, c = np.asarray(s, float), np.asarray(c, float)
+        if name in symmetric:
+            s, c = 0.5 * (s + s.T), 0.5 * (c + c.T)
+        assert_allclose(c, s, atol=ATOL, rtol=RTOL)

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -640,9 +640,9 @@ def test_convergent_filter_local_level_matches_standard(rng):
 
 
 def test_convergent_filter_k_equals_n_gradient_matches_standard(rng):
-    """With tol=0 the until clause never fires, so k == n and the post-convergence tail is empty.
-    The forward reduces to a plain Kalman pass and the gradient (an empty tail backward plus the
-    autodiff pre-convergence backward) must still match StandardFilter."""
+    """With tol=0 the until clause never fires, so the Riccati never converges. The split is then
+    capped at n-1 (a one-step tail -- a single tail step is exactly the Kalman step), and the
+    gradient of this degenerate no-convergence case must still match StandardFilter."""
     m, p, n_shocks, n = 4, 2, 4, 40
     vals = _make_stationary_system(m, p, n_shocks, n, rng)
 

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -15,6 +15,7 @@ from pymc_extras.statespace.filters import (
     UnivariateFilter,
 )
 from pymc_extras.statespace.filters.kalman_filter import BaseFilter
+from pymc_extras.statespace.utils.constants import MISSING_FILL
 from tests.statespace.shared_fixtures import (  # pylint: disable=unused-import
     rng,
 )
@@ -552,3 +553,20 @@ def test_convergent_filter_asserts_nan_symbolic_data(rng):
     # The Assert op raises AssertionError at evaluation time
     with pytest.raises(AssertionError):
         fn(*vals)
+
+
+def test_convergent_filter_rejects_missing_fill_sentinel(rng):
+    """The statespace core replaces NaN with missing_fill_value before the filter runs, so the
+    sentinel -- not just NaN -- must be rejected. This mirrors the real PyMC path, where data is a
+    shared variable holding the pre-filled values."""
+    m, p, n_shocks, n = 3, 2, 3, 30
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+    data_np = vals[0].copy()
+    data_np[5, 0] = MISSING_FILL  # a missing observation, pre-filled by the statespace core
+    shared_data = pytensor.shared(data_np, name="data")
+
+    _, a0, P0, c, d, T, Z, R, H, Q = (pt.as_tensor_variable(v) for v in vals)
+    with pytest.raises(ValueError, match="missing data"):
+        ConvergentFilter().build_graph(
+            pt.as_tensor_variable(shared_data), a0, P0, c, d, T, Z, R, H, Q
+        )

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -570,3 +570,30 @@ def test_convergent_filter_rejects_missing_fill_sentinel(rng):
         ConvergentFilter().build_graph(
             pt.as_tensor_variable(shared_data), a0, P0, c, d, T, Z, R, H, Q
         )
+
+
+def test_convergent_filter_singular_H_gradient_matches_standard(rng):
+    """A measurement-error-free model has singular H. The tail backward routes its one H-coupled
+    term through F^{-1}, so every gradient -- d_H included -- matches StandardFilter even when H is
+    singular."""
+    m, p, n_shocks, n = 4, 3, 4, 120
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+    # Perfectly observe one series: zero its measurement-noise row and column.
+    vals[8][0, :] = 0.0
+    vals[8][:, 0] = 0.0
+
+    def build(kfilter):
+        inputs, outputs = initialize_filter(kfilter, p=p, m=m, r=n_shocks, n=n)
+        loss = outputs[-1].sum()
+        grads = pt.grad(loss, inputs[1:])
+        return pytensor.function(inputs, [loss, *grads], on_unused_input="ignore")
+
+    out_std = build(StandardFilter())(*vals)
+    out_conv = build(ConvergentFilter())(*vals)
+    names = ["loss", "d_a0", "d_P0", "d_c", "d_d", "d_T", "d_Z", "d_R", "d_H", "d_Q"]
+    symmetric = {"d_P0", "d_H", "d_Q"}
+    for name, s, c in zip(names, out_std, out_conv):
+        s, c = np.asarray(s, float), np.asarray(c, float)
+        if name in symmetric:
+            s, c = 0.5 * (s + s.T), 0.5 * (c + c.T)
+        assert_allclose(c, s, atol=ATOL, rtol=RTOL, err_msg=f"{name} mismatch for singular H")

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -648,3 +648,33 @@ def test_convergent_filter_k_equals_n_gradient_matches_standard(rng):
     out_std = build(StandardFilter())(*vals)
     out_conv = build(ConvergentFilter(tol=0.0))(*vals)
     assert_results_match(out_std, out_conv, GRAD_NAMES, err_prefix="tol=0: ")
+
+
+def test_convergent_filter_builds_and_runs_at_float32(rng):
+    """The filter follows ``pytensor.config.floatX``; nothing in its graph is pinned to float64."""
+    m, p, n_shocks, n = 3, 2, 3, 60
+    vals = _make_stationary_system(m, p, n_shocks, n, rng)
+
+    with pytensor.config.change_flags(floatX="float32"):
+        dtype = pytensor.config.floatX
+        shapes = {
+            "data": (n, p),
+            "a0": (m,),
+            "P0": (m, m),
+            "c": (m,),
+            "d": (p,),
+            "T": (m, m),
+            "Z": (p, m),
+            "R": (m, n_shocks),
+            "H": (p, p),
+            "Q": (n_shocks, n_shocks),
+        }
+        inputs = [pt.tensor(name, dtype=dtype, shape=shape) for name, shape in shapes.items()]
+
+        *_, ll_obs = ConvergentFilter().build_graph(*inputs)
+        loss = ll_obs.sum()
+        fn = pytensor.function(inputs, [loss, *pt.grad(loss, inputs[1:])], on_unused_input="ignore")
+
+    results = fn(*[np.asarray(v, dtype=dtype) for v in vals])
+    for name, value in zip(GRAD_NAMES, results, strict=True):
+        assert np.all(np.isfinite(value)), f"{name} is not finite at float32"


### PR DESCRIPTION
Closes #394
Related to #332 

For certain classes of models, the latent state covariance matrix estimated by the Kalman Filter converges to a fixed point, after which is is no longer necessary to compute via expensive linear algebra. This PR adds a new filter, `ConvergentFIlter`, that exploits this property. To take advantage, a model must:

- Have no missing values, and
- No time varying matrices

The `ConvergentFilter` uses a `while` scan, so this cannot be used with jax. All timings are done with numba.

These break the convergence assumptions. But nothing else is required. If these criteria are met, we get big speedups. Here is a table of models, where `n` is the number of timesteps, `m` is the number of hidden states, `p` is the number of observed states, and `r` is the number of shocks. The biggest speedups come from long time series, where there is more iterations in the compute-saving post-convergence scan. Here are some timings for the compiled `logp_dlogp` function for models taken from the example notebooks:

| Model                              | Shape (m, p, r) | n    | StandardFilter | ConvergentFilter | Speedup |
|------------------------------------|-----------------|------|----------------|------------------|---------|
| VARMAX(2,0) 5-obs                  | (10, 5, 5)      | 200  | 3.4            | 1.3              | 2.5x    |
| VARMAX(2,0) 5-obs                  | (10, 5, 5)      | 1000 | 17.2           | 5.1              | 3.4x    |
| VARMAX(2,0) 5-obs                  | (10, 5, 5)      | 5000 | 96.0           | 26.6             | 3.6x    |
| SARIMAX(1,0,1)                     | (2, 1, 1)       | 200  | 1.1            | 0.6              | 1.9x    |
| SARIMAX(1,0,1)                     | (2, 1, 1)       | 1000 | 5.4            | 2.1              | 2.6x    |
| SARIMAX(1,0,1)                     | (2, 1, 1)       | 5000 | 27.9           | 10.1             | 2.8x    |
| SARIMAX(2,1,2)(2,0,2,12)           | (28, 1, 1)      | 200  | 5.7            | 3.1              | 1.8x    |
| SARIMAX(2,1,2)(2,0,2,12)           | (28, 1, 1)      | 1000 | 30.7           | 14.8             | 2.1x    |
| SARIMAX(2,1,2)(2,0,2,12)           | (28, 1, 1)      | 5000 | 153.7          | 63.9             | 2.4x    |
| ETS(A,Ad,A,12)                     | (15, 1, 1)      | 200  | 3.4            | 1.8              | 1.9x    |
| ETS(A,Ad,A,12)                     | (15, 1, 1)      | 1000 | 17.6           | 6.4              | 2.8x    |
| ETS(A,Ad,A,12)                     | (15, 1, 1)      | 5000 | 90.7           | 33.6             | 2.7x    |
| DFM 1-factor 2-lag 4-obs           | (10, 4, 5)      | 200  | 2.9            | 1.5              | 1.9x    |
| DFM 1-factor 2-lag 4-obs           | (10, 4, 5)      | 1000 | 15.6           | 4.9              | 3.2x    |
| DFM 1-factor 2-lag 4-obs           | (10, 4, 5)      | 5000 | 78.3           | 24.8             | 3.2x    |
| Structural LvlTrend+FreqSeas (airpass) | (14, 1, 14) | 200  | 2.5            | 1.5              | 1.7x    |
| Structural LvlTrend+FreqSeas (airpass) | (14, 1, 14) | 1000 | 12.8           | 4.6              | 2.8x    |
| Structural LvlTrend+FreqSeas (airpass) | (14, 1, 14) | 5000 | 66.5           | 23.3             | 2.9x    |


Special thanks to @JeanVanDyk, who derived components of the closed forms used in the handoff step between the two scans. I tried using the full analytic forms he worked out end-to-end, but it was slower than autodiff, I believe because of the number of matmuls involved. It might be faster on GPU, so I want to revist that again at some point.