### PR TITLE
Remove redundant pt.specify_shape calls

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1553,9 +1553,7 @@ class PyMCStateSpace:
             x0, P0, c, d, T, Z, R, H, Q = matrices
 
             if not self.measurement_error:
-                H_jittered = pm.Deterministic(
-                    "H_jittered", pt.specify_shape(stabilize(H), (self.k_endog, self.k_endog))
-                )
+                H_jittered = pm.Deterministic("H_jittered", stabilize(H))
                 matrices = [x0, P0, c, d, T, Z, R, H_jittered, Q]
 
             LinearGaussianStateSpace(

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -626,17 +626,13 @@ class BayesianDynamicFactor(PyMCStateSpace):
             if self.shared_exog_states:
                 # Shared exogenous states: same exog data is used across all endogenous variables
                 # Shape becomes (n_timepoints, k_endog, k_exog)
-                Z_exog = pt.specify_shape(
-                    pt.join(1, *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)]),
-                    (None, self.k_endog, self.k_exog),
-                )
+                Z_exog = pt.join(1, *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)])
             else:
                 # Separate exogenous states: each endogenous variable gets its own exog block
                 # Create block-diagonal structure and reshape to (n_timepoints, k_endog, k_exog * k_endog)
                 Z_exog = pt.linalg.block_diag(
                     *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)]
                 )
-                Z_exog = pt.specify_shape(Z_exog, (None, self.k_endog, self.k_exog * self.k_endog))
 
             # Repeat base design_matrix over time dimension to match exogenous time series
             n_timepoints = Z_exog.shape[0]

--- a/pymc_extras/statespace/models/ETS.py
+++ b/pymc_extras/statespace/models/ETS.py
@@ -487,9 +487,7 @@ class BayesianETS(PyMCStateSpace):
         # dampening factors on all components. We then set the initial covariance to the steady-state of that system,
         # which we hope is similar enough to give a good initialization for the non-stationary system.
 
-        T_stationary = pt.specify_shape(T_stationary, (self.k_states, self.k_states))
         P0 = solve_discrete_lyapunov(T_stationary, pt.linalg.matrix_dot(R, Q, R.T))
-        P0 = pt.specify_shape(P0, (self.k_states, self.k_states))
 
         return P0
 
@@ -645,14 +643,12 @@ class BayesianETS(PyMCStateSpace):
         R = pt.linalg.block_diag(*R_list)
 
         self.ssm["initial_state"] = x0
-        self.ssm["selection"] = pt.specify_shape(R, shape=(self.k_states, self.k_posdef))
+        self.ssm["selection"] = R
 
         T = pt.linalg.block_diag(*T_components)
 
         # Remove the stationary_dampening dummies before saving the transition matrix
-        self.ssm["transition"] = pt.specify_shape(
-            graph_replace(T, {stationary_dampening: 1.0}), (self.k_states, self.k_states)
-        )
+        self.ssm["transition"] = graph_replace(T, {stationary_dampening: 1.0})
 
         Zs = [np.zeros((self.k_endog, self.k_states // self.k_endog)) for _ in range(self.k_endog)]
         for i, Z in enumerate(Zs):

--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -216,9 +216,7 @@ class Autoregressive(Component):
                 ar_idx = (np.zeros(k_nonzero, dtype="int"), np.nonzero(self.order)[0])
                 T = T[ar_idx].set(ar_params[i])
                 transition_matrices.append(T)
-            T = pt.specify_shape(
-                pt.linalg.block_diag(*transition_matrices), (self.k_states, self.k_states)
-            )
+            T = pt.linalg.block_diag(*transition_matrices)
 
         self.ssm["transition", :, :] = T
 
@@ -227,9 +225,7 @@ class Autoregressive(Component):
         R_mask[0] = True
         R = R[:, R_mask]
 
-        self.ssm["selection", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[R for _ in range(k_endog_effective)]), (self.k_states, k_posdef)
-        )
+        self.ssm["selection", :, :] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
 
         Zs = [pt.zeros((1, k_states))[0, 0].set(1.0) for _ in range(k_endog)]
 
@@ -237,7 +233,7 @@ class Autoregressive(Component):
             Z = pt.join(0, *Zs)
         else:
             Z = pt.linalg.block_diag(*Zs)
-        self.ssm["design", :, :] = pt.specify_shape(Z, (k_endog, self.k_states))
+        self.ssm["design", :, :] = Z
 
         cov_idx = ("state_cov", *np.diag_indices(k_posdef))
         self.ssm[cov_idx] = sigma_ar**2

--- a/pymc_extras/statespace/models/structural/components/cycle.py
+++ b/pymc_extras/statespace/models/structural/components/cycle.py
@@ -332,8 +332,7 @@ class Cycle(Component):
             rho = 1
 
         T = rho * _frequency_transition_block(lamb, j=1)
-        transition = block_diag(*[T for _ in range(k_endog_effective)])
-        self.ssm["transition"] = pt.specify_shape(transition, (self.k_states, self.k_states))
+        self.ssm["transition", :, :] = block_diag(*[T for _ in range(k_endog_effective)])
 
         if self.innovations:
             if k_endog_effective == 1:
@@ -343,10 +342,9 @@ class Cycle(Component):
                 sigma_cycle = self.make_and_register_variable(
                     f"sigma_{self.name}", shape=(k_endog_effective,)
                 )
-                state_cov = block_diag(
+                self.ssm["state_cov", :, :] = block_diag(
                     *[pt.eye(2) * sigma_cycle[i] ** 2 for i in range(k_endog_effective)]
                 )
-                self.ssm["state_cov"] = pt.specify_shape(state_cov, (self.k_states, self.k_states))
         else:
             # explicitly set state cov to 0 when no innovations
             self.ssm["state_cov", :, :] = pt.zeros((self.k_posdef, self.k_posdef))

--- a/pymc_extras/statespace/models/structural/components/level_trend.py
+++ b/pymc_extras/statespace/models/structural/components/level_trend.py
@@ -296,29 +296,19 @@ class LevelTrend(Component):
         triu_idx = pt.triu_indices(k_states)
         T = pt.zeros((k_states, k_states))[triu_idx[0], triu_idx[1]].set(1)
 
-        self.ssm["transition", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[T for _ in range(k_endog_effective)]),
-            (self.k_states, self.k_states),
-        )
+        self.ssm["transition", :, :] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
 
         R = np.eye(k_states)
         R = R[:, self.innovations_order]
 
-        self.ssm["selection", :, :] = pt.specify_shape(
-            pt.linalg.block_diag(*[R for _ in range(k_endog_effective)]),
-            (self.k_states, self.k_posdef),
-        )
+        self.ssm["selection", :, :] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
 
         Z = np.array([1.0] + [0.0] * (k_states - 1)).reshape((1, -1))
 
         if self.share_states:
-            self.ssm["design", :, :] = pt.specify_shape(
-                pt.join(0, *[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
-            )
+            self.ssm["design", :, :] = pt.join(0, *[Z for _ in range(k_endog)])
         else:
-            self.ssm["design", :, :] = pt.specify_shape(
-                pt.linalg.block_diag(*[Z for _ in range(k_endog)]), (self.k_endog, self.k_states)
-            )
+            self.ssm["design", :, :] = pt.linalg.block_diag(*[Z for _ in range(k_endog)])
 
         if k_posdef > 0:
             sigma_trend = self.make_and_register_variable(

--- a/pymc_extras/statespace/models/structural/components/regression.py
+++ b/pymc_extras/statespace/models/structural/components/regression.py
@@ -241,14 +241,12 @@ class Regression(Component):
         self.ssm["selection", :, :] = pt.eye(self.k_states)
 
         if self.share_states:
-            self.ssm["design"] = pt.specify_shape(
-                pt.join(1, *[pt.expand_dims(regression_data, 1) for _ in range(k_endog)]),
-                (None, k_endog, self.k_states),
+            self.ssm["design"] = pt.join(
+                1, *[pt.expand_dims(regression_data, 1) for _ in range(k_endog)]
             )
         else:
-            Z = pt.linalg.block_diag(*[pt.expand_dims(regression_data, 1) for _ in range(k_endog)])
-            self.ssm["design"] = pt.specify_shape(
-                Z, (None, k_endog, regression_data.type.shape[1] * k_endog)
+            self.ssm["design"] = pt.linalg.block_diag(
+                *[pt.expand_dims(regression_data, 1) for _ in range(k_endog)]
             )
 
         if self.innovations:

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -864,13 +864,6 @@ class Component:
         obs_intercept.name = d.name
 
         transition = pt.linalg.block_diag(T, o_T)
-        transition = pt.specify_shape(
-            transition,
-            shape=[
-                sum(shapes) if not any([s is None for s in shapes]) else None
-                for shapes in zip(*[T.type.shape, o_T.type.shape])
-            ],
-        )
         transition.name = T.name
 
         design = join_tensors_by_dim_labels(
@@ -883,13 +876,6 @@ class Component:
         design.name = Z.name
 
         selection = pt.linalg.block_diag(R, o_R)
-        selection = pt.specify_shape(
-            selection,
-            shape=[
-                sum(shapes) if not any([s is None for s in shapes]) else None
-                for shapes in zip(*[R.type.shape, o_R.type.shape])
-            ],
-        )
         selection.name = R.name
 
         obs_cov = add_tensors_by_dim_labels(

--- a/pymc_extras/statespace/models/utilities.py
+++ b/pymc_extras/statespace/models/utilities.py
@@ -410,8 +410,7 @@ def reorder_from_labels(
     if indices.tolist() != list(range(n_out)):
         for axis in labeled_axis:
             idx = np.s_[tuple([slice(None, None) if i != axis else indices for i in range(x.ndim)])]
-            shape = x.type.shape
-            x = pt.specify_shape(x[idx], shape)
+            x = x[idx]
 
     return x
 
@@ -609,36 +608,18 @@ def join_tensors_by_dim_labels(
     # Check for no overlap first. In this case, do a block_diagonal join, which implicitly results in padding zeros
     # everywhere they are needed -- no other sorting or padding necessary
     if combined_labels == [*labels, *other_labels]:
-        res = pt.linalg.block_diag(tensor, other_tensor)
-        new_shape = [
-            shape_1 + shape_2 if (shape_1 is not None and shape_2 is not None) else None
-            for shape_1, shape_2 in zip(tensor.type.shape, other_tensor.type.shape)
-        ]
-        return pt.specify_shape(res, new_shape)
+        return pt.linalg.block_diag(tensor, other_tensor)
 
     # Otherwise there is either total overlap or partial overlap. Let the padding and reordering function figure it out.
     tensor = ndim_pad_and_reorder(tensor, labels, combined_labels, labeled_axis)
     other_tensor = ndim_pad_and_reorder(other_tensor, other_labels, combined_labels, labeled_axis)
 
     if block_diag_join:
-        new_shape = [
-            shape_1 + shape_2 if (shape_1 is not None and shape_2 is not None) else None
-            for shape_1, shape_2 in zip(tensor.type.shape, other_tensor.type.shape)
-        ]
         res = pt.linalg.block_diag(tensor, other_tensor)
     else:
-        new_shape = []
-        join_axis_norm = normalize_axis(tensor, join_axis)
-        for i, (shape_1, shape_2) in enumerate(zip(tensor.type.shape, other_tensor.type.shape)):
-            if i == join_axis_norm:
-                new_shape.append(
-                    shape_1 + shape_2 if (shape_1 is not None and shape_2 is not None) else None
-                )
-            else:
-                new_shape.append(shape_1 if shape_1 is not None else shape_2)
         res = pt.concatenate([tensor, other_tensor], axis=join_axis)
 
-    return pt.specify_shape(res, new_shape)
+    return res
 
 
 def get_exog_dims_from_idata(exog_name, idata):


### PR DESCRIPTION
Once upon a time, pytensor's static shape inference was a lot worse, especially in the linalg Ops. That's all been cleaned up, so most of the `specify_shape` Ops in statespace are no longer needed. They're harmless, but still cruft.