### PR TITLE
Add Simulation Smoother

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1562,7 +1562,9 @@ class PyMCStateSpace:
                 pm.Data(**self._fit_exog_data[name])
 
             self._insert_data_variables()
-            matrices = self._insert_constant_timestep(self.unpack_statespace(), step=steps)
+            # The unconditional trajectory spans ``steps + 1`` timesteps, and time-varying
+            # matrices carry one row per timestep.
+            matrices = self._insert_constant_timestep(self.unpack_statespace(), step=steps + 1)
             x0, P0, c, d, T, Z, R, H, Q = matrices
 
             if not self.measurement_error:
@@ -2427,8 +2429,10 @@ class PyMCStateSpace:
 
             forecast_names = MATRIX_NAMES[2:]  # c, d, T, Z, R, H, Q
             time_varying_names = self.ssm.time_varying_names
+            # Start one step early: the transition into the first forecast period uses the
+            # matrices of the last training period, and its observation is discarded.
             forecast_matrices = [
-                m[n_train:] if SHORT_NAME_TO_LONG[name] in time_varying_names else m
+                m[n_train - 1 :] if SHORT_NAME_TO_LONG[name] in time_varying_names else m
                 for m, name in zip(forecast_matrices, forecast_names)
             ]
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -47,6 +47,7 @@ from pymc_extras.statespace.filters import (
 from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
     SequenceMvNormal,
+    SimulationSmoother,
 )
 from pymc_extras.statespace.filters.utilities import stabilize
 from pymc_extras.statespace.utils.constants import (
@@ -1428,23 +1429,54 @@ class PyMCStateSpace:
                     else (None, None)
                 )
 
-                SequenceMvNormal(
-                    f"{name}_{group}",
-                    mus=mu,
-                    covs=cov,
-                    logp=dummy_ll,
-                    dims=state_dims,
-                    method=mvn_method,
-                )
+                if name == "smoothed":
+                    # The simulation smoother draws the whole latent path jointly, so the
+                    # states carry their cross-time posterior covariance.
+                    latent_states = SimulationSmoother(
+                        f"{name}_{group}",
+                        a_smooth=mu,
+                        x0=x0,
+                        P0=P0,
+                        c=c,
+                        d=d,
+                        T=T,
+                        Z=Z,
+                        R=R,
+                        H=H,
+                        Q=Q,
+                        kalman_filter=self.kalman_filter.copy(),
+                        kalman_smoother=self.kalman_smoother.copy(),
+                        sequence_names=tuple(self.kalman_filter.seq_names),
+                        dims=state_dims,
+                        method=mvn_method,
+                    )
+                    # Conditional on a joint draw of the latent path, the observation noise
+                    # is iid, so H alone is the correct per-step covariance. Adding the
+                    # zeros materializes the time axis, which keeps SequenceMvNormal's
+                    # ``(n),(n,n)->(n)`` gufunc from collapsing to a length-1 scan when H is
+                    # rank-3 but time-broadcastable.
+                    obs_mu = d + (Z @ latent_states[..., None]).squeeze(-1)
+                    obs_cov = pt.zeros((obs_mu.shape[0], 1, 1), dtype=H.dtype) + H
+                    obs_logp = pt.zeros_like(obs_mu)
+                else:
+                    SequenceMvNormal(
+                        f"{name}_{group}",
+                        mus=mu,
+                        covs=cov,
+                        logp=dummy_ll,
+                        dims=state_dims,
+                        method=mvn_method,
+                    )
 
-                obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
-                obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
+                    obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
+                    obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
+                    obs_logp = dummy_ll
 
                 SequenceMvNormal(
                     f"{name}_{group}_observed",
                     mus=obs_mu,
                     covs=obs_cov,
-                    logp=dummy_ll,
+                    logp=obs_logp,
                     dims=obs_dims,
                     method=mvn_method,
                 )

--- a/pymc_extras/statespace/filters/__init__.py
+++ b/pymc_extras/statespace/filters/__init__.py
@@ -1,4 +1,7 @@
-from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
+from pymc_extras.statespace.filters.distributions import (
+    LinearGaussianStateSpace,
+    SimulationSmoother,
+)
 from pymc_extras.statespace.filters.kalman_filter import (
     SquareRootFilter,
     StandardFilter,
@@ -9,6 +12,7 @@ from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
 __all__ = [
     "KalmanSmoother",
     "LinearGaussianStateSpace",
+    "SimulationSmoother",
     "SquareRootFilter",
     "StandardFilter",
     "UnivariateFilter",

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -10,6 +10,8 @@ from pymc.pytensorf import intX, normalize_rng_param
 from pytensor.graph.basic import Node
 from pytensor.tensor.random import multivariate_normal
 
+from pymc_extras.statespace.utils.constants import SHORT_NAME_TO_LONG
+
 floatX = pytensor.config.floatX
 COV_ZERO_TOL = 0
 
@@ -19,32 +21,53 @@ lgss_shape_message = (
 )
 
 
-def make_signature(sequence_names):
-    states = "s"
-    obs = "p"
-    exog = "r"
-    time = "t"
-    state_and_obs = "n"
+# Core-shape axis labels used to build gufunc signatures: state, observed, exogenous
+# (shock), time, and the concatenated state+observed axis.
+STATES, OBS, EXOG, TIME, STATE_AND_OBS = "s", "p", "r", "t", "n"
 
-    matrix_to_shape = {
-        "x0": (states,),
-        "P0": (states, states),
-        "c": (states,),
-        "d": (obs,),
-        "T": (states, states),
-        "Z": (obs, states),
-        "R": (states, exog),
-        "H": (obs, obs),
-        "Q": (exog, exog),
-    }
+STATESPACE_CORE_SHAPES = {
+    "x0": (STATES,),
+    "P0": (STATES, STATES),
+    "c": (STATES,),
+    "d": (OBS,),
+    "T": (STATES, STATES),
+    "Z": (OBS, STATES),
+    "R": (STATES, EXOG),
+    "H": (OBS, OBS),
+    "Q": (EXOG, EXOG),
+}
 
+
+def _build_signature(core_shapes, sequence_names, output_shape):
+    """Assemble an extended gufunc signature, prefixing a time axis onto time-varying matrices.
+
+    Parameters
+    ----------
+    core_shapes : dict mapping str to tuple of str
+        Matrix name to its static core-shape axis labels, in signature order.
+    sequence_names : iterable of str
+        Names of the matrices that vary over time.
+    output_shape : tuple of str
+        Core-shape axis labels of the single output.
+
+    Returns
+    -------
+    signature : str
+        Extended signature in pymc's ``[rng]``-aware gufunc format.
+    """
+    matrix_to_shape = dict(core_shapes)
     for matrix in sequence_names:
-        base_shape = matrix_to_shape[matrix]
-        matrix_to_shape[matrix] = (time, *base_shape)
+        matrix_to_shape[matrix] = (TIME, *matrix_to_shape[matrix])
 
-    signature = ",".join(["(" + ",".join(shapes) + ")" for shapes in matrix_to_shape.values()])
+    inputs = ",".join("(" + ",".join(shapes) + ")" for shapes in matrix_to_shape.values())
 
-    return f"{signature},[rng]->[rng],({time},{state_and_obs})"
+    return f"{inputs},[rng]->[rng],({','.join(output_shape)})"
+
+
+def make_signature(sequence_names):
+    return _build_signature(
+        STATESPACE_CORE_SHAPES, sequence_names, output_shape=(TIME, STATE_AND_OBS)
+    )
 
 
 def _forward_simulate_latent_and_obs(
@@ -468,3 +491,223 @@ def sequence_mvnormal_logp(op, values, mus, covs, logp, rng, **kwargs):
         pt.eq(covs.shape[0], mus.shape[0]),
         msg="Observed data and parameters must have the same number of timesteps (dimension 0)",
     )
+
+
+def _simulation_smoother_signature(sequence_names):
+    """Extended gufunc signature for :class:`SimulationSmootherRV`.
+
+    Adds a leading ``a_smooth`` input to the state-space core shapes and outputs the
+    sampled latent trajectory.
+    """
+    return _build_signature(
+        {"a_smooth": (TIME, STATES), **STATESPACE_CORE_SHAPES},
+        sequence_names,
+        output_shape=(TIME, STATES),
+    )
+
+
+class SimulationSmootherRV(SymbolicRandomVariable):
+    default_output = 1
+    _print_name = ("SimulationSmoother", "\\operatorname{SimSmooth}")
+
+    def update(self, node: Node):
+        return {node.inputs[-1]: node.outputs[0]}
+
+
+class SimulationSmoother(Continuous):
+    r"""Durbin-Koopman simulation smoother for a linear Gaussian state-space model.
+
+    Draws a joint sample of the full latent trajectory :math:`\alpha_{1:T}` from
+    the smoothing posterior :math:`p(\alpha_{1:T} | y_{1:T})` using the algorithm
+    of Durbin and Koopman (2002) [1]_:
+
+    1. Forward-simulate :math:`(\alpha^+, y^+)` from the prior at the current
+       parameters.
+    2. Filter and smooth :math:`y^+` to obtain :math:`\hat\alpha^+`.
+    3. Return :math:`\alpha^{\text{sample}} = \alpha^+ - \hat\alpha^+ + \hat\alpha`,
+       where :math:`\hat\alpha` is the smoothed mean of the real data.
+
+    Draws have marginal mean ``a_smooth`` and the full joint posterior covariance,
+    including cross-time correlations. Sampling each step's marginal independently with
+    :class:`SequenceMvNormal` reproduces the former but not the latter.
+
+    Parameters
+    ----------
+    a_smooth : TensorVariable
+        Real-data smoothed state mean, shape ``(T, k_states)``.
+    x0, P0, c, d, T, Z, R, H, Q : TensorVariable
+        State-space matrices defining the model.
+    kalman_filter : BaseFilter
+        Filter object exposing ``build_graph``, called once while building the sampling
+        graph. A Python-side graph builder, not a random-variable input.
+    kalman_smoother : KalmanSmoother
+        Smoother object exposing ``build_graph``, used the same way as ``kalman_filter``.
+    sequence_names : iterable of str, optional
+        Short names of time-varying matrices, mirroring
+        ``LinearGaussianStateSpace``'s ``sequence_names`` argument.
+    method : str, optional
+        Multivariate-normal sampling method. Default ``"svd"``.
+
+    References
+    ----------
+    .. [1] Durbin, J. and Koopman, S. J. (2002). A simple and efficient
+       simulation smoother for state space time series analysis. Biometrika 89,
+       603-616.
+    """
+
+    rv_type = SimulationSmootherRV
+
+    @classmethod
+    def dist(
+        cls,
+        a_smooth,
+        x0,
+        P0,
+        c,
+        d,
+        T,
+        Z,
+        R,
+        H,
+        Q,
+        *,
+        kalman_filter,
+        kalman_smoother,
+        sequence_names=(),
+        method="svd",
+        **kwargs,
+    ):
+        return super().dist(
+            [a_smooth, x0, P0, c, d, T, Z, R, H, Q],
+            kalman_filter=kalman_filter,
+            kalman_smoother=kalman_smoother,
+            sequence_names=tuple(sequence_names),
+            method=method,
+            **kwargs,
+        )
+
+    @classmethod
+    def rv_op(
+        cls,
+        a_smooth,
+        x0,
+        P0,
+        c,
+        d,
+        T,
+        Z,
+        R,
+        H,
+        Q,
+        *,
+        kalman_filter,
+        kalman_smoother,
+        sequence_names=(),
+        method="svd",
+        size=None,
+        rng=None,
+    ):
+        sequence_names = tuple(sequence_names)
+        a_smooth_, x0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = (
+            x.type() for x in (a_smooth, x0, P0, c, d, T, Z, R, H, Q)
+        )
+
+        a_smooth_.name = "a_smooth"
+        c_.name = "c"
+        d_.name = "d"
+        T_.name = "T"
+        Z_.name = "Z"
+        R_.name = "R"
+        H_.name = "H"
+        Q_.name = "Q"
+
+        rng = normalize_rng_param(rng)
+
+        # Prefer the static type-shape so the inner scan sequence length is a
+        # Python int (JAX requires static lengths for ``lax.scan``); fall back to
+        # the symbolic shape only if the model didn't pin it.
+        T_static = a_smooth_.type.shape[0]
+        steps = T_static if T_static is not None else a_smooth_.shape[0]
+
+        # 1. Forward sim of (alpha_plus, y_plus). The Kalman filter uses the
+        # Durbin-Koopman convention where (a0, P0) is the prediction for alpha_1
+        # (not the distribution of alpha_0). To produce alpha_1..alpha_T we sample
+        # init = alpha_1 ~ N(a0, P0), then run T-1 transition steps and prepend
+        # the init.
+        alpha_plus, y_plus, mid_rng = _forward_simulate_latent_and_obs(
+            x0_,
+            P0_,
+            c_,
+            d_,
+            T_,
+            Z_,
+            R_,
+            H_,
+            Q_,
+            steps=steps - 1,
+            rng=rng,
+            sequence_names=sequence_names,
+            method=method,
+            append_x0=True,
+        )
+
+        if T_static is not None:
+            y_plus = pt.specify_shape(y_plus, (T_static, *y_plus.type.shape[1:]))
+            alpha_plus = pt.specify_shape(alpha_plus, (T_static, *alpha_plus.type.shape[1:]))
+
+        # 2. Filter + smooth y_plus under the same theta. The build_graph helpers
+        # consume long names; translate once.
+        long_names = {SHORT_NAME_TO_LONG[s] for s in sequence_names}
+        a_filt_plus, _, _, P_filt_plus, *_ = kalman_filter.build_graph(
+            y_plus,
+            x0_,
+            P0_,
+            c_,
+            d_,
+            T_,
+            Z_,
+            R_,
+            H_,
+            Q_,
+            time_varying_names=long_names,
+        )
+
+        # The smoother only ever iterates over (T, R, Q); intersect.
+        smoother_long_names = long_names & {"transition", "selection", "state_cov"}
+        a_smooth_plus, _ = kalman_smoother.build_graph(
+            T_,
+            R_,
+            Q_,
+            a_filt_plus,
+            P_filt_plus,
+            time_varying_names=smoother_long_names,
+        )
+
+        if T_static is not None:
+            a_smooth_plus = pt.specify_shape(
+                a_smooth_plus, (T_static, *a_smooth_plus.type.shape[1:])
+            )
+
+        # 3. DK identity. The c-term and d-term cancel because alpha_plus and
+        # a_smooth_plus are produced under the same parameters.
+        alpha_sample = alpha_plus - a_smooth_plus + a_smooth_
+
+        # ``inline=True`` splices the inner scans into the parent fgraph at compile
+        # time, so shape inference reaches through them. The JAX backend needs the
+        # resulting static ``n_steps`` to dispatch its scan.
+        op = SimulationSmootherRV(
+            inputs=[a_smooth_, x0_, P0_, c_, d_, T_, Z_, R_, H_, Q_, rng],
+            outputs=[mid_rng, alpha_sample],
+            extended_signature=_simulation_smoother_signature(sequence_names),
+            inline=True,
+        )
+
+        return op(a_smooth, x0, P0, c, d, T, Z, R, H, Q, rng)
+
+
+@_logprob.register(SimulationSmootherRV)
+def simulation_smoother_logp(op, values, *inputs, **kwargs):
+    # The simulation smoother is only ever sampled (during posterior predictive),
+    # never scored. Return a zero matching the output's shape so PyMC's logp
+    # introspection succeeds.
+    return pt.zeros_like(values[0])

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -365,9 +365,6 @@ class KalmanFilterRV(SymbolicRandomVariable):
 
 
 class SequenceMvNormal(Continuous):
-    def __new__(cls, *args, **kwargs):
-        return super().__new__(cls, *args, **kwargs)
-
     @classmethod
     def dist(cls, mus, covs, logp, method="svd", **kwargs):
         mus, covs, logp = map(pt.as_tensor_variable, (mus, covs, logp))

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -47,6 +47,134 @@ def make_signature(sequence_names):
     return f"{signature},[rng]->[rng],({time},{state_and_obs})"
 
 
+def _forward_simulate_latent_and_obs(
+    a0,
+    P0,
+    c,
+    d,
+    T,
+    Z,
+    R,
+    H,
+    Q,
+    *,
+    steps,
+    rng,
+    sequence_names=(),
+    method="svd",
+    append_x0=True,
+):
+    r"""Forward-sample a latent state and observation trajectory from an LGSSM.
+
+    Constructs a single ``pytensor.scan`` whose inner step emits the observation for the
+    state it receives and then transitions to the next state, so both draws consume the
+    same timestep of any time-varying matrix:
+
+    .. math::
+        y_t &= d_t + Z_t a_t + \eta_t \\
+        a_{t+1} &= c_t + T_t a_t + R_t \epsilon_t
+
+    Time-varying matrices therefore carry one row per returned timestep.
+
+    Parameters
+    ----------
+    a0, P0, c, d, T, Z, R, H, Q : TensorVariable
+        State-space matrices in the canonical order. Either core-shape (static) or
+        time-varying ``(time, *core)``; declare time-varying entries via
+        ``sequence_names``.
+    steps : TensorVariable or int
+        Number of forward simulation steps.
+    rng : RandomGenerator
+        Pytensor RNG to thread through the scan.
+    sequence_names : iterable of str, optional
+        Short names ("c", "d", "T", "Z", "R", "H", "Q") of matrices that are
+        time-varying. Default empty (everything static).
+    method : str, optional
+        Multivariate-normal sampling method passed to ``pm.MvNormal.dist``.
+        Default ``"svd"``.
+    append_x0 : bool, optional
+        Prepend the initial state to both trajectories, giving them length ``steps + 1``
+        rather than ``steps``. Default True.
+
+    Returns
+    -------
+    alpha : TensorVariable
+        Latent trajectory, shape ``(steps[+1], k_states)``.
+    y : TensorVariable
+        Observation trajectory, shape ``(steps[+1], k_endog)``.
+    next_rng : Variable
+        RNG state after sampling.
+    """
+    sequence_names = tuple(sequence_names)
+
+    canonical = ["c", "d", "T", "Z", "R", "H", "Q"]
+    all_inputs = [c, d, T, Z, R, H, Q]
+
+    sequences = []
+    non_sequences = []
+    seq_positions = []
+    non_seq_positions = []
+    for i, (x, name) in enumerate(zip(all_inputs, canonical, strict=True)):
+        if name in sequence_names:
+            sequences.append(x)
+            seq_positions.append(i)
+        else:
+            non_sequences.append(x)
+            non_seq_positions.append(i)
+
+    n_seq = len(sequences)
+
+    def step_fn(*args):
+        seqs, (rng, a, *non_seqs) = args[:n_seq], args[n_seq:]
+
+        ordered = [None] * len(canonical)
+        for src_idx, dst_idx in enumerate(seq_positions):
+            ordered[dst_idx] = seqs[src_idx]
+        for src_idx, dst_idx in enumerate(non_seq_positions):
+            ordered[dst_idx] = non_seqs[src_idx]
+        c, d, T, Z, R, H, Q = ordered
+
+        middle_rng, y_innovation = pm.MvNormal.dist(
+            mu=0, cov=H, rng=rng, method=method, return_next_rng=True
+        )
+        next_rng, a_innovation = pm.MvNormal.dist(
+            mu=0, cov=Q, rng=middle_rng, method=method, return_next_rng=True
+        )
+
+        # Emit the observation for the incoming state and transition to the next one, so
+        # both consume this step's slice of the time-varying matrices.
+        y = d + Z @ a + y_innovation
+        a_next = c + T @ a + R @ a_innovation
+
+        return next_rng, a_next, y
+
+    rng_for_scan, init_a_ = pm.MvNormal.dist(a0, P0, rng=rng, method=method, return_next_rng=True)
+
+    # One step per returned timestep, plus one whose state is discarded: the trailing
+    # transition has no observation to pair with.
+    (next_rng, alpha_seq, y_seq) = pytensor.scan(
+        step_fn,
+        outputs_info=[rng_for_scan, init_a_, None],
+        sequences=sequences or None,
+        non_sequences=non_sequences,
+        n_steps=steps + 1,
+        strict=True,
+        return_updates=False,
+    )
+
+    # scan writes the initial state into slot zero of the tape and returns a view that
+    # drops it; the view's input is the tape, which is the trajectory we simulated.
+    alpha_tape = alpha_seq.owner.inputs[0]
+    if append_x0:
+        alpha = alpha_tape[:-1]
+        y = y_seq
+    else:
+        alpha = alpha_tape[1:-1]
+        y = y_seq[1:]
+
+    return alpha, y, next_rng
+
+
 class LinearGaussianStateSpaceRV(SymbolicRandomVariable):
     default_output = 1
     _print_name = ("LinearGuassianStateSpace", "\\operatorname{LinearGuassianStateSpace}")
@@ -160,9 +288,7 @@ class _LinearGaussianStateSpace(Continuous):
         if sequence_names is None:
             sequence_names = []
 
-        a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = map(
-            lambda x: x.type(), [a0, P0, c, d, T, Z, R, H, Q]
-        )
+        a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = (x.type() for x in (a0, P0, c, d, T, Z, R, H, Q))
 
         c_.name = "c"
         d_.name = "d"
@@ -172,81 +298,26 @@ class _LinearGaussianStateSpace(Continuous):
         H_.name = "H"
         Q_.name = "Q"
 
-        # Partition the seven matrices into scan sequences and non-sequences while remembering
-        # each one's canonical position. The inner step rebuilds the canonical (c, d, T, Z, R, H, Q)
-        # ordering by index, so it never has to introspect names inside the scan body.
-        canonical = ["c", "d", "T", "Z", "R", "H", "Q"]
-        all_inputs = [c_, d_, T_, Z_, R_, H_, Q_]
-
-        sequences: list = []
-        non_sequences: list = []
-        seq_positions: list[int] = []
-        non_seq_positions: list[int] = []
-        for i, (x, name) in enumerate(zip(all_inputs, canonical, strict=True)):
-            if name in sequence_names:
-                sequences.append(x)
-                seq_positions.append(i)
-            else:
-                non_sequences.append(x)
-                non_seq_positions.append(i)
-
         rng = normalize_rng_param(rng)
 
-        n_seq = len(sequences)
-
-        def step_fn(*args):
-            seqs, (rng, state, *non_seqs) = args[:n_seq], args[n_seq:]
-
-            ordered: list = [None] * len(canonical)
-            for src_idx, dst_idx in enumerate(seq_positions):
-                ordered[dst_idx] = seqs[src_idx]
-            for src_idx, dst_idx in enumerate(non_seq_positions):
-                ordered[dst_idx] = non_seqs[src_idx]
-            c, d, T, Z, R, H, Q = ordered
-            k = T.shape[0]
-            a = state[:k]
-
-            middle_rng, a_innovation = pm.MvNormal.dist(
-                mu=0, cov=Q, rng=rng, method=method, return_next_rng=True
-            )
-            next_rng, y_innovation = pm.MvNormal.dist(
-                mu=0, cov=H, rng=middle_rng, method=method, return_next_rng=True
-            )
-
-            a_mu = c + T @ a
-            a_next = a_mu + R @ a_innovation
-
-            y_mu = d + Z @ a_next
-            y_next = y_mu + y_innovation
-
-            next_state = pt.concatenate([a_next, y_next], axis=0)
-
-            return next_rng, next_state
-
-        Z_init = Z_ if Z_ in non_sequences else Z_[0]
-        H_init = H_ if H_ in non_sequences else H_[0]
-
-        init_x_ = pm.MvNormal.dist(a0_, P0_, rng=rng, method=method)
-        init_y_ = pm.MvNormal.dist(Z_init @ init_x_, H_init, rng=rng, method=method)
-
-        init_dist_ = pt.concatenate([init_x_, init_y_], axis=0)
-
-        ss_rng, statespace = pytensor.scan(
-            step_fn,
-            outputs_info=[rng, init_dist_],
-            sequences=None if len(sequences) == 0 else sequences,
-            non_sequences=[*non_sequences],
-            n_steps=steps,
-            strict=True,
-            return_updates=False,
+        alpha, y, ss_rng = _forward_simulate_latent_and_obs(
+            a0_,
+            P0_,
+            c_,
+            d_,
+            T_,
+            Z_,
+            R_,
+            H_,
+            Q_,
+            steps=steps,
+            rng=rng,
+            sequence_names=sequence_names,
+            method=method,
+            append_x0=append_x0,
         )
-
-        if append_x0:
-            statespace_ = pt.concatenate([init_dist_[None], statespace], axis=0)
-            statespace_ = pt.specify_shape(statespace_, (steps + 1, None))
-        else:
-            statespace_ = statespace
-            statespace_ = pt.specify_shape(statespace_, (steps, None))
+        statespace_ = pt.concatenate([alpha, y], axis=-1)
+        statespace_ = pt.specify_shape(statespace_, (steps + int(append_x0), None))
 
         linear_gaussian_ss_op = LinearGaussianStateSpaceRV(
             inputs=[a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_, steps, rng],

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -1,3 +1,5 @@
+import copy
+
 from abc import ABC
 
 import numpy as np
@@ -62,6 +64,10 @@ class BaseFilter(ABC):
 
         self.missing_fill_value: float | None = None
         self.cov_jitter = None
+
+    def copy(self) -> "BaseFilter":
+        """Return a shallow copy whose ``seq_names``/``non_seq_names`` are independent."""
+        return copy.copy(self)
 
     def check_params(self, data, a0, P0, c, d, T, Z, R, H, Q):
         """

--- a/pymc_extras/statespace/filters/kalman_smoother.py
+++ b/pymc_extras/statespace/filters/kalman_smoother.py
@@ -1,3 +1,5 @@
+import copy
+
 import pytensor
 import pytensor.tensor as pt
 
@@ -19,6 +21,10 @@ class KalmanSmoother:
         self.cov_jitter = JITTER_DEFAULT
         self.seq_names = []
         self.non_seq_names = []
+
+    def copy(self) -> "KalmanSmoother":
+        """Return a shallow copy whose ``seq_names``/``non_seq_names`` are independent."""
+        return copy.copy(self)
 
     def unpack_args(self, args):
         """
@@ -71,7 +77,7 @@ class KalmanSmoother:
     ):
         self.cov_jitter = cov_jitter
 
-        n, k = filtered_states.type.shape
+        k = filtered_states.type.shape[1]
 
         a_last = pt.specify_shape(filtered_states[-1], (k,))
         P_last = pt.specify_shape(filtered_covariances[-1], (k, k))

--- a/tests/statespace/core/test_statespace_JAX.py
+++ b/tests/statespace/core/test_statespace_JAX.py
@@ -121,11 +121,12 @@ def test_no_nans_in_sampling_output(ss_mod, group, matrix, idata):
     assert not np.any(np.isnan(idata[group][matrix].values))
 
 
+@pytest.mark.filterwarnings("ignore:The RandomType SharedVariables:UserWarning")
 @pytest.mark.parametrize("group", ["prior", "posterior"])
 @pytest.mark.parametrize("kind", ["conditional", "unconditional"])
 def test_sampling_methods(group, kind, ss_mod, idata, rng):
     f = getattr(ss_mod, f"sample_{kind}_{group}")
-    test_idata = f(idata, random_seed=rng)
+    test_idata = f(idata, random_seed=rng, compile_kwargs={"mode": "JAX"})
 
     if kind == "conditional":
         for output in ["filtered", "predicted", "smoothed"]:

--- a/tests/statespace/core/test_statespace_JAX.py
+++ b/tests/statespace/core/test_statespace_JAX.py
@@ -84,7 +84,7 @@ def idata(pymc_mod, rng, mock_pymc_sample):
             )
         with freeze_dims_and_data(pymc_mod):
             idata_prior = pm.sample_prior_predictive(
-                samples=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
+                draws=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
             )
 
     idata.update(idata_prior)
@@ -108,7 +108,7 @@ def idata_exog(exog_pymc_mod, rng, mock_pymc_sample):
             )
         with freeze_dims_and_data(pymc_mod):
             idata_prior = pm.sample_prior_predictive(
-                samples=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
+                draws=10, random_seed=rng, compile_kwargs={"mode": "JAX"}
             )
 
     idata.update(idata_prior)

--- a/tests/statespace/filters/test_distributions.py
+++ b/tests/statespace/filters/test_distributions.py
@@ -11,8 +11,12 @@ from pymc_extras.statespace import structural
 from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
     SequenceMvNormal,
+    SimulationSmoother,
+    _forward_simulate_latent_and_obs,
     _LinearGaussianStateSpace,
 )
+from pymc_extras.statespace.filters.kalman_filter import StandardFilter
+from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     OBS_STATE_DIM,
@@ -25,6 +29,7 @@ from tests.statespace.test_utilities import (
     delete_rvs_from_model,
     fast_eval,
     load_nile_test_data,
+    nile_test_test_helper,
 )
 
 floatX = pytensor.config.floatX
@@ -234,6 +239,43 @@ def test_lgss_with_time_varying_inputs(output_name, rng):
     assert not np.any(np.isnan(idata.prior[output_name].values))
 
 
+@pytest.mark.parametrize("append_x0", [True, False], ids=["with_x0", "without_x0"])
+def test_forward_simulation_reads_one_matrix_row_per_timestep(append_x0):
+    """Every simulated timestep consumes its own row of a time-varying matrix.
+
+    Simulates a noise-free model whose state counts upward from zero and whose
+    observation intercept encodes its own time index, so each returned observation names
+    the row it read: ``y_t == 100 * row + alpha_t``.
+    """
+    steps = 4
+    scalar_zero = np.zeros((1, 1), dtype=floatX)
+    scalar_one = np.ones((1, 1), dtype=floatX)
+    d_time_varying = (np.arange(steps + 1, dtype=floatX) * 100).reshape(-1, 1)
+
+    alpha, y, _ = _forward_simulate_latent_and_obs(
+        pt.as_tensor_variable(np.zeros(1, dtype=floatX)),
+        pt.as_tensor_variable(scalar_zero),
+        pt.as_tensor_variable(np.ones(1, dtype=floatX)),
+        pt.as_tensor_variable(d_time_varying),
+        pt.as_tensor_variable(scalar_one),
+        pt.as_tensor_variable(scalar_one),
+        pt.as_tensor_variable(scalar_one),
+        pt.as_tensor_variable(scalar_zero),
+        pt.as_tensor_variable(scalar_zero),
+        steps=steps,
+        rng=pytensor.shared(np.random.default_rng(0)),
+        sequence_names=("d",),
+        append_x0=append_x0,
+    )
+    alpha_val, y_val = (v.ravel() for v in pytensor.function([], [alpha, y])())
+
+    # The initial state is alpha_0, so timestep t holds the value t and reads row t.
+    expected_timesteps = np.arange(0 if append_x0 else 1, steps + 1, dtype=floatX)
+
+    assert_allclose(alpha_val, expected_timesteps)
+    assert_allclose(y_val, expected_timesteps * 100 + expected_timesteps)
+
+
 def test_lgss_signature():
     # Base case
     x0 = pt.tensor("x0", shape=(None,))
@@ -266,3 +308,310 @@ def test_lgss_signature():
     )
     assert lgss.owner.op.ndim_supp == 2
     assert lgss.owner.op.ndims_params == [1, 2, 1, 1, 3, 2, 2, 2, 2]
+
+
+def _analytic_joint_posterior(a0, P0, c, d, T_mat, Z_mat, R_mat, H_mat, Q_mat, y):
+    """Closed-form posterior of a stacked LGSSM, used as ground truth.
+
+    Stacks ``alpha_1, ..., alpha_T`` into one big vector and writes the joint
+    prior + likelihood as ``MvN(mean_prior, cov_prior)`` plus a Gaussian
+    observation model, then conditions on ``y`` analytically. Uses the
+    Durbin-Koopman convention where ``(a0, P0)`` is the predicted distribution
+    of ``alpha_1``, matching the Kalman filter implementation.
+    """
+    T_steps, k_endog = y.shape
+    k_states = a0.shape[0]
+
+    mean = np.zeros((T_steps, k_states))
+    cov = np.zeros((T_steps, T_steps, k_states, k_states))
+    mean[0] = a0
+    cov[0, 0] = P0
+    for t in range(1, T_steps):
+        mean[t] = c + T_mat @ mean[t - 1]
+        cov[t, t] = T_mat @ cov[t - 1, t - 1] @ T_mat.T + R_mat @ Q_mat @ R_mat.T
+        for s in range(t):
+            cov[t, s] = T_mat @ cov[t - 1, s]
+            cov[s, t] = cov[t, s].T
+
+    prior_mean = mean.reshape(-1)
+    prior_cov = cov.transpose(0, 2, 1, 3).reshape(T_steps * k_states, T_steps * k_states)
+
+    Z_block = np.zeros((T_steps * k_endog, T_steps * k_states))
+    H_block = np.zeros((T_steps * k_endog, T_steps * k_endog))
+    D = np.tile(d, T_steps)
+    for t in range(T_steps):
+        Z_block[t * k_endog : (t + 1) * k_endog, t * k_states : (t + 1) * k_states] = Z_mat
+        H_block[t * k_endog : (t + 1) * k_endog, t * k_endog : (t + 1) * k_endog] = H_mat
+
+    cross = prior_cov @ Z_block.T
+    obs_cov = Z_block @ cross + H_block
+    gain = cross @ np.linalg.inv(obs_cov)
+    post_mean = prior_mean + gain @ (y.reshape(-1) - (D + Z_block @ prior_mean))
+    post_cov = prior_cov - gain @ Z_block @ prior_cov
+
+    return post_mean.reshape(T_steps, k_states), post_cov
+
+
+@pytest.fixture
+def small_lgssm():
+    """Tiny 2-state, 2-obs LGSSM with non-zero c, d and stable T."""
+    k_states, k_endog, n_steps = 2, 2, 15
+    a0 = np.array([0.5, -0.2], dtype=floatX)
+    P0 = np.eye(k_states, dtype=floatX) * 0.1
+    c = np.array([0.05, -0.03], dtype=floatX)
+    d = np.array([0.1, 0.02], dtype=floatX)
+    T_mat = np.array([[0.9, 0.1], [0.0, 0.8]], dtype=floatX)
+    Z_mat = np.array([[1.0, 0.0], [0.5, 1.0]], dtype=floatX)
+    R_mat = np.eye(k_states, dtype=floatX)
+    H_mat = np.eye(k_endog, dtype=floatX) * 0.2
+    Q_mat = np.eye(k_states, dtype=floatX) * 0.3
+
+    rng_ = np.random.default_rng(42)
+    y = np.zeros((n_steps, k_endog))
+    a_prev = a0.copy()
+    for t in range(n_steps):
+        a_prev = c + T_mat @ a_prev + R_mat @ rng_.multivariate_normal(np.zeros(k_states), Q_mat)
+        y[t] = d + Z_mat @ a_prev + rng_.multivariate_normal(np.zeros(k_endog), H_mat)
+
+    return {
+        "a0": a0,
+        "P0": P0,
+        "c": c,
+        "d": d,
+        "T": T_mat,
+        "Z": Z_mat,
+        "R": R_mat,
+        "H": H_mat,
+        "Q": Q_mat,
+        "y": y,
+        "n_steps": n_steps,
+    }
+
+
+def _build_simulation_smoother_func(params, seed):
+    """Compile a callable that returns ``(a_smooth, sample)`` per call."""
+    a0 = pt.as_tensor_variable(params["a0"])
+    P0 = pt.as_tensor_variable(params["P0"])
+    c = pt.as_tensor_variable(params["c"])
+    d = pt.as_tensor_variable(params["d"])
+    T_mat = pt.as_tensor_variable(params["T"])
+    Z_mat = pt.as_tensor_variable(params["Z"])
+    R_mat = pt.as_tensor_variable(params["R"])
+    H_mat = pt.as_tensor_variable(params["H"])
+    Q_mat = pt.as_tensor_variable(params["Q"])
+    y = pt.as_tensor_variable(np.asarray(params["y"], dtype=floatX))
+
+    filt = StandardFilter().build_graph(y, a0, P0, c, d, T_mat, Z_mat, R_mat, H_mat, Q_mat)
+    a_smooth, _ = KalmanSmoother().build_graph(T_mat, R_mat, Q_mat, filt[0], filt[3])
+
+    rng_var = pytensor.shared(np.random.default_rng(seed), name="rng")
+    sample = SimulationSmoother.dist(
+        a_smooth,
+        a0,
+        P0,
+        c,
+        d,
+        T_mat,
+        Z_mat,
+        R_mat,
+        H_mat,
+        Q_mat,
+        kalman_filter=StandardFilter(),
+        kalman_smoother=KalmanSmoother(),
+        rng=rng_var,
+    )
+    return pm.compile([], [a_smooth, sample], on_unused_input="ignore")
+
+
+def test_simulation_smoother_signature(small_lgssm):
+    """Construction sanity: extended_signature and shape match the spec."""
+    params = small_lgssm
+    a_smooth = pt.zeros((params["n_steps"], 2))
+    sample = SimulationSmoother.dist(
+        a_smooth,
+        pt.as_tensor_variable(params["a0"]),
+        pt.as_tensor_variable(params["P0"]),
+        pt.as_tensor_variable(params["c"]),
+        pt.as_tensor_variable(params["d"]),
+        pt.as_tensor_variable(params["T"]),
+        pt.as_tensor_variable(params["Z"]),
+        pt.as_tensor_variable(params["R"]),
+        pt.as_tensor_variable(params["H"]),
+        pt.as_tensor_variable(params["Q"]),
+        kalman_filter=StandardFilter(),
+        kalman_smoother=KalmanSmoother(),
+    )
+    assert sample.type.shape == (params["n_steps"], 2)
+    assert sample.owner.op.ndim_supp == 2
+    assert (
+        sample.owner.op.extended_signature
+        == "(t,s),(s),(s,s),(s),(p),(s,s),(p,s),(s,r),(p,p),(r,r),[rng]->[rng],(t,s)"
+    )
+
+    # Time-varying case: the declared matrix gains a leading time axis.
+    d_time_varying = pt.tensor("d", shape=(None, None))
+    sample = SimulationSmoother.dist(
+        a_smooth,
+        pt.as_tensor_variable(params["a0"]),
+        pt.as_tensor_variable(params["P0"]),
+        pt.as_tensor_variable(params["c"]),
+        d_time_varying,
+        pt.as_tensor_variable(params["T"]),
+        pt.as_tensor_variable(params["Z"]),
+        pt.as_tensor_variable(params["R"]),
+        pt.as_tensor_variable(params["H"]),
+        pt.as_tensor_variable(params["Q"]),
+        kalman_filter=StandardFilter(),
+        kalman_smoother=KalmanSmoother(),
+        sequence_names=("d",),
+    )
+    assert (
+        sample.owner.op.extended_signature
+        == "(t,s),(s),(s,s),(s),(t,p),(s,s),(p,s),(s,r),(p,p),(r,r),[rng]->[rng],(t,s)"
+    )
+
+
+def test_simulation_smoother_joint_covariance(small_lgssm):
+    """Empirical joint mean and covariance over draws match the analytic posterior."""
+    params = small_lgssm
+    post_mean, post_cov = _analytic_joint_posterior(
+        params["a0"],
+        params["P0"],
+        params["c"],
+        params["d"],
+        params["T"],
+        params["Z"],
+        params["R"],
+        params["H"],
+        params["Q"],
+        params["y"],
+    )
+    f = _build_simulation_smoother_func(params, seed=12345)
+    n_draws = 5_000
+    samples = np.stack([f()[1] for _ in range(n_draws)])
+    emp_cov = np.cov(samples.reshape(n_draws, -1).T)
+    assert_allclose(samples.mean(0), post_mean, atol=0.05)
+    assert_allclose(emp_cov, post_cov, atol=0.04)
+
+
+def test_simulation_smoother_unbiased_under_large_d(small_lgssm):
+    """Draws stay centered on the smoothed mean when the observation intercept is large.
+
+    The Durbin-Koopman identity is invariant to ``d``, so a ``d`` term applied
+    inconsistently across the simulated trajectory shows up as a mean shift here while
+    leaving the joint covariance intact.
+    """
+    params = {**small_lgssm, "d": np.array([50.0, -30.0], dtype=floatX)}
+    f = _build_simulation_smoother_func(params, seed=99)
+
+    a_smooth = f()[0]
+    draws = np.stack([f()[1] for _ in range(2_000)])
+
+    assert_allclose(draws.mean(0), a_smooth, atol=0.1)
+
+
+def test_simulation_smoother_with_time_varying_matrix(small_lgssm):
+    """Draws stay centered on the smoothed mean when a matrix varies over time.
+
+    Exercises the ``sequence_names`` path, where the forward simulation, the filter and
+    the smoother must all index the same timestep of ``d``.
+    """
+    params = small_lgssm
+    n_steps, k_endog = params["n_steps"], params["d"].shape[0]
+
+    # A d that swings over time, so a mis-indexed row shifts the smoothed mean.
+    d_time_varying = np.linspace(-5.0, 5.0, n_steps * k_endog, dtype=floatX).reshape(
+        n_steps, k_endog
+    )
+
+    tensors = {
+        k: pt.as_tensor_variable(params[k]) for k in ("a0", "P0", "c", "T", "Z", "R", "H", "Q")
+    }
+    d = pt.as_tensor_variable(d_time_varying)
+    y = pt.as_tensor_variable(np.asarray(params["y"], dtype=floatX))
+
+    filt = StandardFilter().build_graph(
+        y,
+        tensors["a0"],
+        tensors["P0"],
+        tensors["c"],
+        d,
+        tensors["T"],
+        tensors["Z"],
+        tensors["R"],
+        tensors["H"],
+        tensors["Q"],
+        time_varying_names=["obs_intercept"],
+    )
+    a_smooth, _ = KalmanSmoother().build_graph(
+        tensors["T"], tensors["R"], tensors["Q"], filt[0], filt[3]
+    )
+
+    sample = SimulationSmoother.dist(
+        a_smooth,
+        tensors["a0"],
+        tensors["P0"],
+        tensors["c"],
+        d,
+        tensors["T"],
+        tensors["Z"],
+        tensors["R"],
+        tensors["H"],
+        tensors["Q"],
+        kalman_filter=StandardFilter(),
+        kalman_smoother=KalmanSmoother(),
+        sequence_names=("d",),
+        rng=pytensor.shared(np.random.default_rng(7), name="rng"),
+    )
+    f = pm.compile([], [a_smooth, sample], on_unused_input="ignore")
+
+    smoothed_mean = f()[0]
+    draws = np.stack([f()[1] for _ in range(2_000)])
+
+    assert_allclose(draws.mean(0), smoothed_mean, atol=0.1)
+
+
+def test_simulation_smoother_against_statsmodels(rng):
+    """End-to-end check against statsmodels' simulation_smoother on the Nile model.
+
+    Builds a Local Linear Trend in statsmodels and the same matrices in pymc-extras,
+    draws from both simulation smoothers, and asserts empirical mean and joint
+    covariance agree to MC tolerance.
+    """
+    sm_res, [data, _a0, _diffuse_P0, c, d, T_mat, Z_mat, R_mat, H_mat, Q_mat] = (
+        nile_test_test_helper(rng)
+    )
+    # Override the helper's diffuse P0=1e6*I with a tight prior so MC noise
+    # doesn't dominate the comparison.
+    a0 = np.zeros(2, dtype=floatX)
+    P0 = np.eye(2, dtype=floatX) * 0.5
+    sm_res.model.initialize_known(initial_state=a0, initial_state_cov=P0)
+    sm_res = sm_res.model.smooth(sm_res.params)
+
+    params = {
+        "a0": a0,
+        "P0": P0,
+        "c": c,
+        "d": d,
+        "T": T_mat,
+        "Z": Z_mat,
+        "R": R_mat,
+        "H": H_mat,
+        "Q": Q_mat,
+        "y": data,
+    }
+    f = _build_simulation_smoother_func(params, seed=42)
+
+    n_draws = 2_000
+    ours = np.stack([f()[1] for _ in range(n_draws)])
+
+    sim = sm_res.model.simulation_smoother(random_state=1234)
+    sm_samples = np.empty_like(ours)
+    for i in range(n_draws):
+        sim.simulate()
+        sm_samples[i] = sim.simulated_state.T
+
+    cov_ours = np.cov(ours.reshape(n_draws, -1).T)
+    cov_sm = np.cov(sm_samples.reshape(n_draws, -1).T)
+    assert_allclose(cov_ours, cov_sm, atol=0.05)
+    assert_allclose(ours.mean(0), sm_samples.mean(0), atol=0.1)


### PR DESCRIPTION
A simulation smoother draws a *joint* sample of the full latent trajectory $\alpha_{1:T}$ from the smoothing posterior $p(\alpha_{1:T} \mid y_{1:T})$ of a linear Gaussian state-space model, rather than just the per-step marginals $p(\alpha_t \mid y_{1:T})$. The Kalman smoother already gives us the marginal mean $\hat{\alpha}_t = \mathbb{E}[\alpha_t \mid y_{1:T}]$ and marginal covariance $P_{t \mid T} = \text{Var}(\alpha_t \mid y_{1:T})$ for each $t$, but the cross-time block $\text{Cov}(\alpha_t, \alpha_s \mid y_{1:T})$ is not returned. 

We need a simulation smoother in this library because plotting trajectories of the latent state — for `posterior_predictive["smoothed_*"]` and related uses — requires draws that respect the temporal correlation structure, not draws that pretend each $\alpha_t$ is conditionally independent.

This is visible if you run a structural time series model and plot the smoother outputs. If you take an average they look ok but individually they look jagged:

<img width="1560" height="650" alt="smoother_before" src="https://github.com/user-attachments/assets/e6a70fe5-5f0b-43b8-93c6-f8d7d1569f6e" />

The point of the simulation smoother is to build back in the cross-time dependency, which has the effect of smoothing all the trajectories out:

<img width="1560" height="650" alt="smoother_after" src="https://github.com/user-attachments/assets/868b3596-fd01-4fb6-b0d0-df5501de149d" />
