### PR TITLE
Representation simplification

### DIFF
--- a/pymc_extras/statespace/core/compile.py
+++ b/pymc_extras/statespace/core/compile.py
@@ -5,7 +5,7 @@ import pytensor.tensor as pt
 
 from pymc_extras.statespace.core import PyMCStateSpace
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
-from pymc_extras.statespace.utils.constants import SHORT_NAME_TO_LONG
+from pymc_extras.statespace.utils.constants import LONG_NAME_TO_SHORT
 
 
 def compile_statespace(
@@ -16,11 +16,7 @@ def compile_statespace(
 
     x0, _, c, d, T, Z, R, H, Q = statespace_model._unpack_statespace_with_placeholders()
 
-    sequence_names = [x.name for x in [c, d] if x.ndim == 2]
-    sequence_names += [x.name for x in [T, Z, R, H, Q] if x.ndim == 3]
-
-    rename_dict = {v: k for k, v in SHORT_NAME_TO_LONG.items()}
-    sequence_names = list(map(rename_dict.get, sequence_names))
+    sequence_names = [LONG_NAME_TO_SHORT[name] for name in statespace_model.ssm.time_varying_names]
 
     P0 = pt.zeros((x0.shape[0], x0.shape[0]))
 

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -7,20 +7,19 @@ import pytensor.tensor as pt
 floatX = pytensor.config.floatX
 KeyLike = tuple[str | int, ...] | str
 
-# core_ndim: number of trailing dims that define the matrix's "core" shape (1 for vectors,
-# 2 for matrices). Anything stored to the left of those dims is interpreted as a time and/or
-# batch dim by downstream consumers; the representation does not try to distinguish them.
-# time_varying: False rules out leading dims entirely (used for x0 and P0).
-_MATRIX_SPECS: dict[str, tuple[int, bool]] = {
-    "design": (2, True),
-    "obs_intercept": (1, True),
-    "obs_cov": (2, True),
-    "transition": (2, True),
-    "state_intercept": (1, True),
-    "selection": (2, True),
-    "state_cov": (2, True),
-    "initial_state": (1, False),
-    "initial_state_cov": (2, False),
+# Number of trailing dims that define each matrix's "core" shape (1 for vectors, 2 for
+# matrices). Anything to the left is a time and/or batch dim; downstream consumers
+# distinguish them by consulting ``Representation.time_varying_names``.
+_CORE_NDIM: dict[str, int] = {
+    "design": 2,
+    "obs_intercept": 1,
+    "obs_cov": 2,
+    "transition": 2,
+    "state_intercept": 1,
+    "selection": 2,
+    "state_cov": 2,
+    "initial_state": 1,
+    "initial_state_cov": 2,
 }
 
 
@@ -99,9 +98,18 @@ class PytensorRepresentation:
     | ``state_cov``       | ``(r, r)``              |
     +---------------------+-------------------------+
 
-    Any matrix except :math:`\bar x_0` and :math:`P_0` may carry a leading dim of length
-    ``n`` (the number of observations) to declare it time-varying. Downstream consumers
-    decide static vs. time-varying by reading ``stored.ndim``.
+    Any matrix may carry a leading dim of length ``n`` (the number of observations) to
+    make it time-varying. The model is responsible for declaring which matrices vary over
+    time via :meth:`declare_time_varying`; downstream consumers (filter, smoother, etc.)
+    read :attr:`time_varying_names` to dispatch.
+
+    .. warning::
+
+        The time dim must always be the **leftmost** axis of a time-varying matrix. The
+        Kalman filter scan iterates over axis 0, ``pm.Deterministic`` registration prepends
+        a ``TIME_DIM`` coord to the dim list, and forecast slicing reads ``matrix[n_train:]``
+        — all of these assume the time axis sits in front of the core dims. Optional batch
+        dims may sit even further left (``(*batch, time, *core)``).
 
     Examples
     --------
@@ -137,6 +145,7 @@ class PytensorRepresentation:
     """
 
     __slots__ = (
+        "_time_varying_names",
         "design",
         "initial_state",
         "initial_state_cov",
@@ -182,7 +191,9 @@ class PytensorRepresentation:
             "initial_state_cov": initial_state_cov,
         }
 
-        for name in _MATRIX_SPECS:
+        self._time_varying_names: set[str] = set()
+
+        for name in _CORE_NDIM:
             value = provided[name]
             if value is None:
                 tensor = pt.as_tensor_variable(
@@ -207,7 +218,7 @@ class PytensorRepresentation:
         }[name]
 
     def _validate_name(self, name: str) -> None:
-        if name not in _MATRIX_SPECS:
+        if name not in _CORE_NDIM:
             raise IndexError(f"{name!r} is an invalid state space matrix name")
 
     def _coerce(
@@ -215,11 +226,12 @@ class PytensorRepresentation:
     ) -> pt.TensorVariable:
         """Wrap ``value`` as a named TensorVariable after validating the trailing core dims.
 
-        Anything to the left of the core dims is accepted unchanged: ``core``,
-        ``(time, *core)``, ``(*batch, *core)``, or ``(*batch, time, *core)`` are all valid.
-        ``time_varying=False`` matrices reject any leading dim.
+        Anything to the left of the core dims is accepted unchanged -- ``core``,
+        ``(time, *core)``, ``(*batch, *core)``, and ``(*batch, time, *core)`` are all valid.
+        Whether a leading dim is "time" or "batch" is the model's decision, recorded via
+        ``declare_time_varying``; the rep itself does not guess.
         """
-        core_ndim, time_varying = _MATRIX_SPECS[name]
+        core_ndim = _CORE_NDIM[name]
         core_shape = self._core_shape(name)
 
         if isinstance(value, np.ndarray):
@@ -235,28 +247,30 @@ class PytensorRepresentation:
                 f"{name} must have at least {core_ndim} dimension(s); got ndim={tensor.ndim}"
             )
 
-        if not time_varying and tensor.ndim != core_ndim:
-            raise ValueError(
-                f"{name} is never time-varying; expected ndim={core_ndim}, got ndim={tensor.ndim}"
-            )
-
         trailing = tensor.type.shape[-core_ndim:]
         for got, want in zip(trailing, core_shape, strict=True):
-            # Static-None means the dim is unknown until runtime; allow it.
+            # A None entry in ``tensor.type.shape`` is a runtime-only dim (pytensor doesn't
+            # know its size at graph time). Skip; let it fail at runtime if wrong.
             if got is not None and got != want:
                 raise ValueError(f"Trailing dims of {name} are {trailing}, expected {core_shape}")
 
         return tensor
 
-    def is_time_varying(self, name: str) -> bool:
-        """Return True iff the stored tensor has a leading dim beyond its core shape."""
-        self._validate_name(name)
-        return getattr(self, name).ndim > _MATRIX_SPECS[name][0]
+    @property
+    def time_varying_names(self) -> frozenset[str]:
+        """Names of matrices the model declared as time-varying.
 
-    def core_ndim(self, name: str) -> int:
-        """Return the number of trailing dims that define ``name``'s core shape."""
-        self._validate_name(name)
-        return _MATRIX_SPECS[name][0]
+        The Kalman filter iterates over the leading dim of these tensors at scan time;
+        all other matrices are passed in as scan non-sequences (i.e. used unchanged at
+        every step).
+        """
+        return frozenset(self._time_varying_names)
+
+    def declare_time_varying(self, *names: str) -> None:
+        """Mark matrices as time-varying. The filter will iterate over the leading dim."""
+        for name in names:
+            self._validate_name(name)
+            self._time_varying_names.add(name)
 
     def __getitem__(self, key: KeyLike) -> pt.TensorVariable:
         if isinstance(key, str):

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -4,152 +4,136 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pymc_extras.statespace.utils.constants import (
-    NEVER_TIME_VARYING,
-    VECTOR_VALUED,
-)
-
 floatX = pytensor.config.floatX
 KeyLike = tuple[str | int, ...] | str
+
+# core_ndim: number of trailing dims that define the matrix's "core" shape (1 for vectors,
+# 2 for matrices). Anything stored to the left of those dims is interpreted as a time and/or
+# batch dim by downstream consumers; the representation does not try to distinguish them.
+# time_varying: False rules out leading dims entirely (used for x0 and P0).
+_MATRIX_SPECS: dict[str, tuple[int, bool]] = {
+    "design": (2, True),
+    "obs_intercept": (1, True),
+    "obs_cov": (2, True),
+    "transition": (2, True),
+    "state_intercept": (1, True),
+    "selection": (2, True),
+    "state_cov": (2, True),
+    "initial_state": (1, False),
+    "initial_state_cov": (2, False),
+}
 
 
 class PytensorRepresentation:
     r"""
-    Core class to hold all objects required by linear gaussian statespace models
+    Container for the nine state-space matrices of a linear Gaussian model.
 
-    Notation for the linear statespace model is taken from [1], while the specific implementation is adapted from
-    the statsmodels implementation: https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/statespace/representation.py
-    described in [2].
+    Each matrix is stored in its *natural* shape: ``core_shape`` if static, or
+    ``(time, *core_shape)`` if time-varying. Optional leading batch dims are accepted and
+    propagate untouched -- use ``vectorize_graph`` if a downstream consumer needs to lift
+    over them.
 
     Parameters
     ----------
-    k_endog: int
-        Number of observed states (called "endogeous states" in statsmodels)
-    k_states: int
-        Number of hidden states
-    k_posdef: int
-        Number of states that have exogenous shocks; also the rank of the selection matrix R.
-    design: ArrayLike, optional
-        Design matrix, denoted 'Z' in [1].
-    obs_intercept: ArrayLike, optional
-        Constant vector in the observation equation, denoted 'd' in [1]. Currently
-        not used.
-    obs_cov: ArrayLike, optional
-        Covariance matrix for multivariate-normal errors in the observation equation. Denoted 'H' in
-        [1].
-    transition: ArrayLike, optional
-        Transition equation that updates the hidden state between time-steps. Denoted 'T' in [1].
-    state_intercept: ArrayLike, optional
-        Constant vector for the observation equation, denoted 'c' in [1]. Currently not used.
-    selection: ArrayLike, optional
-        Selection matrix that matches shocks to hidden states, denoted 'R' in [1]. This is the identity
-        matrix when k_posdef = k_states.
-    state_cov: ArrayLike, optional
-        Covariance matrix for state equations, denoted 'Q' in [1]. Null matrix when there is no observation
-        noise.
-    initial_state: ArrayLike, optional
-        Experimental setting to allow for Bayesian estimation of the initial state, denoted `alpha_0` in [1]. Default
-        It should potentially be removed in favor of the closed-form diffuse initialization.
-    initial_state_cov: ArrayLike, optional
-        Experimental setting to allow for Bayesian estimation of the initial state, denoted `P_0` in [1]. Default
-        It should potentially be removed in favor of the closed-form diffuse initialization.
+    k_endog : int
+        Number of observed states.
+    k_states : int
+        Number of hidden states.
+    k_posdef : int, optional
+        Rank of the selection matrix :math:`R`; also the number of stochastic shocks. Default
+        ``k_states``.
+    design : array_like, optional
+        Initial value for the design matrix :math:`Z`.
+    obs_intercept : array_like, optional
+        Initial value for :math:`d`.
+    obs_cov : array_like, optional
+        Initial value for the observation noise covariance :math:`H`.
+    transition : array_like, optional
+        Initial value for the transition matrix :math:`T`.
+    state_intercept : array_like, optional
+        Initial value for :math:`c`.
+    selection : array_like, optional
+        Initial value for the selection matrix :math:`R`.
+    state_cov : array_like, optional
+        Initial value for the state innovation covariance :math:`Q`.
+    initial_state : array_like, optional
+        Initial value for :math:`\bar x_0`.
+    initial_state_cov : array_like, optional
+        Initial value for :math:`P_0`.
 
     Notes
     -----
-    A linear statespace system is defined by two equations:
+    A linear state-space system has
 
     .. math::
         \begin{align}
-            x_t &= A_t x_{t-1} + c_t + R_t \varepsilon_t \tag{1} \\
-            y_t &= Z_t x_t + d_t + \eta_t \tag{2} \\
+            x_t &= T_t x_{t-1} + c_t + R_t \varepsilon_t \\
+            y_t &= Z_t x_t + d_t + \eta_t \\
+            \varepsilon_t &\sim N(0, Q_t) \\
+            \eta_t &\sim N(0, H_t) \\
+            x_0 &\sim N(\bar x_0, P_0)
         \end{align}
 
-    Where :math:`\{x_t\}_{t=0}^T` is a trajectory of hidden states, and :math:`\{y_t\}_{t=0}^T` is a trajectory of
-    observable states. Equation 1 is known as the "state transition equation", while describes how the system evolves
-    over time. Equation 2 is the "observation equation", and maps the latent state processes to observed data.
-    The system is Gaussian when the innovations, :math:`\varepsilon_t`, and the measurement errors, :math:`\eta_t`,
-    are normally distributed. The definition is completed by specification of these distributions, as
-    well as an initial state distribution:
+    with hidden state size :math:`m = k_{\text{states}}`, observed size :math:`p = k_{\text{endog}}`,
+    and shock rank :math:`r = k_{\text{posdef}}`. The natural per-matrix shapes are
 
-    .. math::
-        \begin{align}
-            \varepsilon_t &\sim N(0, Q_t) \tag{3} \\
-            \eta_t &\sim N(0, H_t) \tag{4} \\
-            x_0 &\sim N(\bar{x}_0, P_0) \tag{5}
-        \end{align}
+    +---------------------+-------------------------+
+    | Matrix              | Natural shape           |
+    +=====================+=========================+
+    | ``initial_state``   | ``(m,)``                |
+    +---------------------+-------------------------+
+    | ``initial_state_cov`` | ``(m, m)``            |
+    +---------------------+-------------------------+
+    | ``state_intercept`` | ``(m,)``                |
+    +---------------------+-------------------------+
+    | ``obs_intercept``   | ``(p,)``                |
+    +---------------------+-------------------------+
+    | ``transition``      | ``(m, m)``              |
+    +---------------------+-------------------------+
+    | ``design``          | ``(p, m)``              |
+    +---------------------+-------------------------+
+    | ``selection``       | ``(m, r)``              |
+    +---------------------+-------------------------+
+    | ``obs_cov``         | ``(p, p)``              |
+    +---------------------+-------------------------+
+    | ``state_cov``       | ``(r, r)``              |
+    +---------------------+-------------------------+
 
-    The 9 matrices that form equations 1 to 5 are summarized in the table below. We call :math:`N` the number of
-    observations, :math:`m` the number of hidden states, :math:`p` the number of observed states, and :math:`r` the
-    number of innovations.
-
-    +-----------------------------------+-------------------+-----------------------+
-    | Name                              | Symbol            | Shape                 |
-    +===================================+===================+=======================+
-    | Initial hidden state mean         | :math:`x_0`       | :math:`m \times 1`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Initial hidden state covariance   | :math:`P_0`       | :math:`m \times m`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Hidden state vector intercept     | :math:`c_t`       | :math:`m \times 1`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Observed state vector intercept   | :math:`d_t`       | :math:`p \times 1`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Transition matrix                 | :math:`T_t`       | :math:`m \times m`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Design matrix                     | :math:`Z_t`       | :math:`p \times m`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Selection matrix                  | :math:`R_t`       | :math:`m \times r`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Observation noise covariance      | :math:`H_t`       | :math:`p \times p`    |
-    +-----------------------------------+-------------------+-----------------------+
-    | Hidden state innovation covariance| :math:`Q_t`       | :math:`r \times r`    |
-    +-----------------------------------+-------------------+-----------------------+
-
-    The shapes listed above are the core shapes, but in the general case all of these matrices (except for :math:`x_0`
-    and :math:`P_0`) can be time varying. In this case, a time dimension of shape :math:`n`, equal to the number of
-    observations, can be added.
-
-    .. warning:: The time dimension is used as a batch dimension during kalman filtering, and must thus **always**
-                 be the **leftmost** dimension.
-
-    The purpose of this class is to store these matrices, as well as to allow users to easily index into them. Matrices
-    are stored as pytensor ``TensorVariables`` of known shape. Shapes are always accessible via the ``.type.shape``
-    method, which should never return ``None``. Matrices can be accessed via normal numpy array slicing after first
-    indexing by the name of the desired array. The time dimension is stored on the far left, and is automatically
-    sliced away unless specifically requested by the user. See the examples for details.
+    Any matrix except :math:`\bar x_0` and :math:`P_0` may carry a leading dim of length
+    ``n`` (the number of observations) to declare it time-varying. Downstream consumers
+    decide static vs. time-varying by reading ``stored.ndim``.
 
     Examples
     --------
+    Store and retrieve a transition matrix:
+
     .. code:: python
 
         from pymc_extras.statespace.core.representation import PytensorRepresentation
         ssm = PytensorRepresentation(k_endog=1, k_states=3, k_posdef=1)
+        ssm["transition"].type.shape
+        # (3, 3)
 
-        # Access matrices by their names
-        print(ssm['transition'].type.shape)
-        >>> (3, 3)
+    Set individual entries:
 
-        # Slice a matrices
-        print(ssm['observation_cov', 0, 0].eval())
-        >>> 0.0
+    .. code:: python
 
-        # Set elements in a slice of a matrix
-        ssm['design', 0, 0] = 1
-        print(ssm['design'].eval())
-        >>> np.array([[1, 0, 0]])
+        ssm["design", 0, 0] = 1.0
 
-        # Setting an entire matrix is also permitted. If you set a time dimension, it must be the first dimension, and
-        # the "core" dimensions must agree with those set when the ssm object was instantiated.
-        ssm['obs_intercept'] = np.arange(10).reshape(10, 1) # 10 timesteps
-        print(ssm['obs_intercept'].eval())
-        >>> np.array([[1.], [2.], [3.], [4.], [5.], [6.], [7.], [8.], [9.]])
+    Replace an entire matrix, optionally with a time dim:
+
+    .. code:: python
+
+        import numpy as np
+        ssm["obs_intercept"] = np.arange(10)[:, None]    # 10 timesteps, k_endog=1
+        ssm["obs_intercept"].type.shape
+        # (10, 1)
 
     References
     ----------
     .. [1] Durbin, James, and Siem Jan Koopman. 2012.
-        Time Series Analysis by State Space Methods: Second Edition.
-        Oxford University Press.
-    .. [2] Fulton, Chad. "Estimating time series models by state space methods in Python: Statsmodels." (2015).
-           http://www.chadfulton.com/files/fulton_statsmodels_2017_v1.pdf
+       Time Series Analysis by State Space Methods: Second Edition.
+       Oxford University Press.
     """
 
     __slots__ = (
@@ -162,7 +146,6 @@ class PytensorRepresentation:
         "obs_cov",
         "obs_intercept",
         "selection",
-        "shapes",
         "state_cov",
         "state_intercept",
         "transition",
@@ -172,267 +155,142 @@ class PytensorRepresentation:
         self,
         k_endog: int,
         k_states: int,
-        k_posdef: int,
-        design: np.ndarray | None = None,
-        obs_intercept: np.ndarray | None = None,
-        obs_cov=None,
-        transition=None,
-        state_intercept=None,
-        selection=None,
-        state_cov=None,
-        initial_state=None,
-        initial_state_cov=None,
+        k_posdef: int | None = None,
+        design: np.ndarray | pt.TensorVariable | None = None,
+        obs_intercept: np.ndarray | pt.TensorVariable | None = None,
+        obs_cov: np.ndarray | pt.TensorVariable | None = None,
+        transition: np.ndarray | pt.TensorVariable | None = None,
+        state_intercept: np.ndarray | pt.TensorVariable | None = None,
+        selection: np.ndarray | pt.TensorVariable | None = None,
+        state_cov: np.ndarray | pt.TensorVariable | None = None,
+        initial_state: np.ndarray | pt.TensorVariable | None = None,
+        initial_state_cov: np.ndarray | pt.TensorVariable | None = None,
     ) -> None:
-        self.k_states = k_states
         self.k_endog = k_endog
+        self.k_states = k_states
         self.k_posdef = k_posdef if k_posdef is not None else k_states
 
-        # The first dimension is for time varying matrices; it could be n_obs. Not thinking about that now.
-        self.shapes = {
-            "design": (1, self.k_endog, self.k_states),
-            "obs_intercept": (1, self.k_endog),
-            "obs_cov": (1, self.k_endog, self.k_endog),
-            "transition": (1, self.k_states, self.k_states),
-            "state_intercept": (1, self.k_states),
-            "selection": (1, self.k_states, self.k_posdef),
-            "state_cov": (1, self.k_posdef, self.k_posdef),
-            # These are never time varying, so they don't have a dummy first dimension
-            "initial_state": (self.k_states,),
-            "initial_state_cov": (self.k_states, self.k_states),
+        provided = {
+            "design": design,
+            "obs_intercept": obs_intercept,
+            "obs_cov": obs_cov,
+            "transition": transition,
+            "state_intercept": state_intercept,
+            "selection": selection,
+            "state_cov": state_cov,
+            "initial_state": initial_state,
+            "initial_state_cov": initial_state_cov,
         }
 
-        # Initialize the representation matrices
-        scope = locals()
-        for name, shape in self.shapes.items():
-            if scope[name] is not None:
-                matrix = scope[name]
-                if isinstance(matrix, np.ndarray):
-                    matrix = self._numpy_to_pytensor(name, matrix)
-                else:
-                    matrix = self._check_provided_tensor(name, matrix)
-                setattr(self, name, matrix)
-
-            else:
-                matrix = pt.as_tensor_variable(
-                    np.zeros(shape, dtype=floatX), name=name, ndim=len(shape)
+        for name in _MATRIX_SPECS:
+            value = provided[name]
+            if value is None:
+                tensor = pt.as_tensor_variable(
+                    np.zeros(self._core_shape(name), dtype=floatX), name=name
                 )
-                setattr(self, name, matrix)
+            else:
+                tensor = self._coerce(name, value)
+            setattr(self, name, tensor)
 
-    def _validate_key(self, key: KeyLike) -> None:
-        if key not in self.shapes:
-            raise IndexError(f"{key} is an invalid state space matrix name")
+    def _core_shape(self, name: str) -> tuple[int, ...]:
+        k_endog, k_states, k_posdef = self.k_endog, self.k_states, self.k_posdef
+        return {
+            "design": (k_endog, k_states),
+            "obs_intercept": (k_endog,),
+            "obs_cov": (k_endog, k_endog),
+            "transition": (k_states, k_states),
+            "state_intercept": (k_states,),
+            "selection": (k_states, k_posdef),
+            "state_cov": (k_posdef, k_posdef),
+            "initial_state": (k_states,),
+            "initial_state_cov": (k_states, k_states),
+        }[name]
 
-    def _update_shape(self, key: KeyLike, value: np.ndarray | pt.Variable) -> None:
-        if isinstance(value, pt.TensorConstant | pt.TensorVariable):
-            shape = value.type.shape
+    def _validate_name(self, name: str) -> None:
+        if name not in _MATRIX_SPECS:
+            raise IndexError(f"{name!r} is an invalid state space matrix name")
+
+    def _coerce(
+        self, name: str, value: np.ndarray | pt.TensorVariable | float | int
+    ) -> pt.TensorVariable:
+        """Wrap ``value`` as a named TensorVariable after validating the trailing core dims.
+
+        Anything to the left of the core dims is accepted unchanged: ``core``,
+        ``(time, *core)``, ``(*batch, *core)``, or ``(*batch, time, *core)`` are all valid.
+        ``time_varying=False`` matrices reject any leading dim.
+        """
+        core_ndim, time_varying = _MATRIX_SPECS[name]
+        core_shape = self._core_shape(name)
+
+        if isinstance(value, np.ndarray):
+            tensor = pt.as_tensor_variable(value.astype(floatX), name=name)
+        elif isinstance(value, int | float):
+            tensor = pt.as_tensor_variable(np.asarray(value, dtype=floatX), name=name)
         else:
-            shape = value.shape
+            tensor = pt.as_tensor_variable(value)
+            tensor.name = name
 
-        old_shape = self.shapes[key]
-        ndim_core = 1 if key in VECTOR_VALUED else 2
-        if not all([a == b for a, b in zip(shape[-ndim_core:], old_shape[-ndim_core:])]):
+        if tensor.ndim < core_ndim:
             raise ValueError(
-                f"The last two dimensions of {key} must be {old_shape[-ndim_core:]}, found {shape[-ndim_core:]}"
+                f"{name} must have at least {core_ndim} dimension(s); got ndim={tensor.ndim}"
             )
 
-        # Add time dimension dummy if none present
-        if key not in NEVER_TIME_VARYING:
-            if len(shape) == 2 and key not in VECTOR_VALUED:
-                shape = (1, *shape)
-            elif len(shape) == 1:
-                shape = (1, *shape)
+        if not time_varying and tensor.ndim != core_ndim:
+            raise ValueError(
+                f"{name} is never time-varying; expected ndim={core_ndim}, got ndim={tensor.ndim}"
+            )
 
-        self.shapes[key] = shape
+        trailing = tensor.type.shape[-core_ndim:]
+        for got, want in zip(trailing, core_shape, strict=True):
+            # Static-None means the dim is unknown until runtime; allow it.
+            if got is not None and got != want:
+                raise ValueError(f"Trailing dims of {name} are {trailing}, expected {core_shape}")
 
-    def _add_time_dim_to_slice(
-        self, name: str, slice_: list[int] | tuple[int], n_dim: int
-    ) -> tuple[int | slice, ...]:
-        # Case 1: There is never a time dim. No changes needed.
-        if name in NEVER_TIME_VARYING:
-            return slice_
+        return tensor
 
-        # Case 2: The matrix has a time dim, and it was requested. No changes needed.
-        if len(slice_) == n_dim:
-            return slice_
+    def is_time_varying(self, name: str) -> bool:
+        """Return True iff the stored tensor has a leading dim beyond its core shape."""
+        self._validate_name(name)
+        return getattr(self, name).ndim > _MATRIX_SPECS[name][0]
 
-        # Case 3: There's no time dim on the matrix, and none requested. Slice away the dummy dim.
-        if len(slice_) < n_dim:
-            empty_slice = (slice(None, None, None),)
-            n_omitted = n_dim - len(slice_) - 1
-            return (0,) + tuple(slice_) + empty_slice * n_omitted
-
-    @staticmethod
-    def _validate_key_and_get_type(key: KeyLike) -> type[str]:
-        if isinstance(key, tuple) and not isinstance(key[0], str):
-            raise IndexError("First index must the name of a valid state space matrix.")
-
-        return type(key)
-
-    def _validate_matrix_shape(self, name: str, X: np.ndarray | pt.TensorVariable) -> None:
-        time_dim, *expected_shape = self.shapes[name]
-        expected_shape = tuple(expected_shape)
-        shape = X.shape if isinstance(X, np.ndarray) else X.type.shape
-
-        is_vector = name in VECTOR_VALUED
-        not_time_varying = name in NEVER_TIME_VARYING
-
-        if not_time_varying:
-            if is_vector:
-                if X.ndim != 1:
-                    raise ValueError(
-                        f"Array provided for {name} has {X.ndim} dimensions, but it must have exactly 1."
-                    )
-
-            else:
-                if X.ndim != 2:
-                    raise ValueError(
-                        f"Array provided for {name} has {X.ndim} dimensions, but it must have exactly 2."
-                    )
-
-        else:
-            if is_vector:
-                if X.ndim not in [1, 2]:
-                    raise ValueError(
-                        f"Array provided for {name} has {X.ndim} dimensions, "
-                        f"expecting 1 (static) or 2 (time-varying)"
-                    )
-
-                # Time varying vector case, check only the static shapes
-                if X.ndim == 2 and X.shape[1:] != expected_shape:
-                    raise ValueError(
-                        f"Last dimension of array provided for {name} has shape {X.shape[1]}, "
-                        f"expected {expected_shape}"
-                    )
-
-            else:
-                if X.ndim not in [2, 3]:
-                    raise ValueError(
-                        f"Array provided for {name} has {X.ndim} dimensions, "
-                        f"expecting 2 (static) or 3 (time-varying)"
-                    )
-
-                # Time varying matrix case, check only the static shapes
-                if X.ndim == 3 and shape[1:] != expected_shape:
-                    raise ValueError(
-                        f"Last two dimensions of array provided for {name} have shapes {X.shape[1:]}, "
-                        f"expected {expected_shape}"
-                    )
-
-            # TODO: Think of another way to validate shapes of time-varying matrices if we don't know the data
-            #   when the PytensorRepresentation is recreated
-            # if X.shape[-1] != self.data.shape[0]:
-            #     raise ValueError(
-            #         f"Last dimension (time dimension) of array provided for {name} has shape "
-            #         f"{X.shape[-1]}, expected {self.data.shape[0]} (equal to the first dimension of the "
-            #         f"provided data)"
-            #     )
-
-    def _check_provided_tensor(self, name: str, X: pt.TensorVariable) -> pt.TensorVariable:
-        self._validate_matrix_shape(name, X)
-        if name not in NEVER_TIME_VARYING:
-            if X.ndim == 1 and name in VECTOR_VALUED:
-                X = pt.expand_dims(X, (0,))
-                X = pt.specify_shape(X, self.shapes[name])
-
-            elif X.ndim == 2:
-                X = pt.expand_dims(X, (0,))
-                X = pt.specify_shape(X, self.shapes[name])
-
-        return X
-
-    def _numpy_to_pytensor(self, name: str, X: np.ndarray) -> pt.TensorVariable:
-        X = X.copy()
-        self._validate_matrix_shape(name, X)
-
-        # Add a time dimension if one isn't provided
-        if name not in NEVER_TIME_VARYING:
-            if X.ndim == 1 and name in VECTOR_VALUED:
-                X = X[None, ...]
-            elif X.ndim == 2 and name not in VECTOR_VALUED:
-                X = X[None, ...]
-
-        X_pt = pt.as_tensor(X, name=name, dtype=floatX)
-        return X_pt
+    def core_ndim(self, name: str) -> int:
+        """Return the number of trailing dims that define ``name``'s core shape."""
+        self._validate_name(name)
+        return _MATRIX_SPECS[name][0]
 
     def __getitem__(self, key: KeyLike) -> pt.TensorVariable:
-        _type = self._validate_key_and_get_type(key)
+        if isinstance(key, str):
+            self._validate_name(key)
+            return getattr(self, key)
 
-        # Case 1: user asked for an entire matrix by name
-        if _type is str:
-            self._validate_key(key)
-            matrix = getattr(self, key)
+        if isinstance(key, tuple) and isinstance(key[0], str):
+            name, *idx = key
+            self._validate_name(name)
+            tensor = getattr(self, name)
+            if not idx:
+                return tensor
+            return tensor[tuple(idx)]
 
-            # Slice away the time dimension if it's a dummy
-            if (matrix.type.shape[0] == 1) and (key not in NEVER_TIME_VARYING):
-                X = matrix[(0,) + (slice(None),) * (matrix.ndim - 1)]
-                X = pt.specify_shape(X, self.shapes[key][1:])
-                X.name = key
+        raise IndexError("First index must the name of a valid state space matrix.")
 
-                return X
+    def __setitem__(
+        self, key: KeyLike, value: float | int | np.ndarray | pt.TensorVariable
+    ) -> None:
+        if isinstance(key, str):
+            self._validate_name(key)
+            setattr(self, key, self._coerce(key, value))
+            return
 
-            # If it's never time varying, return everything
-            elif key in NEVER_TIME_VARYING:
-                return matrix
+        if isinstance(key, tuple) and isinstance(key[0], str):
+            name, *idx = key
+            self._validate_name(name)
+            existing = getattr(self, name)
+            updated = pt.set_subtensor(existing[tuple(idx)], value)
+            updated.name = name
+            setattr(self, name, updated)
+            return
 
-            # Last possibility is that it's time varying -- also return everything (for now, might need some processing)
-            else:
-                return matrix
+        raise IndexError("First index must the name of a valid state space matrix.")
 
-        # Case 2: user asked for a particular matrix and some slices of it
-        elif _type is tuple:
-            name, *slice_ = key
-            slice_ = tuple(slice_)
-            self._validate_key(name)
-
-            matrix = getattr(self, name)
-            # Case 2a: The user asked for the whole matrix, with time dummies. Return the whole thing
-            # without slicing anything away
-            if slice_ == (slice(None, None, None),) * matrix.ndim:
-                return matrix
-
-            # Case 2b: The user asked for the whole matrix except time dummies. Ignore the slice and act like we're in
-            # case 1.
-            elif slice_ == (slice(None, None, None),) * (matrix.ndim - 1):
-                X = matrix[(0,) + (slice(None),) * (matrix.ndim - 1)]
-                X = pt.specify_shape(X, self.shapes[name][1:])
-                X.name = name
-                return X
-
-            # Case 3b: User asked for an arbitrary sub-matrix. Give it back -- nothing else to be done
-            slice_ = self._add_time_dim_to_slice(name, slice_, matrix.ndim)
-            return matrix[slice_]
-
-        # Case 3: There is only one slice index, but it's not a string
-        else:
-            raise IndexError("First index must the name of a valid state space matrix.")
-
-    def __setitem__(self, key: KeyLike, value: float | int | np.ndarray | pt.Variable) -> None:
-        _type = type(key)
-
-        # Case 1: key is a string: we are setting an entire matrix.
-        if _type is str:
-            self._validate_key(key)
-            if isinstance(value, np.ndarray):
-                value = self._numpy_to_pytensor(key, value)
-            else:
-                value.name = key
-
-            setattr(self, key, value)
-            self._update_shape(key, value)
-
-        # Case 2: key is a string plus a slice: we are setting a subset of a matrix
-        elif _type is tuple:
-            name, *slice_ = key
-            self._validate_key(name)
-
-            matrix = getattr(self, name)
-
-            slice_ = self._add_time_dim_to_slice(name, slice_, matrix.ndim)
-            matrix = pt.set_subtensor(matrix[slice_], value)
-            matrix = pt.specify_shape(matrix, self.shapes[name])
-            matrix.name = name
-
-            setattr(self, name, matrix)
-
-    def copy(self):
+    def copy(self) -> "PytensorRepresentation":
         return copy.copy(self)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -60,7 +60,6 @@ from pymc_extras.statespace.utils.constants import (
     SHOCK_DIM,
     SHORT_NAME_TO_LONG,
     TIME_DIM,
-    VECTOR_VALUED,
 )
 from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
 
@@ -967,15 +966,15 @@ class PyMCStateSpace:
 
         pm_mod = modelcontext(None)
         matrices = self.unpack_statespace()
+        time_varying_names = self.ssm.time_varying_names
 
         registered_matrices = []
         for i, (matrix, name) in enumerate(zip(matrices, MATRIX_NAMES)):
-            time_varying_ndim = 2 if name in VECTOR_VALUED else 3
             if not getattr(pm_mod, name, None):
                 shape, dims = self._get_matrix_shape_and_dims(name)
                 has_dims = dims is not None
 
-                if matrix.ndim == time_varying_ndim and has_dims:
+                if SHORT_NAME_TO_LONG[name] in time_varying_names and has_dims:
                     dims = (TIME_DIM, *dims)
 
                 x = pm.Deterministic(name, matrix, dims=dims)
@@ -1116,6 +1115,7 @@ class PyMCStateSpace:
             *self.unpack_statespace(),
             missing_fill_value=missing_fill_value,
             cov_jitter=cov_jitter,
+            time_varying_names=self.ssm.time_varying_names,
         )
 
         logp = filter_outputs.pop(-1)
@@ -1188,7 +1188,13 @@ class PyMCStateSpace:
             *_, T, Z, R, H, Q = matrices
 
             smooth_states, smooth_covariances = self.kalman_smoother.build_graph(
-                T, R, Q, filtered_states, filtered_covariances, cov_jitter=cov_jitter
+                T,
+                R,
+                Q,
+                filtered_states,
+                filtered_covariances,
+                cov_jitter=cov_jitter,
+                time_varying_names=self.ssm.time_varying_names,
             )
             smooth_states.name = "smooth_states"
             smooth_covariances.name = "smooth_covariances"
@@ -1311,6 +1317,7 @@ class PyMCStateSpace:
             R,
             H,
             Q,
+            time_varying_names=self.ssm.time_varying_names,
         )
 
         filter_outputs.pop(-1)
@@ -1320,7 +1327,12 @@ class PyMCStateSpace:
         filtered_covariances, predicted_covariances, _ = covariances
 
         [smoothed_states, smoothed_covariances] = self.kalman_smoother.build_graph(
-            T, R, Q, filtered_states, filtered_covariances
+            T,
+            R,
+            Q,
+            filtered_states,
+            filtered_covariances,
+            time_varying_names=self.ssm.time_varying_names,
         )
 
         grouped_outputs = [
@@ -1937,10 +1949,16 @@ class PyMCStateSpace:
                 R,
                 H,
                 Q,
+                time_varying_names=self.ssm.time_varying_names,
             )
 
             smoother_outputs = self.kalman_smoother.build_graph(
-                T, R, Q, filter_outputs[0], filter_outputs[3]
+                T,
+                R,
+                Q,
+                filter_outputs[0],
+                filter_outputs[3],
+                time_varying_names=self.ssm.time_varying_names,
             )
 
             filter_outputs = filter_outputs[:-1] + list(smoother_outputs)
@@ -2409,8 +2427,9 @@ class PyMCStateSpace:
                     )
 
             forecast_names = MATRIX_NAMES[2:]  # c, d, T, Z, R, H, Q
+            time_varying_names = self.ssm.time_varying_names
             forecast_matrices = [
-                m[n_train:] if m.ndim == (2 if name in VECTOR_VALUED else 3) else m
+                m[n_train:] if SHORT_NAME_TO_LONG[name] in time_varying_names else m
                 for m, name in zip(forecast_matrices, forecast_names)
             ]
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -2770,7 +2770,7 @@ class PyMCStateSpace:
             else:
                 shock_trajectory = pt.as_tensor_variable(shock_trajectory)
 
-            time_varying_T = T.ndim == 3
+            time_varying_T = "transition" in self.ssm.time_varying_names
 
             def irf_step(*args):
                 if time_varying_T:

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -173,35 +173,37 @@ class _LinearGaussianStateSpace(Continuous):
         H_.name = "H"
         Q_.name = "Q"
 
-        sequences = [
-            x
-            for x, name in zip([c_, d_, T_, Z_, R_, H_, Q_], ["c", "d", "T", "Z", "R", "H", "Q"])
-            if name in sequence_names
-        ]
-        non_sequences = [x for x in [c_, d_, T_, Z_, R_, H_, Q_] if x not in sequences]
+        # Partition the seven matrices into scan sequences and non-sequences while remembering
+        # each one's canonical position. The inner step rebuilds the canonical (c, d, T, Z, R, H, Q)
+        # ordering by index, so it never has to introspect names inside the scan body.
+        canonical = ["c", "d", "T", "Z", "R", "H", "Q"]
+        all_inputs = [c_, d_, T_, Z_, R_, H_, Q_]
+
+        sequences: list = []
+        non_sequences: list = []
+        seq_positions: list[int] = []
+        non_seq_positions: list[int] = []
+        for i, (x, name) in enumerate(zip(all_inputs, canonical, strict=True)):
+            if name in sequence_names:
+                sequences.append(x)
+                seq_positions.append(i)
+            else:
+                non_sequences.append(x)
+                non_seq_positions.append(i)
 
         rng = normalize_rng_param(rng)
 
-        def sort_args(args):
-            sorted_args = []
-
-            # Inside the scan, outputs_info variables get a time step appended to their name
-            # e.g. x -> x[t]. Remove this so we can identify variables by name.
-            arg_names = [x.name.replace("[t]", "") for x in args]
-
-            # c, d ,T, Z, R, H, Q is the "canonical" ordering
-            for name in ["c", "d", "T", "Z", "R", "H", "Q"]:
-                idx = arg_names.index(name)
-                sorted_args.append(args[idx])
-
-            return sorted_args
-
-        n_seq = len(sequence_names)
+        n_seq = len(sequences)
 
         def step_fn(*args):
             seqs, (rng, state, *non_seqs) = args[:n_seq], args[n_seq:]
 
-            c, d, T, Z, R, H, Q = sort_args((*seqs, *non_seqs))
+            ordered: list = [None] * len(canonical)
+            for src_idx, dst_idx in enumerate(seq_positions):
+                ordered[dst_idx] = seqs[src_idx]
+            for src_idx, dst_idx in enumerate(non_seq_positions):
+                ordered[dst_idx] = non_seqs[src_idx]
+            c, d, T, Z, R, H, Q = ordered
             k = T.shape[0]
             a = state[:k]
 

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -18,6 +18,7 @@ from pymc_extras.statespace.filters.utilities import (
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_NAMES,
     JITTER_DEFAULT,
+    LONG_NAME_TO_SHORT,
     MATRIX_NAMES,
     MISSING_FILL,
 )
@@ -150,6 +151,7 @@ class BaseFilter(ABC):
         Q,
         missing_fill_value=None,
         cov_jitter=None,
+        time_varying_names=(),
     ) -> list[TensorVariable]:
         """
         Construct the computation graph for the Kalman filter. See [1] for details.
@@ -200,8 +202,11 @@ class BaseFilter(ABC):
 
         data, a0, P0, *params = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)
         data = pt.specify_shape(data, (data.type.shape[0], self.n_endog))
+        # ``time_varying_names`` is keyed on long names ("transition", ...) but the filter
+        # tracks ordering with the short single-letter names. Translate.
+        time_varying_short = {LONG_NAME_TO_SHORT[n] for n in time_varying_names}
         sequences, non_sequences, seq_names, non_seq_names = split_vars_into_seq_and_nonseq(
-            params, PARAM_NAMES
+            params, PARAM_NAMES, time_varying_short
         )
 
         self.seq_names = seq_names

--- a/pymc_extras/statespace/filters/kalman_smoother.py
+++ b/pymc_extras/statespace/filters/kalman_smoother.py
@@ -6,7 +6,7 @@ from pymc_extras.statespace.filters.utilities import (
     split_vars_into_seq_and_nonseq,
     stabilize,
 )
-from pymc_extras.statespace.utils.constants import JITTER_DEFAULT
+from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, LONG_NAME_TO_SHORT
 
 
 class KalmanSmoother:
@@ -60,7 +60,14 @@ class KalmanSmoother:
         return a, P, a_smooth, P_smooth, T, R, Q
 
     def build_graph(
-        self, T, R, Q, filtered_states, filtered_covariances, cov_jitter=JITTER_DEFAULT
+        self,
+        T,
+        R,
+        Q,
+        filtered_states,
+        filtered_covariances,
+        cov_jitter=JITTER_DEFAULT,
+        time_varying_names=(),
     ):
         self.cov_jitter = cov_jitter
 
@@ -69,8 +76,9 @@ class KalmanSmoother:
         a_last = pt.specify_shape(filtered_states[-1], (k,))
         P_last = pt.specify_shape(filtered_covariances[-1], (k, k))
 
+        time_varying_short = {LONG_NAME_TO_SHORT[n] for n in time_varying_names}
         sequences, non_sequences, seq_names, non_seq_names = split_vars_into_seq_and_nonseq(
-            [T, R, Q], ["T", "R", "Q"]
+            [T, R, Q], ["T", "R", "Q"], time_varying_short
         )
 
         self.seq_names = seq_names

--- a/pymc_extras/statespace/filters/utilities.py
+++ b/pymc_extras/statespace/filters/utilities.py
@@ -1,41 +1,34 @@
+from collections.abc import Iterable
+
 import pytensor.tensor as pt
 
-from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, NEVER_TIME_VARYING, VECTOR_VALUED
+from pymc_extras.statespace.utils.constants import JITTER_DEFAULT
 
 
-def decide_if_x_time_varies(x, name):
-    if name in NEVER_TIME_VARYING:
-        return False
+def split_vars_into_seq_and_nonseq(params, param_names, time_varying_names: Iterable[str]):
+    """Split filter inputs into scan sequences and non-sequences.
 
-    ndim = x.ndim
+    Parameters
+    ----------
+    params : sequence of TensorVariable
+        Filter input matrices in the order given by ``param_names``.
+    param_names : sequence of str
+        Long names of the matrices in ``params``.
+    time_varying_names : iterable of str
+        Names of matrices the model declared as time-varying. Anything in this set is
+        treated as a scan sequence; everything else is a non-sequence.
 
-    if name in VECTOR_VALUED:
-        if ndim not in [1, 2]:
-            raise ValueError(
-                f"Vector {name} has {ndim} dimensions; it should have either 1 (static),"
-                f" or 2 (time varying )"
-            )
-
-        return ndim == 2
-
-    if ndim not in [2, 3]:
-        raise ValueError(
-            f"Matrix {name} has {ndim} dimensions; it should have either"
-            f" 2 (static), or 3 (time varying)."
-        )
-
-    return ndim == 3
-
-
-def split_vars_into_seq_and_nonseq(params, param_names):
+    Returns
+    -------
+    sequences, non_sequences, seq_names, non_seq_names : four lists
+        The split inputs and their names.
     """
-    Split inputs into those that are time varying and those that are not. This division is required by scan.
-    """
+    time_varying_names = frozenset(time_varying_names)
     sequences, non_sequences = [], []
     seq_names, non_seq_names = [], []
 
     for param, name in zip(params, param_names):
-        if decide_if_x_time_varies(param, name):
+        if name in time_varying_names:
             sequences.append(param)
             seq_names.append(name)
         else:

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -646,6 +646,8 @@ class BayesianDynamicFactor(PyMCStateSpace):
             design_matrix = pt.concatenate([design_matrix_time, Z_exog], axis=2)
 
         self.ssm["design"] = design_matrix
+        if self.exog_flag:
+            self.ssm.declare_time_varying("design")
 
         # Transition matrix (T)
         # Construction with block-diagonal structure:

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -583,6 +583,7 @@ class BayesianSARIMAX(PyMCStateSpace):
             )
 
             self.ssm["obs_intercept"] = (exog_data @ exog_beta)[:, None]
+            self.ssm.declare_time_varying("obs_intercept")
 
         # Set up the state covariance matrix
         state_cov_idx = ("state_cov", *np.diag_indices(self.k_posdef))

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -513,6 +513,7 @@ class BayesianVARMAX(PyMCStateSpace):
                 raise NotImplementedError()
 
             self.ssm["obs_intercept"] = obs_intercept
+            self.ssm.declare_time_varying("obs_intercept")
 
         if self.stationary_initialization:
             # Solve for matrix quadratic for P0

--- a/pymc_extras/statespace/models/structural/components/regression.py
+++ b/pymc_extras/statespace/models/structural/components/regression.py
@@ -250,6 +250,7 @@ class Regression(Component):
             self.ssm["design"] = pt.specify_shape(
                 Z, (None, k_endog, regression_data.type.shape[1] * k_endog)
             )
+        self.ssm.declare_time_varying("design")
 
         if self.innovations:
             sigma_beta = self.make_and_register_variable(

--- a/pymc_extras/statespace/models/structural/components/seasonality.py
+++ b/pymc_extras/statespace/models/structural/components/seasonality.py
@@ -590,6 +590,7 @@ class TimeSeasonality(Component):
         T = self._build_transition_matrix()
         if T.ndim == 3:
             self.ssm["transition"] = T
+            self.ssm.declare_time_varying("transition")
         else:
             self.ssm["transition", :, :] = T
 

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -239,11 +239,12 @@ class StructuralTimeSeries(PyMCStateSpace):
         self.ssm = ssm.copy()
 
         if k_posdef == 0:
+            # Components without shocks degrade to a one-shock placeholder so the filter has
+            # consistent dims; the placeholder selection/state_cov are zero, so the shock has
+            # no effect.
             self.ssm.k_posdef = self.k_posdef
-            self.ssm.shapes["state_cov"] = (1, 1, 1)
-            self.ssm["state_cov"] = pt.zeros((1, 1, 1))
-            self.ssm.shapes["selection"] = (1, self.k_states, 1)
-            self.ssm["selection"] = pt.zeros((1, self.k_states, 1))
+            self.ssm["state_cov"] = pt.zeros((1, 1))
+            self.ssm["selection"] = pt.zeros((self.k_states, 1))
 
         P0 = self.make_and_register_variable("P0", shape=(self.k_states, self.k_states))
         self.ssm["initial_state_cov"] = P0
@@ -824,25 +825,14 @@ class Component:
         return k_states, k_posdef, k_endog
 
     def _combine_statespace_representations(self, other):
-        def make_slice(name, x, o_x):
-            ndim = max(x.ndim, o_x.ndim)
-            return (name,) + (slice(None, None, None),) * ndim
-
         k_states, k_posdef, k_endog = self._get_combined_shapes(other)
-
-        self_matrices = [self.ssm[name] for name in LONG_MATRIX_NAMES]
-        other_matrices = [other.ssm[name] for name in LONG_MATRIX_NAMES]
 
         self_observed_states = self.observed_state_names
         other_observed_states = other.observed_state_names
 
-        x0, P0, c, d, T, Z, R, H, Q = (
-            self.ssm[make_slice(name, x, o_x)]
-            for name, x, o_x in zip(LONG_MATRIX_NAMES, self_matrices, other_matrices)
-        )
+        x0, P0, c, d, T, Z, R, H, Q = (self.ssm[name] for name in LONG_MATRIX_NAMES)
         o_x0, o_P0, o_c, o_d, o_T, o_Z, o_R, o_H, o_Q = (
-            other.ssm[make_slice(name, x, o_x)]
-            for name, x, o_x in zip(LONG_MATRIX_NAMES, self_matrices, other_matrices)
+            other.ssm[name] for name in LONG_MATRIX_NAMES
         )
 
         initial_state = pt.concatenate(conform_time_varying_and_time_invariant_matrices(x0, o_x0))
@@ -864,13 +854,6 @@ class Component:
         obs_intercept.name = d.name
 
         transition = pt.linalg.block_diag(T, o_T)
-        transition = pt.specify_shape(
-            transition,
-            shape=[
-                sum(shapes) if not any([s is None for s in shapes]) else None
-                for shapes in zip(*[T.type.shape, o_T.type.shape])
-            ],
-        )
         transition.name = T.name
 
         design = join_tensors_by_dim_labels(
@@ -883,13 +866,6 @@ class Component:
         design.name = Z.name
 
         selection = pt.linalg.block_diag(R, o_R)
-        selection = pt.specify_shape(
-            selection,
-            shape=[
-                sum(shapes) if not any([s is None for s in shapes]) else None
-                for shapes in zip(*[R.type.shape, o_R.type.shape])
-            ],
-        )
         selection.name = R.name
 
         obs_cov = add_tensors_by_dim_labels(

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -894,6 +894,7 @@ class Component:
             obs_cov=obs_cov,
             state_cov=state_cov,
         )
+        new_ssm.declare_time_varying(*(self.ssm.time_varying_names | other.ssm.time_varying_names))
 
         return new_ssm
 

--- a/pymc_extras/statespace/models/utilities.py
+++ b/pymc_extras/statespace/models/utilities.py
@@ -6,12 +6,6 @@ import pytensor.tensor as pt
 
 from pytensor.tensor import TensorVariable
 
-from pymc_extras.statespace.utils.constants import (
-    LONG_MATRIX_NAMES,
-    MATRIX_NAMES,
-    VECTOR_VALUED,
-)
-
 
 def cleanup_states(states: list[str]) -> list[str]:
     """
@@ -301,60 +295,37 @@ def make_SARIMA_transition_matrix(
 
 def conform_time_varying_and_time_invariant_matrices(A, B):
     """
-    Adjust either A or B to conform to the other in the time dimension
+    Conform two statespace matrices to a common ndim by lifting the static one to the time
+    length of the time-varying one.
 
-    In the context of building a structural model from components, it might be the case that one component has
-    time-varying statespace matrices, while the other does not. In this case, it is not possible to concatenate
-    or block diagonalize the pair of matrices A and B without first expanding the time-invariant matrix to have a
-    time dimension. This function checks if exactly one of the two time varies, and adjusts the other accordingly if
-    need be.
+    Combining components from a structural model can pair a time-varying matrix against a
+    static one. ``concatenate`` and ``block_diag`` need both to have the same ndim, so the
+    static side is broadcast over the missing leading axis. If neither or both sides carry
+    a time dim, both are returned unchanged.
 
     Parameters
     ----------
-    A: pt.TensorVariable
-        An anonymous statespace matrix
-    B: pt.TensorVariable
-        An anonymous statespace matrix
+    A : TensorVariable
+        First statespace matrix.
+    B : TensorVariable
+        Second statespace matrix.
 
     Returns
     -------
-    (A, B): Tuple of pt.TensorVariable
-        A and B, with one or neither expanded to have a time dimension.
+    A_out, B_out : tuple of TensorVariable
+        ``(A, B)`` with at most one side broadcast over a new leading axis.
     """
 
-    if A.name == B.name:
-        name = A.name
-    else:
-        if all([X.name not in MATRIX_NAMES + LONG_MATRIX_NAMES for X in [A, B]]):
-            raise ValueError(
-                "At least one matrix passed to conform_time_varying_and_time_invariant_matrices should be a "
-                "statespace matrix"
-            )
-        name = A.name if A.name in MATRIX_NAMES + LONG_MATRIX_NAMES else B.name
-
-    time_varying_ndim = 3 - int(name in VECTOR_VALUED)
-
-    if not all([x.ndim == time_varying_ndim for x in [A, B]]):
-        return A, B
-
-    T_A, *A_dims = A.type.shape
-    T_B, *B_dims = B.type.shape
-
-    if T_A == T_B:
-        return A, B
-
-    if T_A == 1:
-        A_out = pt.repeat(A, B.shape[0], axis=0)
-        A_out = pt.specify_shape(A_out, (T_B, *tuple(A_dims)))
+    # If only one side has a leading time dim, broadcast the static side along the missing
+    # axis to match the time length of the other.
+    if A.ndim < B.ndim:
+        A_out = pt.broadcast_to(A[None], (B.shape[0], *A.type.shape))
         A_out.name = A.name
-
         return A_out, B
 
-    if T_B == 1:
-        B_out = pt.repeat(B, A.shape[0], axis=0)
-        B_out = pt.specify_shape(B_out, (T_A, *tuple(B_dims)))
+    if B.ndim < A.ndim:
+        B_out = pt.broadcast_to(B[None], (A.shape[0], *B.type.shape))
         B_out.name = B.name
-
         return A, B_out
 
     return A, B

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -16,9 +16,6 @@ FACTOR_DIM = "factor"
 ERROR_AR_PARAM_DIM = "error_lag_ar"
 EXOG_STATE_DIM = "exogenous"
 
-NEVER_TIME_VARYING = ["initial_state", "initial_state_cov", "a0", "P0"]
-VECTOR_VALUED = ["initial_state", "state_intercept", "obs_intercept", "a0", "c", "d"]
-
 MISSING_FILL = -9999.0
 JITTER_DEFAULT = 1e-8 if pytensor.config.floatX.endswith("64") else 1e-6
 

--- a/tests/statespace/core/test_representation.py
+++ b/tests/statespace/core/test_representation.py
@@ -26,13 +26,11 @@ class BasicFunctionality(unittest.TestCase):
     def setUp(self):
         self.rng = np.random.default_rng(TEST_SEED)
 
-    def test_numpy_to_pytensor(self):
+    def test_assign_numpy_matrix(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
-        X = np.eye(5)
-        X_pt = ssm._numpy_to_pytensor("transition", X)
-        self.assertTrue(isinstance(X_pt, pt.TensorVariable))
-        assert_allclose(ssm["transition"].type.shape, X.shape)
-
+        ssm["transition"] = np.eye(5)
+        assert isinstance(ssm["transition"], pt.TensorVariable)
+        assert_allclose(ssm["transition"].type.shape, (5, 5))
         assert ssm["transition"].name == "transition"
 
     def test_default_shapes_full_rank(self):
@@ -131,7 +129,7 @@ class BasicFunctionality(unittest.TestCase):
         with self.assertRaises(IndexError) as e:
             X = ssm["invalid_key"]
         msg = str(e.exception)
-        self.assertEqual(msg, "invalid_key is an invalid state space matrix name")
+        self.assertEqual(msg, "'invalid_key' is an invalid state space matrix name")
 
     def test_non_string_key_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
@@ -166,9 +164,7 @@ class BasicFunctionality(unittest.TestCase):
         with self.assertRaises(ValueError) as e:
             ssm["transition"] = T
         msg = str(e.exception)
-        self.assertEqual(
-            msg, "The last two dimensions of transition must be (5, 5), found (10, 10)"
-        )
+        self.assertEqual(msg, "Trailing dims of transition are (10, 10), expected (5, 5)")
 
 
 if __name__ == "__main__":

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -158,6 +158,7 @@ def ss_mod_time_varying():
             slope = self.make_and_register_variable("slope", ())
             time_trend = slope * pt.arange(self.n_timesteps)
             self.ssm["obs_intercept"] = time_trend[:, None]
+            self.ssm.declare_time_varying("obs_intercept")
 
         @property
         def param_names(self) -> list[str]:
@@ -591,6 +592,7 @@ def test_sample_conditional_with_time_varying():
 
             sigma_cov = self.make_and_register_variable("sigma_cov", (None,))
             self.ssm["state_cov"] = sigma_cov[:, None, None] ** 2
+            self.ssm.declare_time_varying("state_cov")
 
         @property
         def param_names(self) -> list[str]:

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -133,6 +133,7 @@ def f_standard_nd():
 
     inputs = [data, a0, P0, c, d, T, Z, R, H, Q]
 
+    time_varying_names = ("transition", "design", "selection", "obs_cov", "state_cov")
     (
         filtered_states,
         predicted_states,
@@ -141,9 +142,11 @@ def f_standard_nd():
         predicted_covs,
         observed_covs,
         ll_obs,
-    ) = StandardFilter().build_graph(*inputs)
+    ) = StandardFilter().build_graph(*inputs, time_varying_names=time_varying_names)
 
-    smoothed_states, smoothed_covs = ksmoother.build_graph(T, R, Q, filtered_states, filtered_covs)
+    smoothed_states, smoothed_covs = ksmoother.build_graph(
+        T, R, Q, filtered_states, filtered_covs, time_varying_names=time_varying_names
+    )
 
     outputs = [
         filtered_states,


### PR DESCRIPTION
I originally copied the `Representation` class from statsmodels to get started as quickly as possible. Over time I've realized I made some mistakes. This PR goes back to fix them.

- The design assumed all matrices were time varying, and had a silent batch dimension. This is silly, pytensor has `vectorize_graph`, we don't need to early add and slice away a secret batch dim
- Likewise, that secret batch dim led to add matrices being built via set_subtensor, which results in some gnarly Ops.
- Also, statespace matrices were only allowed to be up to 3d. Any higher and it would raise. Certain matrices (x0, P0) were forbidden from having batch dims. All of this got in the way of e.g. #450 
- Logic for deciding what was time varying and what was static at the Kalman Filter was too complex, too magical, and again ruled out batch dims.

This PR:

- Removes all of the time-varying and dimension checks. Batch away.
- Requires models to explicitly register a matrix as time-varying using the `self.ssm.declare_time_varying` method.
- The list of time-varying matrices is set explicitly and passed around to where it is needed.  
- Assigning matrices to the `ssm` should be more ergonomic, `self.ssm['transition'] = T` instead of `self.ssm['transition', : ,:] = T`