### PR TITLE
Add GenPareto and ExtGenPareto (Generalized Pareto) distributions

### DIFF
--- a/docs/api/distributions.rst
+++ b/docs/api/distributions.rst
@@ -15,6 +15,8 @@ like regular PyMC distributions and can be used directly inside a model.
    GeneralizedPoisson
    BetaNegativeBinomial
    GenExtreme
+   GenPareto
+   ExtGenPareto
    R2D2M2CP
    Skellam
    histogram_approximation

--- a/pymc_extras/distributions/__init__.py
+++ b/pymc_extras/distributions/__init__.py
@@ -17,7 +17,13 @@
 Experimental probability distributions for stochastic nodes in PyMC.
 """
 
-from pymc_extras.distributions.continuous import Chi, GenExtreme, Maxwell
+from pymc_extras.distributions.continuous import (
+    Chi,
+    ExtGenPareto,
+    GenExtreme,
+    GenPareto,
+    Maxwell,
+)
 from pymc_extras.distributions.discrete import (
     BetaNegativeBinomial,
     GeneralizedPoisson,
@@ -33,7 +39,9 @@ __all__ = [
     "BetaNegativeBinomial",
     "Chi",
     "DiscreteMarkovChain",
+    "ExtGenPareto",
     "GenExtreme",
+    "GenPareto",
     "GeneralizedPoisson",
     "JointCategorical",
     "Maxwell",

--- a/pymc_extras/distributions/continuous.py
+++ b/pymc_extras/distributions/continuous.py
@@ -24,7 +24,9 @@ import pytensor.tensor as pt
 
 from pymc import ChiSquared, CustomDist
 from pymc.distributions import transforms
-from pymc.distributions.dist_math import check_parameters
+from pymc.distributions.dist_math import (
+    check_parameters,
+)
 from pymc.distributions.distribution import Continuous
 from pymc.distributions.shape_utils import rv_size_is_none
 from pymc.logprob.utils import CheckParameterValue
@@ -32,6 +34,9 @@ from pymc.pytensorf import floatX
 from pytensor.tensor.random.op import RandomVariable
 from pytensor.tensor.variable import TensorVariable
 from scipy import stats
+
+from pymc_extras.distributions.pymc_extgenpareto import ExtGenPareto  # noqa: F401
+from pymc_extras.distributions.pymc_genpareto import GenPareto  # noqa: F401
 
 
 class GenExtremeRV(RandomVariable):

--- a/pymc_extras/distributions/pymc_extgenpareto.py
+++ b/pymc_extras/distributions/pymc_extgenpareto.py
@@ -1,0 +1,345 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import pytensor.tensor as pt
+
+from pymc.distributions.dist_math import (
+    check_icdf_parameters,
+    check_icdf_value,
+    check_parameters,
+)
+from pymc.distributions.distribution import Continuous, SymbolicRandomVariable
+from pymc.distributions.shape_utils import implicit_size_from_params, rv_size_is_none
+from pymc.distributions.transforms import _default_transform
+from pymc.pytensorf import floatX, normalize_rng_param
+from pytensor.tensor.random.utils import normalize_size_param
+
+from pymc_extras.distributions import pytensor_extgenpareto as extgenpareto
+from pymc_extras.distributions import pytensor_genpareto as genpareto
+from pymc_extras.distributions.pymc_genpareto import _AbstractGPDLogitCDFTransform
+
+
+class ExtGenParetoRV(SymbolicRandomVariable):
+    name = "extgenpareto"
+    extended_signature = "[rng],[size],(),(),(),()->[rng],()"
+    _print_name = ("ExtGenPareto", "\\operatorname{ExtGenPareto}")
+
+    @classmethod
+    def rv_op(cls, mu, sigma, xi, kappa, *, size=None, rng=None):
+        mu = pt.as_tensor(mu)
+        sigma = pt.as_tensor(sigma)
+        xi = pt.as_tensor(xi)
+        kappa = pt.as_tensor(kappa)
+        rng = normalize_rng_param(rng)
+        size = normalize_size_param(size)
+        if rv_size_is_none(size):
+            size = implicit_size_from_params(mu, sigma, xi, kappa, ndims_params=cls.ndims_params)
+        next_rng, u = rng.uniform(size=size)
+        # Carrier draw u = F; excess = -log(1 - u ** (1/kappa)), via log1mexp so
+        # small-kappa draws do not collapse to the lower endpoint (1 - u**.. -> 1).
+        excess = extgenpareto._ext_gpd_excess_from_log_prob(pt.log(u), kappa)
+        draws = genpareto._gpd_quantile_from_excess(excess, mu, sigma, xi)
+        return cls(inputs=[rng, size, mu, sigma, xi, kappa], outputs=[next_rng, draws])(
+            rng, size, mu, sigma, xi, kappa
+        )
+
+
+class ExtGenPareto(Continuous):
+    r"""Extended Generalized Pareto distribution.
+
+    The extended GPD (Type 1) of Naveau et al. (2016) [1]_ is equivalent to
+    the EGP3 model of Papastathopoulos and Tawn (2013) [2]_. It transforms
+    the GPD CDF :math:`G` through the carrier :math:`v \mapsto v^\kappa`:
+
+    .. math::
+
+       F(x \mid \mu, \sigma, \xi, \kappa) =
+           \left[G\!\left(x \mid \mu, \sigma, \xi\right)\right]^{\kappa}.
+
+    The GPD parameters :math:`\mu, \sigma, \xi` describe the tail (large :math:`x`),
+    as in the GPD. :math:`\kappa > 0` is an additional shape parameter for the body
+    (small :math:`x`); :math:`\kappa = 1` recovers the GPD. The extra parameter
+    gives more flexibility to model the body while leaving the GPD tail unchanged.
+    Typical applications include threshold exceedances [2]_ and modeling rainfall
+    intensities [1]_.
+
+    .. plot::
+        :context: close-figs
+        :include-source: False
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        x = np.linspace(0.02, 4, 200)  # above 0: for kappa < 1 the density diverges at x = 0
+        xi = 0.2
+        for kappa in [0.8, 1.0, 1.2, 2.0, 3.0]:
+            G = st.genpareto.cdf(x, c=xi)
+            g = st.genpareto.pdf(x, c=xi)
+            scaled_pdf = np.power(G, kappa - 1) * g  # ExtGPD density divided by kappa.
+            plt.plot(x, scaled_pdf, label=rf'$\kappa$ = {kappa}')
+        plt.xlabel('x', fontsize=12)
+        plt.ylabel('tail-scaled density', fontsize=12)
+        plt.ylim(0, 1.5)
+        plt.legend(loc='upper right', title=rf'$\mu = 0,\ \sigma = 1,\ \xi = {xi}$')
+        plt.show()
+
+    ========  =========================================================================
+    Support   :math:`\begin{cases} x \geq \mu, & \xi \geq 0 \\ \mu \leq x < \mu - \sigma/\xi, & \xi < 0 \end{cases}`
+    Mean      :math:`\begin{cases} \mu + \dfrac{\sigma}{\xi}\left[\kappa B(\kappa, 1 - \xi) - 1\right], & \xi < 1,\ \xi \neq 0 \\ \mu + \sigma\left(\psi(\kappa + 1) + \gamma\right), & \xi = 0 \\ \infty, & \xi \geq 1 \end{cases}`
+    Variance  :math:`\begin{cases} \left(\dfrac{\sigma}{\xi}\right)^2 \left[\kappa B(\kappa, 1 - 2\xi) - \kappa^2 B(\kappa, 1 - \xi)^2\right], & \xi < 1/2,\ \xi \neq 0 \\ \sigma^2\left(\pi^2/6 - \psi'(\kappa + 1)\right), & \xi = 0 \\ \infty, & \xi \geq 1/2 \end{cases}`
+    Median    :math:`\begin{cases} \mu + \dfrac{\sigma}{\xi}\left[\left(1 - 2^{-1/\kappa}\right)^{-\xi} - 1\right], & \xi \neq 0 \\ \mu - \sigma\ln\!\left(1 - 2^{-1/\kappa}\right), & \xi = 0 \end{cases}`
+    Mode      :math:`\begin{cases} \mu + \dfrac{\sigma}{\xi}\left(T^{-\xi} - 1\right), & \kappa > 1,\ \xi \geq -1,\ \xi \neq 0 \\ \mu + \sigma\ln\kappa, & \kappa > 1,\ \xi = 0 \\ \mu, & \kappa \leq 1,\ \xi \geq -1 \\ \mu - \sigma/\xi, & \kappa \geq 1,\ \xi < -1 \end{cases}` where :math:`T = \dfrac{1 + \xi}{\kappa + \xi}`
+    ========  =========================================================================
+
+    Here :math:`B(a, b) = \Gamma(a)\Gamma(b)/\Gamma(a + b)` is the Beta function,
+    :math:`\psi` the digamma, :math:`\psi'` the trigamma, and :math:`\gamma` the
+    Euler--Mascheroni constant.
+
+    Parameters
+    ----------
+    mu : tensor_like of float
+        Location parameter (the threshold).
+    sigma : tensor_like of float
+        Scale parameter (sigma > 0).
+    xi : tensor_like of float
+        Tail shape parameter (large :math:`x`), as in :class:`GenPareto`.
+    kappa : tensor_like of float
+        Body shape parameter (small :math:`x`, ``kappa > 0``). ``kappa = 1``
+        reduces the distribution to :class:`GenPareto`.
+
+    References
+    ----------
+    .. [1] Naveau, P., Huser, R., Ribereau, P., & Hannart, A. (2016). Modeling
+        jointly low, moderate, and heavy rainfall intensities without a threshold
+        selection. Water Resources Research, 52(4), 2753-2769.
+        https://doi.org/10.1002/2015WR018552
+    .. [2] Papastathopoulos, I., & Tawn, J. A. (2013). Extended generalised
+        Pareto models for tail estimation. Journal of Statistical Planning and
+        Inference, 143(1), 131-143.
+        https://arxiv.org/abs/1111.6899
+
+    Notes
+    -----
+    All of the Notes on :class:`GenPareto` apply here too. The :math:`r`-th moment
+    is finite iff :math:`\xi < 1/r`, as for the GPD.
+
+    For positive :math:`\xi`, tail-only data can make :math:`\sigma` and
+    :math:`\kappa` hard to identify separately. In the small-:math:`\sigma`,
+    large-:math:`\kappa` regime, observations above the threshold are informed
+    mainly by a combined tail-survival scale rather than by the two parameters
+    individually, making the fit sensitive to very broad :math:`\sigma` priors.
+
+    .. plot::
+        :context: close-figs
+        :include-source: False
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import arviz as az
+        plt.style.use("arviz-darkgrid")
+
+        def gpd_log_survival(x, sigma, xi):
+            return -(1.0 / xi) * np.log1p(xi * x / sigma)
+
+        def gpd_log_pdf(x, sigma, xi):
+            return -np.log(sigma) - (1.0 / xi + 1.0) * np.log1p(xi * x / sigma)
+
+        def extgpd_log_pdf(x, sigma, xi, kappa):
+            log_s = gpd_log_survival(x, sigma, xi)
+            log_g = np.log1p(-np.exp(log_s))
+            return np.log(kappa) + (kappa - 1.0) * log_g + gpd_log_pdf(x, sigma, xi)
+
+        def boundary_log_pdf(x, xi, lam):
+            alpha = 1.0 / xi
+            return (
+                np.log(lam)
+                - (alpha + 1.0) * np.log(xi)
+                - (alpha + 1.0) * np.log(x)
+                - lam * (xi * x) ** (-alpha)
+            )
+
+        x = np.linspace(1e-3, 8.0, 1200)
+        xi = 1.5
+        lam = 2.0
+        alpha = 1.0 / xi
+        sigmas = [0.7, 0.2, 0.05, 0.01]
+
+        plt.plot(x, np.exp(boundary_log_pdf(x, xi, lam)), "k--", lw=2.5, label="limit")
+        colors = plt.cm.plasma(np.linspace(0.08, 0.82, len(sigmas)))
+        for sigma, color in zip(sigmas, colors):
+            kappa = lam / sigma**alpha
+            plt.plot(
+                x,
+                np.exp(extgpd_log_pdf(x, sigma, xi, kappa)),
+                color=color,
+                lw=1.9,
+                label=rf"$\sigma={sigma:g}$, $\kappa={kappa:.1f}$",
+            )
+        plt.axvline(0.0, color="0.25", lw=1.2, ls=":")
+        plt.xlabel("x", fontsize=12)
+        plt.ylabel("density", fontsize=12)
+        plt.title(r"ExtGPD non-identifiability between $\sigma$ and $\kappa$")
+        plt.xlim(0.0, 8.0)
+        plt.ylim(bottom=0.0)
+        plt.legend(
+            fontsize=8,
+            frameon=False,
+            title=rf"$\mu=0$, $\xi={xi}$, $\kappa\sigma^{{1/\xi}}={lam:g}$",
+            title_fontsize=9,
+        )
+        plt.show()
+
+    Examples
+    --------
+    Fitting exceedances over a known threshold, with :math:`\kappa` as an
+    additional body shape:
+
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        from pymc_extras.distributions import ExtGenPareto
+
+        exceedances = data[data > threshold]
+        xmax = exceedances.max()
+        excess = exceedances - threshold
+        s_hat = np.median(excess) / np.log(2.0)
+
+        with pm.Model():
+            # Regularize sigma to the observed excess scale; see recommendations.
+            pareto_sigma = pm.LogNormal("pareto_sigma", mu=np.log(s_hat), sigma=1.0)
+            # Center kappa on the GPD case while allowing broad body-shape variation.
+            pareto_kappa = pm.LogNormal("pareto_kappa", mu=0.0, sigma=1.0)
+            # xi lower bound: see modeling recommendations below.
+            pareto_xi = pm.TruncatedNormal(
+                "pareto_xi",
+                mu=0.0,
+                sigma=2.0,
+                lower=pm.math.maximum(-1.0, -pareto_sigma / (xmax - threshold)),
+            )
+            ExtGenPareto(
+                "obs",
+                mu=threshold,
+                sigma=pareto_sigma,
+                xi=pareto_xi,
+                kappa=pareto_kappa,
+                observed=exceedances,
+            )
+            idata = pm.sample()
+
+    .. _extgenpareto-modeling-recommendations:
+
+    .. rubric:: Modeling recommendations
+
+    For :math:`\xi`, use the same lower-bound rule as :ref:`GenPareto
+    <genpareto-modeling-recommendations>`: combine the data-in-support constraint
+    with the :math:`-1` floor.
+
+    - **Regularize** :math:`\sigma` **to the excess scale.** :math:`\sigma` carries the
+      data's units, so center its prior on the observed excess scale rather than on an
+      arbitrary unit scale. A simple closed-form default is
+      :math:`\hat{s}=\operatorname{median}(x-\mu)/\log 2`, the median match for the
+      exponential GPD carrier (:math:`\xi=0`, :math:`\kappa=1`), with
+      ``LogNormal(log(s_hat), 1)``. This gives a wide prior on the observed scale
+      without encouraging the small-:math:`\sigma`, large-:math:`\kappa` trade
+      described in the Notes.
+
+    - **Center** :math:`\kappa` **on the GPD case.** ``LogNormal(0, 1)`` is symmetric in
+      :math:`\log\kappa` about :math:`\kappa = 1` and allows a broad range of body shapes
+      while enforcing :math:`\kappa` positive. :math:`\kappa` is mainly informed by the body of
+      the exceedance distribution; tail-dominated data can leave it correlated with
+      :math:`\sigma`. Inspect its posterior and prefer the GPD when :math:`\kappa`
+      remains compatible with :math:`1`.
+
+    - **Keep** :math:`\mu` **fixed at the threshold.** In a peaks-over-threshold
+      fit, :math:`\mu` is chosen in advance. Estimating it is especially unstable
+      for ExtGPD because a :math:`\kappa < 1` density diverges at the lower
+      endpoint :math:`x = \mu`. If :math:`\mu` must be estimated, floor
+      :math:`\kappa \geq 1` or put a prior on :math:`\min(\text{data}) - \mu`
+      that vanishes at :math:`0`.
+    """
+
+    rv_type = ExtGenParetoRV
+    rv_op = ExtGenParetoRV.rv_op
+
+    @classmethod
+    def dist(cls, mu=0, sigma=1, xi=0, kappa=1, **kwargs):
+        mu = pt.as_tensor_variable(floatX(mu))
+        sigma = pt.as_tensor_variable(floatX(sigma))
+        xi = pt.as_tensor_variable(floatX(xi))
+        kappa = pt.as_tensor_variable(floatX(kappa))
+        return super().dist([mu, sigma, xi, kappa], **kwargs)
+
+    def logp(value, mu, sigma, xi, kappa):
+        return check_parameters(
+            extgenpareto.logpdf(value, mu, sigma, xi, kappa),
+            sigma > 0,
+            kappa > 0,
+            msg="sigma > 0, kappa > 0",
+        )
+
+    def logcdf(value, mu, sigma, xi, kappa):
+        return check_parameters(
+            extgenpareto.logcdf(value, mu, sigma, xi, kappa),
+            sigma > 0,
+            kappa > 0,
+            msg="sigma > 0, kappa > 0",
+        )
+
+    def logccdf(value, mu, sigma, xi, kappa):
+        return check_parameters(
+            extgenpareto.logsf(value, mu, sigma, xi, kappa),
+            sigma > 0,
+            kappa > 0,
+            msg="sigma > 0, kappa > 0",
+        )
+
+    def icdf(value, mu, sigma, xi, kappa):
+        res = extgenpareto.ppf(value, mu, sigma, xi, kappa)
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(res, sigma > 0, kappa > 0, msg="sigma > 0, kappa > 0")
+
+    def support_point(rv, size, mu, sigma, xi, kappa):
+        # Support point = backward(0): the median, which the logit-CDF maps to y = 0 (F = 0.5).
+        # backward floors it just above mu, so when the median rounds onto mu for small kappa,
+        # forward stays finite (it would be -inf exactly at mu).
+        point = _ExtGenParetoLogitCDF().backward(
+            pt.zeros_like(mu), None, None, mu, sigma, xi, kappa
+        )
+        if not rv_size_is_none(size):
+            point = pt.full(size, point)
+        return point
+
+
+class _ExtGenParetoLogitCDF(_AbstractGPDLogitCDFTransform):
+    """``y = logit(F(x))`` transform for :class:`ExtGenPareto`."""
+
+    _logp = staticmethod(extgenpareto.logpdf)
+    _logcdf = staticmethod(extgenpareto.logcdf)
+    _logccdf = staticmethod(extgenpareto.logsf)
+
+    @staticmethod
+    def _excess_from_logit(value, mu, sigma, xi, kappa):
+        return extgenpareto._ext_gpd_excess_from_logit(value, kappa)
+
+    @staticmethod
+    def _quantile_from_excess(excess, mu, sigma, xi, kappa):
+        return genpareto._gpd_quantile_from_excess(excess, mu, sigma, xi)
+
+
+@_default_transform.register(ExtGenPareto)
+def _extgenpareto_default_transform(op, rv):
+    return _ExtGenParetoLogitCDF()

--- a/pymc_extras/distributions/pymc_genpareto.py
+++ b/pymc_extras/distributions/pymc_genpareto.py
@@ -1,0 +1,307 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pymc.distributions.dist_math import (
+    check_icdf_parameters,
+    check_icdf_value,
+    check_parameters,
+)
+from pymc.distributions.distribution import Continuous, SymbolicRandomVariable
+from pymc.distributions.shape_utils import implicit_size_from_params, rv_size_is_none
+from pymc.distributions.transforms import _default_transform
+from pymc.logprob.transforms import Transform
+from pymc.pytensorf import floatX, normalize_rng_param
+from pytensor.tensor.random.utils import normalize_size_param
+
+from pymc_extras.distributions import pytensor_genpareto as genpareto
+
+
+class GenParetoRV(SymbolicRandomVariable):
+    name = "genpareto"
+    extended_signature = "[rng],[size],(),(),()->[rng],()"
+    _print_name = ("GenPareto", "\\operatorname{GenPareto}")
+
+    @classmethod
+    def rv_op(cls, mu, sigma, xi, *, size=None, rng=None):
+        mu = pt.as_tensor(mu)
+        sigma = pt.as_tensor(sigma)
+        xi = pt.as_tensor(xi)
+        rng = normalize_rng_param(rng)
+        size = normalize_size_param(size)
+        if rv_size_is_none(size):
+            size = implicit_size_from_params(mu, sigma, xi, ndims_params=cls.ndims_params)
+        # Draw the survival probability directly so excess = -log(v) avoids the
+        # 1 - u cancellation that hurts the heavy upper tail.
+        next_rng, v = rng.uniform(size=size)
+        draws = genpareto._gpd_quantile_from_excess(-pt.log(v), mu, sigma, xi)
+        return cls(inputs=[rng, size, mu, sigma, xi], outputs=[next_rng, draws])(
+            rng, size, mu, sigma, xi
+        )
+
+
+class GenPareto(Continuous):
+    r"""Generalized Pareto distribution.
+
+    The Generalized Pareto distribution (GPD) is the canonical model for
+    exceedances over a threshold (peaks-over-threshold), the counterpart of the
+    GEV used for block maxima. Its CDF is
+
+    .. math::
+
+       G(x \mid \mu, \sigma, \xi) = \begin{cases}
+           1 - \left(1 + \xi\,\frac{x - \mu}{\sigma}\right)^{-1/\xi}, & \xi \neq 0, \\[6pt]
+           1 - \exp\!\left(-\dfrac{x - \mu}{\sigma}\right),           & \xi = 0.
+       \end{cases}
+
+    The shape :math:`\xi` is parametrized as in Scarrott and MacDonald (2012) [1]_,
+    matching SciPy's ``genpareto`` ``c`` parameter.
+
+    .. plot::
+        :context: close-figs
+        :include-source: False
+
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import scipy.stats as st
+        import arviz as az
+        plt.style.use('arviz-darkgrid')
+        x = np.linspace(0, 4, 500)
+        for xi in [-1.2, -1.0, -0.8, -0.5, 0.0, 2.0]:
+            pdf = st.genpareto.pdf(x, c=xi, loc=0.0, scale=1.0)
+            plt.plot(x, pdf, label=rf'$\xi$ = {xi:g}')
+        plt.xlabel('x', fontsize=12)
+        plt.ylabel('probability density', fontsize=12)
+        plt.ylim(0, 2.5)
+        plt.legend(loc='upper right', title=r'$\mu = 0,\ \sigma = 1$')
+        plt.show()
+
+    ========  =========================================================================
+    Support   :math:`\begin{cases} x \geq \mu, & \xi \geq 0 \\ \mu \leq x < \mu - \sigma/\xi, & \xi < 0 \end{cases}`
+    Mean      :math:`\begin{cases} \mu + \dfrac{\sigma}{1 - \xi}, & \xi < 1 \\ \infty, & \xi \geq 1 \end{cases}`
+    Variance  :math:`\begin{cases} \dfrac{\sigma^2}{(1 - \xi)^2 (1 - 2\xi)}, & \xi < 1/2 \\ \infty, & \xi \geq 1/2 \end{cases}`
+    Median    :math:`\begin{cases} \mu + \dfrac{\sigma (2^{\xi} - 1)}{\xi}, & \xi \neq 0 \\ \mu + \sigma \ln 2, & \xi = 0 \end{cases}`
+    Mode      :math:`\begin{cases} \mu, & \xi \geq -1 \\ \mu - \sigma/\xi, & \xi \leq -1 \end{cases}`
+    Entropy   :math:`\ln \sigma + \xi + 1`
+    ========  =========================================================================
+
+    Parameters
+    ----------
+    mu : tensor_like of float
+        Location parameter (the threshold).
+    sigma : tensor_like of float
+        Scale parameter (sigma > 0).
+    xi : tensor_like of float
+        Shape parameter. :math:`\xi > 0` gives a heavy (Pareto) tail,
+        :math:`\xi = 0` an exponential tail, and :math:`\xi < 0` a bounded
+        upper tail.
+
+    References
+    ----------
+    .. [1] Scarrott, C., & MacDonald, A. (2012). A review of extreme value
+        threshold estimation and uncertainty quantification. REVSTAT -
+        Statistical Journal, 10(1), 33-60.
+        https://doi.org/10.57805/revstat.v10i1.110
+    .. [2] Pickands, J. (1975). Statistical Inference Using Extreme Order
+        Statistics. Annals of Statistics, 3(1), 119-131.
+        https://www.jstor.org/stable/2958083
+
+    Notes
+    -----
+    The support is :math:`[\mu, \infty)` for :math:`\xi \geq 0`. For
+    :math:`\xi < 0`, the support has a finite right endpoint
+    :math:`x_F := \mu - \sigma/\xi`; values at or above :math:`x_F` have density
+    :math:`0`. Since :math:`x_F` depends on :math:`\sigma` and :math:`\xi`, a fit
+    that leaves them free must keep every observation inside the support (see
+    :ref:`Modeling recommendations <genpareto-modeling-recommendations>`).
+
+    The :math:`r`-th moment is finite iff :math:`\xi < 1/r`. Thus the mean is
+    finite for :math:`\xi < 1` and the variance for :math:`\xi < 1/2`. Every
+    moment exists for :math:`\xi \leq 0`.
+
+    Examples
+    --------
+    Fitting exceedances over a known threshold:
+
+    .. code-block:: python
+
+        import pymc as pm
+        from pymc_extras.distributions import GenPareto
+
+        exceedances = data[data > threshold]
+        xmax = exceedances.max()
+        with pm.Model():
+            # sigma carries the data's units; use a wide log-scale prior when the
+            # data scale is unknown.
+            pareto_sigma = pm.LogNormal("pareto_sigma", mu=0.0, sigma=10.0)
+            # xi lower bound: see Modeling recommendations.
+            pareto_xi = pm.TruncatedNormal(
+                "pareto_xi",
+                mu=0.0,
+                sigma=2.0,
+                lower=pm.math.maximum(-1.0, -pareto_sigma / (xmax - threshold)),
+            )
+            GenPareto("obs", mu=threshold, sigma=pareto_sigma, xi=pareto_xi, observed=exceedances)
+            idata = pm.sample()
+
+    .. _genpareto-modeling-recommendations:
+
+    .. rubric:: Modeling recommendations
+
+    - **Keep the data inside the support.** If :math:`\xi` is allowed to be
+      negative, the support has a finite upper wall :math:`x = x_F`, where
+      :math:`x_F := \mu - \sigma/\xi`,
+      and the observations stay inside it only when :math:`\max(\text{data}) < x_F`,
+      equivalently :math:`\xi > -\sigma/(\max(\text{data}) - \mu)`. Encoding this as
+      the :math:`\xi` prior's lower bound keeps :math:`x_F` above the data; without
+      it the sampler can reach :math:`(\sigma, \xi)` for which
+      :math:`x_F < \max(\text{data})`, putting an observation out of support and
+      causing divergences. (:math:`\xi \geq 0` has no upper wall and always
+      contains the data.)
+
+    - **Floor** :math:`\xi` **at** :math:`-1`. If :math:`\xi` is allowed below
+      :math:`-1`, the density diverges at the wall :math:`x = x_F`: as :math:`x_F`
+      decreases toward :math:`\max(\text{data})` the likelihood tends to
+      :math:`+\infty`. Choose the :math:`\xi` prior to enforce :math:`\xi \geq -1` (where
+      the wall density is finite); combined with the in-support bound, this gives the
+      example prior's lower limit :math:`\max(-1,\ -\sigma/(\max(\text{data}) - \mu))`.
+
+    - **Cap** :math:`\xi` **from above if moments must exist.** When the application needs a
+      finite mean or variance, bound the :math:`\xi` prior above accordingly: :math:`\xi < 1`
+      (mean) or :math:`\xi < 1/2` (variance).
+
+    - **Keep** :math:`\mu` **fixed at the threshold.** In a peaks-over-threshold fit
+      :math:`\mu` is chosen in advance, not inferred. Estimating it has two failure
+      modes: proposals with :math:`\mu > \min(\text{data})` put observations out
+      of support, and the corner :math:`\mu \to \min(\text{data})`,
+      :math:`\sigma \to 0` has unbounded likelihood when :math:`\xi > n - 1`.
+
+    .. rubric:: Implementation details
+
+    **Numerical precision near the wall.** As :math:`x` nears the wall :math:`x = x_F`,
+    the margin :math:`1 + \xi (x - \mu)/\sigma` cancels toward :math:`0`. The
+    log-density value stays accurate, but its gradient w.r.t. :math:`\sigma` and
+    :math:`\xi` has relative error of order the machine epsilon divided by that
+    margin. It stems from the finite precision of :math:`x`, and no reformulation
+    of ``logp`` avoids it.
+
+    **Difference from SciPy.** For :math:`\xi < 0` the wall :math:`x = x_F` is treated
+    as open: ``logp`` returns :math:`-\infty` there. There is a finite limiting
+    density for :math:`-1 \leq \xi < 0` as :math:`x \to x_F^-`, and SciPy returns
+    the limiting value. This endpoint carries zero probability mass, so the choice
+    affects neither sampling nor integration.
+
+    """
+
+    rv_type = GenParetoRV
+    rv_op = GenParetoRV.rv_op
+
+    @classmethod
+    def dist(cls, mu=0, sigma=1, xi=0, **kwargs):
+        mu = pt.as_tensor_variable(floatX(mu))
+        sigma = pt.as_tensor_variable(floatX(sigma))
+        xi = pt.as_tensor_variable(floatX(xi))
+        return super().dist([mu, sigma, xi], **kwargs)
+
+    def logp(value, mu, sigma, xi):
+        return check_parameters(genpareto.logpdf(value, mu, sigma, xi), sigma > 0, msg="sigma > 0")
+
+    def logcdf(value, mu, sigma, xi):
+        return check_parameters(genpareto.logcdf(value, mu, sigma, xi), sigma > 0, msg="sigma > 0")
+
+    def logccdf(value, mu, sigma, xi):
+        return check_parameters(genpareto.logsf(value, mu, sigma, xi), sigma > 0, msg="sigma > 0")
+
+    def icdf(value, mu, sigma, xi):
+        res = genpareto.ppf(value, mu, sigma, xi)
+        res = check_icdf_value(res, value)
+        return check_icdf_parameters(res, sigma > 0, msg="sigma > 0")
+
+    def support_point(rv, size, mu, sigma, xi):
+        # Median: the mean is infinite for xi >= 1.
+        excess = np.log(2.0)  # -log(1 - 0.5)
+        median = genpareto._gpd_quantile_from_excess(excess, mu, sigma, xi)
+        if not rv_size_is_none(size):
+            median = pt.full(size, median)
+        return median
+
+
+class _AbstractGPDLogitCDFTransform(Transform):
+    """Transform a GPD/ExtGPD from its constrained support to an unconstrained domain.
+
+    The variate ``x`` has half-infinite support ``[mu, inf)`` for ``xi >= 0`` and bounded support
+    ``[mu, mu - sigma/xi)`` for ``xi < 0``. The easy-to-compute logit-CDF ``y = logit(F(x))``
+    handles both cases in a unified way: ``F`` maps any support onto ``(0, 1)`` and ``logit``
+    onto the real line, so ``y`` is standard ``Logistic`` for every ``xi``. It is smooth across
+    ``xi = 0``, so the sampler's target stays continuously differentiable in the parameters.
+
+    Subclasses supply ``_logp`` / ``_logcdf`` / ``_logccdf`` / ``_excess_from_logit`` (the GPD
+    excess ``m = -log S(x)`` from ``y = logit(F)``) / ``_quantile_from_excess``.
+    """
+
+    name = "gpd_logit_cdf"
+    ndim_supp = 0
+
+    # Set by subclasses (see the class docstring).
+    _logp = _logcdf = _logccdf = _excess_from_logit = _quantile_from_excess = None
+
+    def forward(self, value, rng, size, *distribution_parameters):
+        """Quantile -> logit: ``value`` is the data point x; returns ``y = logit(F(x))``."""
+        # logit(F) = log F - log(1 - F) = logcdf - logccdf, both stable.
+        log_F = self._logcdf(value, *distribution_parameters)
+        log_S = self._logccdf(value, *distribution_parameters)
+        return log_F - log_S
+
+    def backward(self, value, rng, size, *distribution_parameters):
+        """Logit -> quantile: ``value`` is ``y = logit(F)``; returns the data point x."""
+        mu = distribution_parameters[0]
+        excess = self._excess_from_logit(value, *distribution_parameters)
+        x = self._quantile_from_excess(excess, *distribution_parameters)
+        # In finite precision the quantile can round onto mu (it is strictly above mu in
+        # exact arithmetic), where a kappa < 1 density is +inf; floor it just above. The
+        # offset scales with |mu| and the working precision.
+        finfo = np.finfo(value.dtype)
+        floor = pt.abs(mu) * (8.0 * finfo.eps) + finfo.tiny
+        return pt.maximum(x, mu + floor)
+
+    def log_jac_det(self, value, rng, size, *distribution_parameters):
+        x = self.backward(value, rng, size, *distribution_parameters)
+        # The transformed density is exactly Logistic(value); the framework adds
+        # logp(x) back, so log|dx/dy| = logistic - logp(x).
+        logistic = -pt.softplus(value) - pt.softplus(-value)
+        return logistic - self._logp(x, *distribution_parameters)
+
+
+class _GenParetoLogitCDF(_AbstractGPDLogitCDFTransform):
+    """``y = logit(F(x))`` transform for :class:`GenPareto`."""
+
+    _logp = staticmethod(genpareto.logpdf)
+    _logcdf = staticmethod(genpareto.logcdf)
+    _logccdf = staticmethod(genpareto.logsf)
+
+    @staticmethod
+    def _excess_from_logit(value, mu, sigma, xi):
+        # u = sigmoid(y); m = -log(1 - u) = -log(sigmoid(-y)) = softplus(y). Stable for all y.
+        return pt.softplus(value)
+
+    @staticmethod
+    def _quantile_from_excess(excess, mu, sigma, xi):
+        return genpareto._gpd_quantile_from_excess(excess, mu, sigma, xi)
+
+
+@_default_transform.register(GenPareto)
+def _genpareto_default_transform(op, rv):
+    return _GenParetoLogitCDF()

--- a/pymc_extras/distributions/pytensor_distributions_helper.py
+++ b/pymc_extras/distributions/pytensor_distributions_helper.py
@@ -1,0 +1,48 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""``ppf_bounds_cont`` vendored verbatim from pymc-devs/pytensor-distributions.
+
+https://github.com/pymc-devs/pytensor-distributions/blob/13ab4708a5fce7b4f73bd35014c73ca7a8667d6a/pytensor_distributions/helper.py
+"""
+
+import pytensor.tensor as pt
+
+
+def ppf_bounds_cont(x_val, q, lower, upper):
+    """
+    Apply bounds checking for the inverse CDF of continuous distributions.
+
+    Parameters
+    ----------
+    x_val : tensor
+        The computed PPF value
+    q : tensor
+        Probability value (quantile) between 0 and 1
+    lower : float
+        Lower bound of the distribution support
+    upper : float
+        Upper bound of the distribution support
+
+    Returns
+    -------
+    tensor
+        PPF value with proper bounds: NaN for q outside [0,1],
+        lower bound for q=0, upper bound for q=1, otherwise x_val
+    """
+    return pt.switch(
+        pt.or_(pt.lt(q, 0), pt.gt(q, 1)),
+        pt.nan,
+        pt.switch(pt.eq(q, 0), lower, pt.switch(pt.eq(q, 1), upper, x_val)),
+    )

--- a/pymc_extras/distributions/pytensor_extgenpareto.py
+++ b/pymc_extras/distributions/pytensor_extgenpareto.py
@@ -1,0 +1,158 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Extended Generalized Pareto distribution (Naveau et al. 2016 Type 1)."""
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pymc_extras.distributions.pytensor_distributions_helper import ppf_bounds_cont
+from pymc_extras.distributions.pytensor_genpareto import (
+    _gpd_log_H,
+    _gpd_log_h,
+    _gpd_log_S,
+    _gpd_quantile_from_excess,
+    _gpd_upper_bound,
+    _in_gpd_support,
+    _log1p_div,
+)
+
+
+def logpdf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    # log g = log kappa + (kappa - 1) log H + log h. The carrier term vanishes
+    # at kappa = 1; guarding it keeps the GPD reduction exact at the lower
+    # endpoint (z = 0, log H = -inf), where (kappa - 1) * log H would be 0 * -inf.
+    carrier = pt.switch(pt.eq(kappa, 1.0), 0.0, (kappa - 1) * _gpd_log_H(z, xi))
+    logp = pt.log(kappa) + carrier + _gpd_log_h(z, sigma, xi)
+    logp = pt.switch(_in_gpd_support(z, xi), logp, -np.inf)
+    logp = pt.switch(pt.eq(z, np.inf), -np.inf, logp)
+    return logp
+
+
+def logcdf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logcdf = pt.switch(above_upper, 0.0, kappa * _gpd_log_H(z, xi))
+    logcdf = pt.switch(z >= 0, logcdf, -np.inf)
+    logcdf = pt.switch(pt.eq(z, np.inf), 0.0, logcdf)
+    return logcdf
+
+
+def logsf(x, mu, sigma, xi, kappa):
+    z = (x - mu) / sigma
+    a = _gpd_log_S(z, xi)  # log(1 - H), accurate in the tail
+    log_H = pt.log1mexp(a)
+    generic = pt.log1mexp(kappa * log_H)
+    s = pt.exp(a)  # S_gpd
+    # r = kappa * S_gpd, formed via exp(log kappa + a) and capped at 1 so the unused
+    # (generic-branch) tail expression cannot overflow.
+    r = pt.exp(pt.minimum(pt.log(kappa) + a, 0.0))
+    # 1 - H**kappa = kappa S [1 + (s - r)/2 + (r**2 - 3 r s + 2 s**2)/6 + ...].
+    # This is a Taylor expansion in *both* S_gpd and kappa*S_gpd, so it is only
+    # valid where both are small; writing it in r = kappa S and s = S keeps every
+    # term bounded (no kappa**k powers, which overflow for huge kappa).
+    series_m1 = (s - r) / 2.0 + (r * r - 3.0 * r * s + 2.0 * s * s) / 6.0
+    tail = pt.log(kappa) + a + pt.log1p(series_m1)
+    # The Taylor tail runs where S_gpd and kappa*S_gpd are both below machine epsilon
+    # (a < log_eps and log(kappa) + a < log_eps); the generic log1mexp(kappa log H) runs
+    # otherwise. Both conditions gate the switch: for tiny kappa the second holds in the body
+    # (S_gpd ~ 1) too, where the Taylor does not apply.
+    log_eps = float(np.log(np.finfo(a.dtype).eps))
+    logsf = pt.switch(pt.and_(a < log_eps, pt.log(kappa) + a < log_eps), tail, generic)
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logsf = pt.switch(pt.or_(above_upper, pt.eq(z, np.inf)), -np.inf, logsf)
+    logsf = pt.switch(z < 0, 0.0, logsf)
+    return logsf
+
+
+def _ext_gpd_excess_from_log_prob(log_q, kappa):
+    """GPD excess ``m = -log(1 - F ** (1/kappa))`` from ``log_q = log F``.
+
+    For the carrier ``F = H ** kappa``, the GPD CDF is ``H = exp(log_q / kappa)``
+    and its survival ``1 - H``, so ``m = -log(1 - H) = -log1mexp(log_q / kappa)``
+    (``pt.log1mexp(a) = log(1 - exp(a))`` for ``a <= 0``). This form stays accurate when ``H``
+    rounds to ``1``: for small ``kappa`` the survival ``1 - H`` is tiny, and forming it directly
+    would collapse the excess to ``0`` (and the quantile to ``mu``). Shared
+    by the quantile, the sampler, ``support_point`` and the default transform so
+    all four inverses agree. ``log_q`` must be ``<= 0`` (a log-probability).
+    """
+    return -pt.log1mexp(log_q / kappa)
+
+
+def _ext_gpd_excess_from_logit(value, kappa):
+    """GPD excess ``m = -log S(x)`` from ``value = logit(F(x))``.
+
+    The ExtGPD CDF is ``F = G ** kappa = sigmoid(value)`` (``G`` the GPD CDF), so the excess
+    depends only on ``value`` and ``kappa``:
+        m = -log(1 - G) = -log(1 - sigmoid(value) ** (1/kappa)).
+    Evaluated stably in two branches split at a large cutoff. Writing
+    a := -log G = -log(sigmoid(value)) / kappa gives m = -log1mexp(-a):
+      bulk (value < cutoff): m = -log1mexp(log_F / kappa), log_F = log sigmoid(value).
+      tail (value >= cutoff, the extreme upper tail where F -> 1): a held in logs as log_a,
+        m = -log_a where a < eps, else -log1mexp(-a).
+    The unused branch's inputs are clamped (log_F via cutoff, a via log_max) so it stays finite.
+    """
+    finfo = np.finfo(value.dtype)
+    log_max = float(np.log(finfo.max))  # a = exp(min(log_a, log_max)) stays finite
+    log_eps = float(np.log(finfo.eps))  # at or below log_eps, m = -log_a
+    # cutoff is the large value where log_F / kappa reaches finfo.tiny. Near the tail
+    # log_F = -exp(-value), giving value = -log(tiny) - log(kappa); for kappa <= 1 it is -log(tiny).
+    cutoff = np.asarray(-np.log(finfo.tiny), dtype=value.dtype) - pt.maximum(
+        np.asarray(0.0, value.dtype), pt.log(kappa)
+    )
+    t = pt.softplus(value)
+    log_F = -pt.softplus(-pt.minimum(value, cutoff))
+    m_bulk = _ext_gpd_excess_from_log_prob(log_F, kappa)
+    s = pt.exp(-pt.maximum(t, cutoff))  # S_ext, clamped so _log1p_div stays finite
+    log_a = -t + pt.log(_log1p_div(-s)) - pt.log(kappa)
+    a = pt.exp(pt.minimum(log_a, log_max))
+    m_tail = pt.switch(log_a < log_eps, -log_a, -pt.log1mexp(-a))
+    return pt.switch(value < cutoff, m_bulk, m_tail)
+
+
+def ppf(q, mu, sigma, xi, kappa):
+    q = pt.as_tensor_variable(q)
+    # F = H ** kappa = q  ->  H = q ** (1/kappa); excess m = -log(1 - H), built
+    # with log1mexp so a tiny 1 - H (small kappa) is not rounded away to 0.
+    excess = _ext_gpd_excess_from_log_prob(pt.log(q), kappa)
+    x = _gpd_quantile_from_excess(excess, mu, sigma, xi)
+    return ppf_bounds_cont(x, q, mu, _gpd_upper_bound(mu, sigma, xi))
+
+
+def cdf(x, mu, sigma, xi, kappa):
+    return pt.exp(logcdf(x, mu, sigma, xi, kappa))
+
+
+def pdf(x, mu, sigma, xi, kappa):
+    return pt.exp(logpdf(x, mu, sigma, xi, kappa))
+
+
+def sf(x, mu, sigma, xi, kappa):
+    return pt.exp(logsf(x, mu, sigma, xi, kappa))
+
+
+def isf(x, mu, sigma, xi, kappa):
+    x = pt.as_tensor_variable(x)
+    # log F = log1p(-x), accurate for tiny x; ppf(1 - x) forms 1 - x first and loses it.
+    excess = _ext_gpd_excess_from_log_prob(pt.log1p(-x), kappa)
+    quantile = _gpd_quantile_from_excess(excess, mu, sigma, xi)
+    return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
+
+
+def rvs(mu, sigma, xi, kappa, size=None, random_state=None):
+    # Inverse-CDF on a carrier draw u = F; excess = -log(1 - u ** (1/kappa)).
+    u = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
+    excess = _ext_gpd_excess_from_log_prob(pt.log(u), kappa)
+    return _gpd_quantile_from_excess(excess, mu, sigma, xi)

--- a/pymc_extras/distributions/pytensor_genpareto.py
+++ b/pymc_extras/distributions/pytensor_genpareto.py
@@ -1,0 +1,170 @@
+#   Copyright 2022 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Generalized Pareto distribution."""
+
+import numpy as np
+import pytensor.tensor as pt
+
+from pytensor.tensor.variable import TensorVariable
+
+from pymc_extras.distributions.pytensor_distributions_helper import ppf_bounds_cont
+
+
+def _series_cutoff(dtype) -> float:
+    """``|u|`` below which the divided-difference helpers switch to their series.
+
+    The exact forms (``log(1 + u) / u``, ``(exp(u) - 1) / u``) are accurate in *value* for every
+    ``u != 0``, but autodiff builds their gradient as a difference that cancels with relative
+    error ``~ eps / |u|``. Balancing that against the series' ``~ u**4`` gradient-truncation
+    error puts the crossover at ``eps ** (1/5)``, so the cutoff tracks the dtype's ``eps`` (a
+    constant tuned for float64 is ~50x too small for float32). The crossover optimizes only
+    this single gradient (the first derivative), not the value (accurate either way) or higher
+    derivatives.
+    """
+    return float(np.finfo(dtype).eps) ** 0.2
+
+
+def _log1p_div(u: TensorVariable) -> TensorVariable:
+    """``log(1 + u) / u``, analytically continued across ``u = 0``.
+
+    ``safe_u`` keeps the naive branch away from ``u = 0`` where catastrophic cancellation occurs
+    for the gradient.
+    """
+    cutoff = _series_cutoff(u.dtype)
+    use_series = pt.lt(pt.abs(u), cutoff)
+    series = 1.0 - u / 2.0 + u**2 / 3.0 - u**3 / 4.0 + u**4 / 5.0
+    safe_u = pt.switch(use_series, np.asarray(1.0, dtype=u.dtype), u)
+    return pt.switch(use_series, series, pt.log1p(safe_u) / safe_u)
+
+
+def _expm1_div(u: TensorVariable) -> TensorVariable:
+    """``(exp(u) - 1) / u``, analytically continued across ``u = 0``.
+
+    Same series and ``safe_u`` construction as ``_log1p_div``.
+    """
+    cutoff = _series_cutoff(u.dtype)
+    use_series = pt.lt(pt.abs(u), cutoff)
+    series = 1.0 + u / 2.0 + u**2 / 6.0 + u**3 / 24.0 + u**4 / 120.0
+    safe_u = pt.switch(use_series, np.asarray(1.0, dtype=u.dtype), u)
+    return pt.switch(use_series, series, pt.expm1(safe_u) / safe_u)
+
+
+def _gpd_log_h(z, sigma, xi):
+    """GPD log-density, in-support expression (no support masking)."""
+    t = xi * z
+    return -pt.log(sigma) - pt.log1p(t) - z * _log1p_div(t)
+
+
+def _gpd_log_S(z, xi):
+    """GPD log survival ``log(1 - H) = -m``, in-support expression.
+
+    Computed directly from the survival exponent ``m = log1p(xi z) / xi`` rather
+    than as ``log1mexp(log H)``, so it stays accurate arbitrarily deep in the upper
+    tail (where ``log H -> 0`` and any ``H``-based route underflows).
+    """
+    return -(z * _log1p_div(xi * z))
+
+
+def _gpd_log_H(z, xi):
+    """GPD log-CDF, in-support expression (no support masking / no saturation)."""
+    return pt.log1mexp(_gpd_log_S(z, xi))
+
+
+def _gpd_quantile_from_excess(excess, mu, sigma, xi):
+    """Invert the GPD given ``excess = -log(survival) = m >= 0``.
+
+    ``z = expm1(xi m) / xi = m * expm1_div(xi m)`` -> ``value = mu + sigma z``.
+    Reused by the ``icdf`` method (``excess`` from a CDF probability) and by the
+    random Op (``excess`` from a uniform survival draw).
+    """
+    return mu + sigma * excess * _expm1_div(xi * excess)
+
+
+def _gpd_upper_bound(mu, sigma, xi):
+    """Right endpoint of the GPD support: ``mu - sigma / xi`` for xi < 0, else +inf."""
+    has_bounded_support = pt.lt(xi, 0)
+    div_xi = pt.switch(has_bounded_support, xi, 1.0)  # 1.0: arbitrary finite, discarded below
+    return pt.switch(has_bounded_support, mu - sigma / div_xi, np.inf)
+
+
+def _in_gpd_support(z, xi):
+    """GPD support mask: ``z >= 0`` and (for ``xi < 0``) ``s = 1 + xi z > 0``."""
+    return pt.and_(z >= 0, 1 + xi * z > 0)
+
+
+def logpdf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    logp = pt.switch(_in_gpd_support(z, xi), _gpd_log_h(z, sigma, xi), -np.inf)
+    # The density vanishes at the +inf tail for every xi; for xi > 0 the
+    # in-support branch would evaluate log1p(inf)/inf -> nan there, so pin
+    # z = +inf to -inf explicitly.
+    logp = pt.switch(pt.eq(z, np.inf), -np.inf, logp)
+    return logp
+
+
+def logcdf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    # Three regions: below mu -> 0 (log -inf); for xi < 0 past the finite upper
+    # endpoint mu - sigma/xi -> 1 (log 0); else log1mexp(-m).
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logcdf = pt.switch(above_upper, 0.0, _gpd_log_H(z, xi))
+    logcdf = pt.switch(z >= 0, logcdf, -np.inf)
+    # CDF -> 1 (logcdf 0) at the +inf tail; for xi > 0 _gpd_log_H(inf) is nan.
+    logcdf = pt.switch(pt.eq(z, np.inf), 0.0, logcdf)
+    return logcdf
+
+
+def logsf(x, mu, sigma, xi):
+    z = (x - mu) / sigma
+    # m directly (log S = -m): accurate in the heavy tail, where the generic
+    # log1mexp(logcdf) survival fallback collapses (logcdf -> 0 there).
+    logsf = _gpd_log_S(z, xi)
+    # For xi < 0 past the finite upper endpoint, and at the +inf tail, S = 0.
+    above_upper = pt.and_(pt.lt(xi, 0), pt.le(1 + xi * z, 0))
+    logsf = pt.switch(pt.or_(above_upper, pt.eq(z, np.inf)), -np.inf, logsf)
+    # Below mu the survival is 1 (logsf 0).
+    logsf = pt.switch(z < 0, 0.0, logsf)
+    return logsf
+
+
+def ppf(q, mu, sigma, xi):
+    q = pt.as_tensor_variable(q)
+    x = _gpd_quantile_from_excess(-pt.log1p(-q), mu, sigma, xi)  # excess = -log(1 - q)
+    return ppf_bounds_cont(x, q, mu, _gpd_upper_bound(mu, sigma, xi))
+
+
+def cdf(x, mu, sigma, xi):
+    return pt.exp(logcdf(x, mu, sigma, xi))
+
+
+def pdf(x, mu, sigma, xi):
+    return pt.exp(logpdf(x, mu, sigma, xi))
+
+
+def sf(x, mu, sigma, xi):
+    return pt.exp(logsf(x, mu, sigma, xi))
+
+
+def isf(x, mu, sigma, xi):
+    x = pt.as_tensor_variable(x)
+    # m = -log(x) directly; ppf(1 - x) would lose a tiny x to the 1 - x rounding.
+    quantile = _gpd_quantile_from_excess(-pt.log(x), mu, sigma, xi)
+    return ppf_bounds_cont(quantile, x, _gpd_upper_bound(mu, sigma, xi), mu)
+
+
+def rvs(mu, sigma, xi, size=None, random_state=None):
+    # Inverse-CDF on a survival draw: excess = -log(v) avoids the 1 - v cancellation.
+    v = pt.random.uniform(size=size, rng=random_state, return_next_rng=True)[1]
+    return _gpd_quantile_from_excess(-pt.log(v), mu, sigma, xi)

--- a/tests/distributions/test_continuous.py
+++ b/tests/distributions/test_continuous.py
@@ -11,6 +11,7 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
+
 import numpy as np
 import pymc as pm
 

--- a/tests/distributions/test_generalized_pareto.py
+++ b/tests/distributions/test_generalized_pareto.py
@@ -1,0 +1,623 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+
+# general imports
+import pytest
+import scipy.stats.distributions as sp
+
+
+# test support imports from pymc
+from pymc.distributions.distribution import support_point as _support_point
+from pymc.logprob.utils import ParameterValueError
+from pymc.testing import (
+    BaseTestDistributionRandom,
+    Domain,
+    Rplus,
+    Rplusbig,
+    assert_support_point_is_expected,
+    check_icdf,
+    check_logccdf,
+    check_logcdf,
+    check_logp,
+    check_selfconsistency_icdf,
+    select_by_precision,
+)
+from scipy import stats
+
+# the distributions to be tested
+from pymc_extras.distributions import ExtGenPareto, GenPareto
+
+# xi is unconstrained, so (None, None) edges skip the harness's invalid-edge probe.
+# Bounded to (-1, 1]: xi <= -1 diverges at the wall (see TestGenParetoBoundaries) and
+# xi > 1 pushes the q=0.99 quantile past check_icdf's absolute tolerance.
+XI_DOMAIN = Domain([-0.9, -0.5, -0.1, 0, 0.1, 0.5, 1], dtype="float64", edges=(None, None))
+# Leading 0 lets the harness probe the invalid kappa <= 0; trailing inf is unbounded.
+KAPPA_DOMAIN = Domain([0, 0.25, 0.5, 1, 2, 5, np.inf], dtype="float64")
+# sigma capped so check_icdf's absolute tolerance holds on the heavy-tail quantiles.
+SIGMA_ICDF = Domain([0, 0.1, 0.5, 1.0, 2.0, np.inf], dtype="float64")
+
+
+def ref_ext_logp(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0 or (1 + xi * z) <= 0:
+        return -np.inf
+    log_H = sp.genpareto.logcdf(z, c=xi)
+    log_h = sp.genpareto.logpdf(z, c=xi) - np.log(sigma)
+    return np.log(kappa) + (kappa - 1) * log_H + log_h
+
+
+def ref_ext_logcdf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0:
+        return -np.inf
+    if xi < 0 and (1 + xi * z) <= 0:
+        return 0.0
+    return kappa * sp.genpareto.logcdf(z, c=xi)
+
+
+def ref_ext_logccdf(value, mu, sigma, xi, kappa):
+    # S = 1 - H ** kappa, with H the GPD CDF. Compute via the GPD log-CDF so the
+    # reference stays accurate deep in the tail (where H -> 1 and the naive
+    # 1 - H**kappa underflows to 0) -- exactly the regime logccdf is for.
+    z = (value - mu) / sigma
+    if z < 0:
+        return 0.0
+    if xi < 0 and (1 + xi * z) <= 0:
+        return -np.inf
+    return np.log(-np.expm1(kappa * sp.genpareto.logcdf(z, c=xi)))
+
+
+def ref_ext_icdf(q, mu, sigma, xi, kappa):
+    # G^{-1}(q) = H^{-1}(q ** (1/kappa)).
+    return sp.genpareto.ppf(q ** (1 / kappa), c=xi, loc=mu, scale=sigma)
+
+
+class TestGenParetoClass:
+    """
+    Wrapper class so that tests of experimental additions can be dropped into
+    PyMC directly on adoption.
+    """
+
+    def test_logp(self):
+        check_logp(
+            GenPareto,
+            Rplusbig,
+            {"mu": Domain([0], edges=(None, None)), "sigma": Rplusbig, "xi": XI_DOMAIN},
+            lambda value, mu, sigma, xi: sp.genpareto.logpdf(value, c=xi, loc=mu, scale=sigma),
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_logcdf(self):
+        check_logcdf(
+            GenPareto,
+            Rplusbig,
+            {"mu": Domain([0], edges=(None, None)), "sigma": Rplusbig, "xi": XI_DOMAIN},
+            lambda value, mu, sigma, xi: sp.genpareto.logcdf(value, c=xi, loc=mu, scale=sigma),
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_logccdf(self):
+        # log survival function: exact and tail-stable (vs the lossy
+        # log1mexp(logcdf) fallback). Compared against scipy genpareto.logsf.
+        check_logccdf(
+            GenPareto,
+            Rplusbig,
+            {"mu": Domain([0], edges=(None, None)), "sigma": Rplusbig, "xi": XI_DOMAIN},
+            lambda value, mu, sigma, xi: sp.genpareto.logsf(value, c=xi, loc=mu, scale=sigma),
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_icdf(self):
+        check_icdf(
+            GenPareto,
+            {"mu": Domain([0], edges=(None, None)), "sigma": SIGMA_ICDF, "xi": XI_DOMAIN},
+            lambda q, mu, sigma, xi: sp.genpareto.ppf(q, c=xi, loc=mu, scale=sigma),
+            decimal=select_by_precision(float64=5, float32=3),
+        )
+
+    def test_icdf_selfconsistency(self):
+        # cdf(icdf(q)) == q, no scipy reference needed.
+        check_selfconsistency_icdf(
+            GenPareto,
+            {"mu": Domain([0], edges=(None, None)), "sigma": SIGMA_ICDF, "xi": XI_DOMAIN},
+            decimal=select_by_precision(float64=5, float32=3),
+        )
+
+    @pytest.mark.parametrize(
+        "mu, sigma, xi, size, expected",
+        [
+            (0.0, 1.0, 0.0, None, np.log(2.0)),
+            (2.0, 3.0, 0.5, None, 2.0 + 3.0 * (2.0**0.5 - 1) / 0.5),
+            (0.0, 1.0, 0.0, (3,), np.full(3, np.log(2.0))),
+        ],
+    )
+    def test_genpareto_support_point(self, mu, sigma, xi, size, expected):
+        with pm.Model() as model:
+            GenPareto("x", mu=mu, sigma=sigma, xi=xi, size=size)
+        assert_support_point_is_expected(model, expected)
+
+    def test_rng_matches_scipy(self):
+        # Inverse-CDF sampling cannot match SciPy's draws element-wise (different
+        # uniform stream), so compare distributionally via a KS test.
+        for xi in (-0.3, 0.0, 0.4):
+            draws = pm.draw(GenPareto.dist(mu=0.0, sigma=2.0, xi=xi, size=20_000), random_seed=11)
+            ks = stats.kstest(draws, lambda v, xi=xi: sp.genpareto.cdf(v, c=xi, scale=2.0))
+            assert ks.pvalue > 0.01
+
+
+class TestGenPareto(BaseTestDistributionRandom):
+    pymc_dist = GenPareto
+    pymc_dist_params = {"mu": 0.0, "sigma": 2.0, "xi": 0.3}
+    expected_rv_op_params = {"mu": 0.0, "sigma": 2.0, "xi": 0.3}
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
+
+
+class TestExtGenParetoClass:
+    """
+    Wrapper class so that tests of experimental additions can be dropped into
+    PyMC directly on adoption.
+    """
+
+    def test_logp(self):
+        check_logp(
+            ExtGenPareto,
+            Rplus,
+            {
+                "mu": Domain([0], edges=(None, None)),
+                "sigma": Rplusbig,
+                "xi": XI_DOMAIN,
+                "kappa": KAPPA_DOMAIN,
+            },
+            ref_ext_logp,
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_logcdf(self):
+        check_logcdf(
+            ExtGenPareto,
+            Rplus,
+            {
+                "mu": Domain([0], edges=(None, None)),
+                "sigma": Rplusbig,
+                "xi": XI_DOMAIN,
+                "kappa": KAPPA_DOMAIN,
+            },
+            ref_ext_logcdf,
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_logccdf(self):
+        check_logccdf(
+            ExtGenPareto,
+            Rplus,
+            {
+                "mu": Domain([0], edges=(None, None)),
+                "sigma": Rplusbig,
+                "xi": XI_DOMAIN,
+                "kappa": KAPPA_DOMAIN,
+            },
+            ref_ext_logccdf,
+            decimal=select_by_precision(float64=6, float32=3),
+        )
+
+    def test_icdf(self):
+        check_icdf(
+            ExtGenPareto,
+            {
+                "mu": Domain([0], edges=(None, None)),
+                "sigma": SIGMA_ICDF,
+                "xi": XI_DOMAIN,
+                "kappa": KAPPA_DOMAIN,
+            },
+            ref_ext_icdf,
+            decimal=select_by_precision(float64=5, float32=3),
+        )
+
+    def test_icdf_selfconsistency(self):
+        check_selfconsistency_icdf(
+            ExtGenPareto,
+            {
+                "mu": Domain([0], edges=(None, None)),
+                "sigma": SIGMA_ICDF,
+                "xi": XI_DOMAIN,
+                "kappa": KAPPA_DOMAIN,
+            },
+            decimal=select_by_precision(float64=5, float32=3),
+        )
+
+    @pytest.mark.parametrize(
+        "mu, sigma, xi, kappa, size",
+        [
+            (0.0, 1.0, 0.0, 2.0, None),
+            (1.0, 2.0, 0.3, 0.5, None),
+            (0.0, 1.0, -0.2, 3.0, (4,)),
+        ],
+    )
+    def test_extgenpareto_support_point(self, mu, sigma, xi, kappa, size):
+        with pm.Model() as model:
+            ExtGenPareto("x", mu=mu, sigma=sigma, xi=xi, kappa=kappa, size=size)
+        expected = ref_ext_icdf(0.5, mu, sigma, xi, kappa)
+        if size is not None:
+            expected = np.full(size, expected)
+        assert_support_point_is_expected(model, expected)
+
+    @pytest.mark.parametrize("kappa", [0.5, 0.01])
+    def test_small_kappa_inverses_share_the_stable_excess(self, kappa):
+        # icdf, the transform's backward, and support_point share one log1mexp carrier
+        # inverse, so for small kappa they agree and stay strictly above mu instead of
+        # collapsing onto it (a -log(-expm1(.)) form would round the tiny survival to 1,
+        # sending the excess to 0 and the initial logp to -inf).
+        mu, sigma = 0.0, 1.0
+        median = ref_ext_icdf(0.5, mu, sigma, 0.0, kappa)
+        assert median > mu
+
+        icdf_half = float(
+            pm.icdf(ExtGenPareto.dist(mu=mu, sigma=sigma, xi=0.0, kappa=kappa), 0.5).eval()
+        )
+        np.testing.assert_allclose(icdf_half, median, rtol=1e-9)
+
+        with pm.Model() as model:
+            ExtGenPareto("x", mu=mu, sigma=sigma, xi=0.0, kappa=kappa)
+        rv = model.free_RVs[0]
+        tr = model.rvs_to_transforms[rv]
+        backward0 = float(tr.backward(np.array(0.0), *rv.owner.inputs).eval())
+        np.testing.assert_allclose(backward0, median, rtol=1e-9)  # y = logit(0.5) = 0
+
+        assert_support_point_is_expected(model, np.array(median))
+        assert np.isfinite(model.compile_logp()(model.initial_point()))
+
+    @pytest.mark.parametrize("kappa", [1e-4, 1e-300])
+    def test_support_point_floors_when_median_collapses(self, kappa):
+        # support_point is backward(0) (the median, at transformed y = 0). For small kappa the
+        # median rounds onto mu, so the floor keeps it just above mu and the transformed initial
+        # point stays finite (it would be -inf exactly at mu). mu = 2 makes even kappa = 1e-4
+        # collapse (median excess below ULP(mu)).
+        mu, sigma = 2.0, 1.5
+        with pm.Model() as model:
+            ExtGenPareto("x", mu=mu, sigma=sigma, xi=0.0, kappa=kappa)
+        rv = model.free_RVs[0]
+        sp = float(_support_point(rv).eval())
+        finfo = np.finfo(np.float64)
+        floor = abs(mu) * (8.0 * finfo.eps) + finfo.tiny  # same floor as the backward transform
+        np.testing.assert_allclose(sp, mu + floor, rtol=1e-12)
+        assert sp > mu
+        # finite transformed initial point and logp for every kappa > 0
+        assert np.isfinite(model.compile_logp()(model.initial_point()))
+
+    def test_support_point_is_transformed_median(self):
+        # For ordinary kappa the median is interior; as backward(0) it maps to the transformed
+        # Logistic's center y = 0.
+        with pm.Model() as model:
+            ExtGenPareto("x", mu=0.0, sigma=1.0, xi=0.3, kappa=2.0)
+        (y_init,) = model.initial_point().values()
+        np.testing.assert_allclose(y_init, 0.0, atol=1e-9)
+
+    def test_rng_matches_distribution(self):
+        # No SciPy equivalent: check that the empirical CDF (the model's own
+        # logcdf) of the draws is Uniform(0, 1) via a KS test.
+        for xi, kappa in ((-0.2, 0.5), (0.0, 0.01), (0.0, 2.0), (0.3, 3.0)):
+            dist = ExtGenPareto.dist(mu=0.0, sigma=1.0, xi=xi, kappa=kappa, size=20_000)
+            draws = pm.draw(dist, random_seed=7)
+            u = np.exp(
+                pm.logcdf(ExtGenPareto.dist(mu=0.0, sigma=1.0, xi=xi, kappa=kappa), draws).eval()
+            )
+            assert stats.kstest(u, "uniform").pvalue > 0.01
+
+
+class TestExtGenPareto(BaseTestDistributionRandom):
+    pymc_dist = ExtGenPareto
+    pymc_dist_params = {"mu": 0.0, "sigma": 1.5, "xi": 0.2, "kappa": 2.0}
+    expected_rv_op_params = {"mu": 0.0, "sigma": 1.5, "xi": 0.2, "kappa": 2.0}
+    tests_to_run = ["check_pymc_params_match_rv_op", "check_rv_size"]
+
+
+class TestGenParetoBoundaries:
+    """Explicit boundary / invalid-input behaviour for both GPD classes.
+
+    Covers ``x = inf``, ``q = 0``, ``q = 1`` (with ``xi < 0``), and ``sigma`` /
+    ``kappa`` out of range.
+    """
+
+    def test_logp_logcdf_at_infinity(self):
+        # density at +inf is 0 (logp -inf); CDF at +inf is 1 (logcdf 0). The
+        # xi=0 path is the delicate one: 0*inf is nan, so the +inf tail is pinned
+        # explicitly. Batch the three xi into one dist so each method compiles once.
+        xi = np.array([-0.5, 0.0, 0.5])
+        for dist in (
+            GenPareto.dist(mu=0.0, sigma=1.0, xi=xi),
+            ExtGenPareto.dist(mu=0.0, sigma=1.0, xi=xi, kappa=2.0),
+        ):
+            assert np.all(pm.logp(dist, np.inf).eval() == -np.inf)
+            assert np.all(pm.logcdf(dist, np.inf).eval() == 0.0)
+
+    def test_icdf_endpoints(self):
+        # q=0 -> mu (lower endpoint); q=1 -> finite upper bound (xi<0) or +inf.
+        # Batch the three xi into one dist so each endpoint compiles once, not per xi.
+        xi = np.array([-0.5, 0.0, 0.5])
+        with np.errstate(divide="ignore"):  # xi = 0 -> inf upper bound, not a warning
+            expected_hi = np.where(xi < 0, 1.0 - 2.0 / xi, np.inf)
+        # ExtGPD shares the same endpoints (carrier maps 0->0, 1->1).
+        gpd = GenPareto.dist(mu=1.0, sigma=2.0, xi=xi)
+        ext = ExtGenPareto.dist(mu=1.0, sigma=2.0, xi=xi, kappa=np.array([2.0, 0.5, 3.0]))
+        for dist in (gpd, ext):
+            assert np.all(pm.icdf(dist, 0.0).eval() == 1.0)
+            np.testing.assert_allclose(pm.icdf(dist, 1.0).eval(), expected_hi)
+
+    def test_icdf_outside_unit_interval_is_nan(self):
+        for q in (-0.1, 1.1):
+            assert np.isnan(pm.icdf(GenPareto.dist(mu=0.0, sigma=1.0, xi=0.2), q).eval())
+            ext = ExtGenPareto.dist(mu=0.0, sigma=1.0, xi=0.2, kappa=2.0)
+            assert np.isnan(pm.icdf(ext, q).eval())
+
+    def test_invalid_sigma_raises(self):
+        for sigma in (0.0, -1.0):
+            with pytest.raises(ParameterValueError):
+                pm.logp(GenPareto.dist(mu=0.0, sigma=sigma, xi=0.1), 1.0).eval()
+            with pytest.raises(ParameterValueError):
+                pm.logp(ExtGenPareto.dist(mu=0.0, sigma=sigma, xi=0.1, kappa=2.0), 1.0).eval()
+
+    def test_invalid_kappa_raises(self):
+        # kappa <= 0 and kappa = nan both fail the kappa > 0 check and raise.
+        for kappa in (0.0, -1.0, np.nan):
+            with pytest.raises(ParameterValueError):
+                pm.logp(ExtGenPareto.dist(mu=0.0, sigma=1.0, xi=0.1, kappa=kappa), 1.0).eval()
+
+
+class TestGenParetoHeavyTail:
+    """Heavy-tail (xi > 1) coverage with *relative* tolerance.
+
+    The generic ``check_icdf`` harness uses an absolute tolerance, so it cannot
+    exercise xi > 1 -- the quantiles there are ~1e10 and dwarf any absolute
+    bound. But xi > 1 is precisely the infinite-mean regime where the median
+    ``support_point`` matters, so test it directly against SciPy with rtol.
+    """
+
+    @pytest.mark.parametrize("xi", [1.5, 3.0])
+    def test_support_point_is_median_with_infinite_mean(self, xi):
+        # mean is infinite for xi >= 1, so support_point must fall back to the
+        # median (not the mean) -- check it equals the GPD median.
+        mu, sigma = 1.0, 2.0
+        with pm.Model() as model:
+            GenPareto("x", mu=mu, sigma=sigma, xi=xi)
+        expected = sp.genpareto.ppf(0.5, c=xi, loc=mu, scale=sigma)
+        assert_support_point_is_expected(model, expected)
+
+    def test_ext_support_point_median_infinite_mean(self):
+        mu, sigma, xi, kappa = 0.0, 1.0, 2.0, 3.0
+        with pm.Model() as model:
+            ExtGenPareto("x", mu=mu, sigma=sigma, xi=xi, kappa=kappa)
+        expected = ref_ext_icdf(0.5, mu, sigma, xi, kappa)
+        assert_support_point_is_expected(model, expected)
+
+
+class TestGenParetoTransforms:
+    """Both distributions register a default probability-integral transform.
+
+    Without a transform, an unobserved (latent) GPD variable would be sampled on
+    all of R, where every proposal below mu has -inf logp -- breaking NUTS. The
+    transform maps to the (parameter-dependent) support, so sampling stays valid
+    for both the heavy (xi >= 0) and bounded (xi < 0) regimes. A naive Interval
+    transform would do this too, but its log-Jacobian is discontinuous in xi at
+    0; the probability-integral transform (``y = logit(F(x))``) is C1 in every
+    parameter, so it does not inject a gradient kink when xi is random.
+    """
+
+    def test_default_transform_is_registered(self):
+        with pm.Model() as model:
+            x = GenPareto("x", mu=5.0, sigma=1.0, xi=0.3)
+            e = ExtGenPareto("e", mu=2.0, sigma=1.0, xi=-0.4, kappa=2.0)
+        assert model.rvs_to_transforms[x] is not None
+        assert model.rvs_to_transforms[e] is not None
+
+    @pytest.mark.parametrize(
+        "dist_kwargs, builder",
+        [
+            ({"mu": 0.0, "sigma": 1.5, "xi": -0.5}, GenPareto),
+            ({"mu": 0.0, "sigma": 1.5, "xi": 0.0}, GenPareto),
+            ({"mu": 0.0, "sigma": 1.5, "xi": 0.5}, GenPareto),
+            ({"mu": 0.0, "sigma": 1.0, "xi": -0.3, "kappa": 2.0}, ExtGenPareto),
+            ({"mu": 0.0, "sigma": 1.0, "xi": 0.3, "kappa": 2.0}, ExtGenPareto),
+        ],
+    )
+    def test_transformed_density_integrates_to_one(self, dist_kwargs, builder):
+        # The transform's log-Jacobian must be correct: exp(transformed logp)
+        # integrates to 1 over the unconstrained line.
+        from scipy.integrate import trapezoid
+
+        with pm.Model() as model:
+            builder("x", **dist_kwargs)
+        y = model.value_vars[0]
+        logp = pytensor.function([y], model.logp(sum=True))
+        # The integrand is the smooth, exactly-Logistic transformed density, so 2001
+        # points over +-30 integrate to ~1e-13 (tail truncation dominates).
+        ys = np.linspace(-30, 30, 2001)
+        density = np.exp(np.array([float(logp(yi)) for yi in ys]))
+        np.testing.assert_allclose(trapezoid(density, ys), 1.0, atol=1e-3)
+
+    @pytest.mark.parametrize(
+        "builder, kwargs, ys, roundtrip",
+        [
+            # bounded xi<0: the y~37 sigmoid-saturation point; round-trips to ~45.
+            (GenPareto, {"mu": 0.0, "sigma": 1.5, "xi": -0.5}, (-45.0, -37.0, 37.0, 45.0), True),
+            # unbounded xi=0: exact arbitrarily far out.
+            (GenPareto, {"mu": 0.0, "sigma": 1.0, "xi": 0.0}, (-30.0, 100.0, 1000.0), False),
+            # heavy xi>0: below the y~709/xi quantile overflow.
+            (GenPareto, {"mu": 0.0, "sigma": 1.0, "xi": 0.3}, (37.0, 200.0, 400.0), False),
+            # bounded ExtGPD: carrier on the moving xi<0 wall.
+            (
+                ExtGenPareto,
+                {"mu": 0.0, "sigma": 1.0, "xi": -0.3, "kappa": 0.5},
+                (-45.0, -37.0, 37.0, 45.0),
+                True,
+            ),
+            # ExtGPD deep tail: the y~745 log-F underflow, recovered survival-side.
+            (
+                ExtGenPareto,
+                {"mu": 0.0, "sigma": 1.0, "xi": 0.0, "kappa": 2.0},
+                (-30.0, 100.0, 1000.0),
+                False,
+            ),
+            # ExtGPD large kappa: the inverse must depend on kappa.
+            (
+                ExtGenPareto,
+                {"mu": 0.0, "sigma": 1.0, "xi": 0.0, "kappa": 1e8},
+                (-30.0, 0.0, 30.0),
+                True,
+            ),
+            # ExtGPD kappa<1: the small-kappa inverse keeps a tiny survival off 0.
+            (
+                ExtGenPareto,
+                {"mu": 0.0, "sigma": 1.0, "xi": 0.0, "kappa": 1e-2},
+                (-5.0, 0.0, 40.0),
+                True,
+            ),
+            # ExtGPD collapse: quantile collapses onto mu, still exact finite Logistic.
+            (
+                ExtGenPareto,
+                {"mu": 2.0, "sigma": 1.0, "xi": 0.0, "kappa": 1e-300},
+                (-30.0, 0.0, 80.0),
+                False,
+            ),
+        ],
+        ids=[
+            "bounded-gpd",
+            "unbounded-gpd",
+            "heavy-gpd",
+            "bounded-ext",
+            "unbounded-ext-deep",
+            "ext-large-kappa",
+            "ext-small-kappa",
+            "ext-collapse",
+        ],
+    )
+    def test_transformed_logp_is_logistic_where_representable(self, builder, kwargs, ys, roundtrip):
+        # Where the quantile is representable the transformed logp equals Logistic(y),
+        # x stays in support (x >= mu), and the map round-trips. Covers the sigmoid
+        # saturation (y ~ 37), the deep tail, and ten orders of magnitude in kappa.
+        mu = kwargs["mu"]
+        with pm.Model() as model:
+            x = builder("x", **kwargs)
+        yv = model.value_vars[0]
+        inputs = x.owner.inputs
+        tr = model.rvs_to_transforms[x]
+        logp = pytensor.function([yv], model.logp(sum=True))
+        backward = pytensor.function([yv], tr.backward(yv, *inputs))
+        forward_backward = (
+            pytensor.function([yv], tr.forward(tr.backward(yv, *inputs), *inputs))
+            if roundtrip
+            else None
+        )
+        for y in ys:
+            lp = float(logp(y))
+            assert np.isfinite(lp), (kwargs, y)
+            np.testing.assert_allclose(lp, -np.logaddexp(0.0, y) - np.logaddexp(0.0, -y), atol=1e-6)
+            xb = float(backward(y))
+            assert np.isfinite(xb) and xb >= mu, (kwargs, y)  # support is [mu, ...)
+            if forward_backward is not None:
+                np.testing.assert_allclose(float(forward_backward(y)), y, atol=1e-6)
+
+    def test_transformed_logp_robust_in_unoptimized_mode(self):
+        # The transformed logp must not rely on the optimizer cancelling logp(backward)
+        # against log_jac_det: in fast_compile the numbers are evaluated, and over the
+        # whole reachable range (incl. the small-kappa collapse) it stays finite Logistic.
+        fast = pytensor.compile.mode.Mode(linker="py", optimizer="fast_compile")
+        cases = [
+            (GenPareto, {"mu": 2.0, "sigma": 1.5, "xi": -0.5}),
+            (GenPareto, {"mu": 0.0, "sigma": 1.0, "xi": 0.3}),
+            (ExtGenPareto, {"mu": 2.0, "sigma": 1.0, "xi": 0.0, "kappa": 0.0067}),
+            (ExtGenPareto, {"mu": 0.0, "sigma": 1e-50, "xi": 0.0, "kappa": 0.0067}),
+        ]
+        for builder, kw in cases:
+            with pm.Model() as model:
+                builder("x", **kw)
+            fn = pytensor.function([model.value_vars[0]], model.logp(sum=True), mode=fast)
+            for y in np.linspace(-25.0, 25.0, 51):
+                lp = float(fn(y))
+                assert not np.isnan(lp), (builder.__name__, kw, y)
+                logistic = -np.logaddexp(0.0, y) - np.logaddexp(0.0, -y)
+                np.testing.assert_allclose(lp, logistic, atol=1e-3)
+
+    def test_small_kappa_collapse_saturates_with_exact_density(self):
+        # For kappa << 1 the ExtGPD median sits ~0.5 ** (1/kappa) below mu, under
+        # ulp(mu), so the whole bulk is a numerical point mass: distinct y all map to
+        # the same floored x. The map is therefore NOT injective here -- but the
+        # sampled density stays exactly Logistic and the readout stays in support.
+        mu = 2.0
+        with pm.Model() as model:
+            x = ExtGenPareto("x", mu=mu, sigma=1.0, xi=0.0, kappa=0.01)
+        yv = model.value_vars[0]
+        tr = model.rvs_to_transforms[x]
+        inputs = x.owner.inputs
+        logp = pytensor.function([yv], model.logp(sum=True))
+        backward = pytensor.function([yv], tr.backward(yv, *inputs))
+        roundtrip = pytensor.function([yv], tr.forward(tr.backward(yv, *inputs), *inputs))
+        ys = (-10.0, -5.0, 0.0)
+        xs = [float(backward(y)) for y in ys]
+        rts = [float(roundtrip(y)) for y in ys]
+        # saturation: distinct y collapse onto one floored x, just above mu (in support)
+        assert xs[0] == xs[1] == xs[2] > mu
+        # so it is not injective here -- forward(backward(.)) is constant, not identity
+        assert rts[0] == rts[1] == rts[2]
+        # yet the sampled density is still exactly Logistic at each y
+        for y in ys:
+            np.testing.assert_allclose(
+                float(logp(y)), -np.logaddexp(0.0, y) - np.logaddexp(0.0, -y), atol=1e-2
+            )
+
+    def test_transform_finite_under_float32(self):
+        # dtype-aware floor: the small-kappa lower-tail collapse must not NaN under
+        # float32, where a literal 1e-300 floor underflows to 0 (leaving logp = +inf).
+        fast = pytensor.compile.mode.Mode(linker="py", optimizer="fast_compile")
+        with pytensor.config.change_flags(floatX="float32"):
+            with pm.Model() as model:
+                ExtGenPareto("x", mu=0.0, sigma=1.0, xi=0.0, kappa=1e-20)
+            fn = pytensor.function([model.value_vars[0]], model.logp(sum=True), mode=fast)
+            for y in (-10.0, 0.0, 10.0):
+                lp = float(fn(np.float32(y)))
+                assert not np.isnan(lp)
+                logistic = -np.logaddexp(0.0, y) - np.logaddexp(0.0, -y)
+                np.testing.assert_allclose(lp, logistic, atol=1e-2)
+
+    def test_transform_roundtrip_resolves_subnormal_kappa_tail(self):
+        # The PyTensor helper owns the exact excess value; this checks the PyMC
+        # transform still wires that stable inverse through backward/forward.
+        with pm.Model() as model:
+            x = ExtGenPareto("x", mu=0.0, sigma=1.0, xi=0.0, kappa=4e-309)
+        yv = model.value_vars[0]
+        tr = model.rvs_to_transforms[x]
+        inputs = x.owner.inputs
+        roundtrip = pytensor.function([yv], tr.forward(tr.backward(yv, *inputs), *inputs))
+        got = float(roundtrip(710.0))
+        assert np.isfinite(got)
+        np.testing.assert_allclose(got, 710.0, rtol=0, atol=1e-9)
+
+    def test_jacobian_gradient_is_continuous_through_xi_zero(self):
+        # Why y = logit(F(x)) and not an Interval transform: with random xi the
+        # transformed logp must be C1 in xi across 0; an Interval transform's Jacobian
+        # jumps by ~1e12 at xi = 0, driving divergences.
+        with pm.Model() as model:
+            xi = pm.Normal("xi", 0.0, 1.0)
+            GenPareto("x", mu=0.0, sigma=1.0, xi=xi)
+        val_xi = next(v for v in model.value_vars if v.name == "xi")
+        val_x = next(v for v in model.value_vars if v.name != "xi")
+        logp = model.logp(sum=True)
+        fn = pytensor.function([val_xi, val_x], pt.grad(logp, val_xi), on_unused_input="ignore")
+        grad_minus = float(fn(-1e-6, 0.5))
+        grad_plus = float(fn(1e-6, 0.5))
+        assert abs(grad_minus - grad_plus) < 1e-3

--- a/tests/distributions/test_pytensor_extgenpareto.py
+++ b/tests/distributions/test_pytensor_extgenpareto.py
@@ -1,0 +1,365 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from decimal import Decimal, getcontext
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+import scipy.stats.distributions as sp
+
+from scipy import stats
+
+from pymc_extras.distributions import pytensor_extgenpareto as ExtGenPareto
+from pymc_extras.distributions import pytensor_genpareto as GenPareto
+
+
+def ref_ext_logpdf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0 or (1 + xi * z) <= 0:
+        return -np.inf
+    log_H = sp.genpareto.logcdf(z, c=xi)
+    log_h = sp.genpareto.logpdf(z, c=xi) - np.log(sigma)
+    return np.log(kappa) + (kappa - 1) * log_H + log_h
+
+
+def ref_ext_logcdf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0:
+        return -np.inf
+    if xi < 0 and (1 + xi * z) <= 0:
+        return 0.0
+    return kappa * sp.genpareto.logcdf(z, c=xi)
+
+
+def ref_ext_logsf(value, mu, sigma, xi, kappa):
+    z = (value - mu) / sigma
+    if z < 0:
+        return 0.0
+    if xi < 0 and (1 + xi * z) <= 0:
+        return -np.inf
+    return np.log(-np.expm1(kappa * sp.genpareto.logcdf(z, c=xi)))
+
+
+def ref_ext_ppf(q, mu, sigma, xi, kappa):
+    return sp.genpareto.ppf(q ** (1 / kappa), c=xi, loc=mu, scale=sigma)
+
+
+def _gpd_ref_logp(value, mu, sigma, xi, kappa):
+    """100-digit ExtGPD logp from the exact margin ``s = 1 + xi*z``."""
+    getcontext().prec = 100
+    z = (Decimal(value) - mu) / sigma
+    log_s = (1 + xi * z).ln()
+    logp = -sigma.ln() - (1 + 1 / xi) * log_s
+    log_H = (1 - ((Decimal(-1) / xi) * log_s).exp()).ln()
+    return logp + kappa.ln() + (kappa - 1) * log_H
+
+
+def _gpd_ref_grad(value, params, which):
+    """High-precision central difference d logp / d ``which``."""
+    h = abs(params[which]) * Decimal("1e-22") or Decimal("1e-22")
+    hi = dict(params, **{which: params[which] + h})
+    lo = dict(params, **{which: params[which] - h})
+    return (_gpd_ref_logp(value, **hi) - _gpd_ref_logp(value, **lo)) / (2 * h)
+
+
+def _ext_gpd_excess_ref(y, kappa):
+    """High-precision GPD excess m = -log(1 - sigmoid(y) ** (1/kappa)) at xi = 0."""
+    getcontext().prec = 500
+    y, kappa = Decimal(y), Decimal(kappa)
+    log_sigmoid = -(1 + (-y).exp()).ln()
+    return float(-(1 - (log_sigmoid / kappa).exp()).ln())
+
+
+def test_functional_api_is_self_consistent():
+    x = np.array([0.3, 1.0, 3.0])
+    params = (0.0, 1.0, 0.2, 1.5)
+
+    np.testing.assert_allclose(
+        ExtGenPareto.cdf(x, *params).eval(), np.exp(ExtGenPareto.logcdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.pdf(x, *params).eval(), np.exp(ExtGenPareto.logpdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.sf(x, *params).eval(), np.exp(ExtGenPareto.logsf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.cdf(x, *params).eval() + ExtGenPareto.sf(x, *params).eval(),
+        1.0,
+        atol=1e-9,
+    )
+
+    q = np.array([0.1, 0.5, 0.9])
+    np.testing.assert_allclose(
+        ExtGenPareto.isf(q, *params).eval(), ExtGenPareto.ppf(1 - q, *params).eval()
+    )
+    assert np.all(np.isnan(ExtGenPareto.ppf(np.array([-0.1, 1.1]), *params).eval()))
+    np.testing.assert_allclose(float(ExtGenPareto.ppf(0.0, *params).eval()), 0.0)
+
+
+def test_isf_keeps_the_upper_tail():
+    # isf uses log1p(-x) (= log F) directly; ppf(1 - x) forms 1 - x first and loses the tiny
+    # survival x in the heavy upper tail. For xi = 0 the deep-tail isf is -log(x) + log(kappa);
+    # the direct route tracks it (rtol covers the O(x) asymptotic gap at x = 1e-8) while the naive
+    # ppf(1 - x) drifts off (~8e-4 at x = 1e-15).
+    x = np.array([1e-8, 1e-12, 1e-15])
+    for kappa in (0.5, 2.0, 10.0):
+        ref = -np.log(x) + np.log(kappa)
+        isf_val = ExtGenPareto.isf(x, 0.0, 1.0, 0.0, kappa).eval()
+        np.testing.assert_allclose(isf_val, ref, rtol=1e-9)
+        naive = ExtGenPareto.ppf(1 - x, 0.0, 1.0, 0.0, kappa).eval()
+        assert abs(isf_val[-1] - ref[-1]) < abs(naive[-1] - ref[-1])
+
+
+def test_rvs_shape_dtype_and_random_state():
+    params = (0.0, 1.0, 0.2, 1.5)
+    draws = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    )
+    out = draws.eval()
+    assert out.shape == (4, 3) and out.dtype == np.float64
+    assert np.all(out >= 0.0)
+
+    same = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    ).eval()
+    diff = ExtGenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(9))
+    ).eval()
+    np.testing.assert_array_equal(out, same)
+    assert not np.array_equal(out, diff)
+
+
+@pytest.mark.parametrize(
+    "mu, sigma, xi, kappa",
+    [
+        (0.0, 1.0, -0.3, 0.5),
+        (0.0, 1.0, 0.0, 2.0),
+        (1.0, 2.0, 0.4, 3.0),
+    ],
+)
+def test_logpdf_logcdf_logsf_ppf_match_references(mu, sigma, xi, kappa):
+    upper = mu - sigma / xi if xi < 0 else 10.0
+    x = np.linspace(mu + 0.05, upper - 0.05 if xi < 0 else upper, 20)
+    q = np.array([0.1, 0.5, 0.9])
+
+    np.testing.assert_allclose(
+        ExtGenPareto.logpdf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logpdf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+        atol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.logcdf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logcdf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.logsf(x, mu, sigma, xi, kappa).eval(),
+        [ref_ext_logsf(v, mu, sigma, xi, kappa) for v in x],
+        rtol=1e-8,
+    )
+    np.testing.assert_allclose(
+        ExtGenPareto.ppf(q, mu, sigma, xi, kappa).eval(),
+        ref_ext_ppf(q, mu, sigma, xi, kappa),
+        rtol=1e-10,
+    )
+
+
+def test_logpdf_logcdf_at_infinity():
+    x = pt.constant(np.inf)
+    xi = pt.constant(np.array([-0.5, 0.0, 0.5]))
+    assert np.all(ExtGenPareto.logpdf(x, 0.0, 1.0, xi, 2.0).eval() == -np.inf)
+    assert np.all(ExtGenPareto.logcdf(x, 0.0, 1.0, xi, 2.0).eval() == 0.0)
+
+
+def test_ppf_endpoints():
+    xi = np.array([-0.5, 0.0, 0.5])
+    kappa = np.array([2.0, 0.5, 3.0])
+    with np.errstate(divide="ignore"):
+        expected_hi = np.where(xi < 0, 1.0 - 2.0 / xi, np.inf)
+    assert np.all(ExtGenPareto.ppf(0.0, 1.0, 2.0, xi, kappa).eval() == 1.0)
+    np.testing.assert_allclose(ExtGenPareto.ppf(1.0, 1.0, 2.0, xi, kappa).eval(), expected_hi)
+
+
+def test_ppf_outside_unit_interval_is_nan():
+    for q in (-0.1, 1.1):
+        assert np.isnan(ExtGenPareto.ppf(q, 0.0, 1.0, 0.2, 2.0).eval())
+
+
+def test_logsf_reduces_to_gpd_at_kappa_one():
+    value = np.linspace(0.05, 8.0, 40)
+    for xi in (-0.3, 0.0, 0.4):
+        ext = ExtGenPareto.logsf(value, 0.0, 1.5, xi, 1.0).eval()
+        gpd = GenPareto.logsf(value, 0.0, 1.5, xi).eval()
+        np.testing.assert_allclose(ext, gpd, rtol=1e-12, atol=1e-12)
+
+
+def test_kappa_one_equals_gpd():
+    value = np.linspace(0.0, 8.0, 60)
+    for xi in (-0.3, -1e-8, 0.0, 0.25, 0.8):
+        ext = ExtGenPareto.logpdf(value, 0.0, 1.5, xi, 1.0).eval()
+        gpd = GenPareto.logpdf(value, 0.0, 1.5, xi).eval()
+        np.testing.assert_allclose(ext, gpd, rtol=1e-12, atol=1e-12)
+
+
+def test_rvs_matches_distribution():
+    for xi, kappa in ((-0.2, 0.5), (0.0, 2.0), (0.3, 3.0)):
+        draws = ExtGenPareto.rvs(
+            0.0, 1.0, xi, kappa, size=20_000, random_state=pytensor.shared(np.random.default_rng(7))
+        ).eval()
+        u = ExtGenPareto.cdf(draws, 0.0, 1.0, xi, kappa).eval()
+        assert stats.kstest(u, "uniform").pvalue > 0.01
+
+
+@pytest.mark.parametrize("kappa", [0.5, 0.01])
+def test_small_kappa_ppf_uses_stable_excess(kappa):
+    median = ref_ext_ppf(0.5, 0.0, 1.0, 0.0, kappa)
+    assert median > 0.0
+
+    got = float(ExtGenPareto.ppf(0.5, 0.0, 1.0, 0.0, kappa).eval())
+    np.testing.assert_allclose(got, median, rtol=1e-6)
+
+
+def test_small_kappa_draws_do_not_collapse_to_mu():
+    draws = ExtGenPareto.rvs(
+        0.0, 1.0, 0.0, 0.01, size=20_000, random_state=pytensor.shared(np.random.default_rng(7))
+    ).eval()
+    assert (draws >= 0.0).all()
+    assert np.mean(draws == 0.0) < 0.01
+
+
+@pytest.mark.parametrize("dtype", ["float64", "float32"])
+def test_excess_from_logit_across_cutoff_for_huge_kappa(dtype):
+    y = pt.scalar("y", dtype=dtype)
+    kappa = pt.scalar("kappa", dtype=dtype)
+    m = ExtGenPareto._ext_gpd_excess_from_logit(y, kappa)
+    f = pytensor.function([y, kappa], [m, *pt.grad(m, [y, kappa])])
+    rtol = 1e-12 if dtype == "float64" else 1e-5
+    ys = [0.0, 200.0, 500.0, 680.0, 700.0, 730.0] if dtype == "float64" else [0.0, 50.0, 70.0, 85.0]
+    for yv in ys:
+        for kv in (1.0, 1e3, 1e8, 1e15):
+            m_val, dy, dk = f(np.asarray(yv, dtype), np.asarray(kv, dtype))
+            assert np.all(np.isfinite([m_val, dy, dk])), f"non-finite at y={yv}, kappa={kv}"
+            np.testing.assert_allclose(
+                float(m_val),
+                _ext_gpd_excess_ref(yv, kv),
+                rtol=rtol,
+                err_msg=f"excess wrong at y={yv}, kappa={kv}",
+            )
+
+
+def test_excess_from_logit_upper_tail_is_finite_under_float32():
+    y = pt.scalar("y", dtype="float32")
+    excess = ExtGenPareto._ext_gpd_excess_from_logit(y, np.float32(2.0))
+    assert excess.dtype == "float32"
+    fn = pytensor.function([y], excess)
+    for yi in (90.0, 200.0, 700.0, 5000.0):
+        m = float(fn(np.float32(yi)))
+        assert np.isfinite(m)
+        np.testing.assert_allclose(m, yi + np.log(2.0), rtol=1e-3)
+
+
+def test_excess_from_logit_resolves_subnormal_kappa_tail():
+    y = pt.dscalar("y")
+    excess = float(
+        pytensor.function([y], ExtGenPareto._ext_gpd_excess_from_logit(y, 4e-309))(710.0)
+    )
+    assert excess > 0.0
+    np.testing.assert_allclose(excess, 0.395390331, rtol=1e-4)
+
+
+def test_logsf_stable_in_far_tail():
+    for kappa in (0.5, 1.0, 2.5, 5.0):
+        x = np.array([100.0, 300.0, 1000.0])
+        got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa).eval()
+        assert np.all(np.isfinite(got))
+        np.testing.assert_allclose(got, np.log(kappa) - x, rtol=1e-9)
+
+
+@pytest.mark.parametrize("kappa", [10.0, 1e155, 1e300])
+def test_logsf_is_a_valid_log_probability_for_large_kappa(kappa):
+    x = np.array([40.0, 100.0, 1000.0])
+    kappa_t = pt.constant(np.asarray(kappa, dtype="float64"))
+    got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa_t).eval()
+    assert np.all(got <= 0.0)
+    small = np.log(kappa) - x < -30.0
+    np.testing.assert_allclose(got[small], (np.log(kappa) - x)[small], rtol=1e-9)
+
+
+@pytest.mark.parametrize("kappa", [1e-2, 1e-100])
+def test_logsf_small_kappa_in_the_body_matches_reference(kappa):
+    x = np.array([0.01, 0.1, 0.5, 2.0])
+    got = ExtGenPareto.logsf(x, 0.0, 1.0, 0.0, kappa).eval()
+    ref = np.log(-np.expm1(kappa * np.log1p(-np.exp(-x))))
+    np.testing.assert_allclose(got, ref, rtol=1e-9)
+
+
+def test_boundary_logp_value_holds_but_gradient_tracks_the_margin():
+    mu, sigma, xi, kappa = 0.4, 1.3, -0.3, 2.5
+    eps = np.finfo(np.float64).eps
+    margins = [1e-2, 1e-6, 1e-12]
+
+    v, sig, xs, ks = (pt.dscalar(n) for n in ("v", "sig", "xs", "ks"))
+    logp = ExtGenPareto.logpdf(v, mu, sig, xs, ks)
+    fn = pytensor.function(
+        [v, sig, xs, ks],
+        [logp, pt.grad(logp, sig), pt.grad(logp, xs), pt.grad(logp, ks)],
+    )
+
+    params = {
+        "mu": Decimal(mu),
+        "sigma": Decimal(sigma),
+        "xi": Decimal(xi),
+        "kappa": Decimal(kappa),
+    }
+    prev_logp = np.inf
+    for s_target in margins:
+        value = mu + sigma * ((s_target - 1) / xi)
+        logp_f, *grads_f = (float(o) for o in fn(value, sigma, xi, kappa))
+        logp_ref = _gpd_ref_logp(value, **params)
+
+        assert np.isfinite(logp_f), s_target
+        assert all(np.isfinite(g) for g in grads_f), s_target
+        assert logp_f < prev_logp, s_target
+        prev_logp = logp_f
+        assert abs((Decimal(logp_f) - logp_ref) / logp_ref) < 1e-4, s_target
+
+        grad_bound = 100 * eps / s_target
+        for name, g in zip(["sigma", "xi", "kappa"], grads_f):
+            g_ref = _gpd_ref_grad(value, params, name)
+            rel = abs((Decimal(g) - g_ref) / g_ref)
+            assert np.sign(g) == np.sign(float(g_ref)), (name, s_target)
+            if name == "kappa":
+                assert rel < 1e-10, (name, s_target, float(rel))
+            else:
+                assert rel < grad_bound, (name, s_target, float(rel))
+
+
+def test_logp_gradient_is_continuous_through_xi_zero():
+    xi = pt.dscalar("xi")
+    logp = ExtGenPareto.logpdf(pt.constant(2.3), 0.0, 1.0, xi, 2.0)
+    fn = pytensor.function([xi], [logp, pt.grad(logp, xi)], on_unused_input="ignore")
+
+    _, grad0 = fn(0.0)
+    assert np.isfinite(grad0)
+    _, grad_minus = fn(-1e-7)
+    _, grad_plus = fn(1e-7)
+    assert abs(grad_minus - grad0) < 1e-5
+    assert abs(grad_plus - grad0) < 1e-5
+    h = 1e-5
+    fd = (fn(h)[0] - fn(-h)[0]) / (2 * h)
+    assert abs(grad0 - fd) < 1e-5

--- a/tests/distributions/test_pytensor_genpareto.py
+++ b/tests/distributions/test_pytensor_genpareto.py
@@ -1,0 +1,197 @@
+#   Copyright 2020 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+from decimal import Decimal, getcontext
+
+import numpy as np
+import pytensor
+import pytensor.tensor as pt
+import pytest
+import scipy.stats.distributions as sp
+
+from pymc_extras.distributions import pytensor_genpareto as GenPareto
+
+
+def _gpd_ref_logp(value, mu, sigma, xi):
+    """100-digit GPD logp from the exact margin ``s = 1 + xi*z``."""
+    getcontext().prec = 100
+    z = (Decimal(value) - mu) / sigma
+    log_s = (1 + xi * z).ln()
+    return -sigma.ln() - (1 + 1 / xi) * log_s
+
+
+def _gpd_ref_grad(value, params, which):
+    """High-precision central difference d logp / d ``which``."""
+    h = abs(params[which]) * Decimal("1e-22") or Decimal("1e-22")
+    hi = dict(params, **{which: params[which] + h})
+    lo = dict(params, **{which: params[which] - h})
+    return (_gpd_ref_logp(value, **hi) - _gpd_ref_logp(value, **lo)) / (2 * h)
+
+
+def test_functional_api_is_self_consistent():
+    x = np.array([0.3, 1.0, 3.0])
+    params = (0.0, 1.0, 0.2)
+
+    np.testing.assert_allclose(
+        GenPareto.cdf(x, *params).eval(), np.exp(GenPareto.logcdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.pdf(x, *params).eval(), np.exp(GenPareto.logpdf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.sf(x, *params).eval(), np.exp(GenPareto.logsf(x, *params).eval())
+    )
+    np.testing.assert_allclose(
+        GenPareto.cdf(x, *params).eval() + GenPareto.sf(x, *params).eval(), 1.0, atol=1e-9
+    )
+
+    q = np.array([0.1, 0.5, 0.9])
+    np.testing.assert_allclose(
+        GenPareto.isf(q, *params).eval(), GenPareto.ppf(1 - q, *params).eval()
+    )
+    assert np.all(np.isnan(GenPareto.ppf(np.array([-0.1, 1.1]), *params).eval()))
+    np.testing.assert_allclose(float(GenPareto.ppf(0.0, *params).eval()), 0.0)
+
+
+def test_rvs_shape_dtype_and_random_state():
+    params = (0.0, 1.0, 0.2)
+    draws = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    )
+    out = draws.eval()
+    assert out.shape == (4, 3) and out.dtype == np.float64
+    assert np.all(out >= 0.0)
+
+    same = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(0))
+    ).eval()
+    diff = GenPareto.rvs(
+        *params, size=(4, 3), random_state=pytensor.shared(np.random.default_rng(9))
+    ).eval()
+    np.testing.assert_array_equal(out, same)
+    assert not np.array_equal(out, diff)
+
+
+def test_logp_logcdf_at_infinity():
+    x = pt.constant(np.inf)
+    xi = pt.constant(np.array([-0.5, 0.0, 0.5]))
+    assert np.all(GenPareto.logpdf(x, 0.0, 1.0, xi).eval() == -np.inf)
+    assert np.all(GenPareto.logcdf(x, 0.0, 1.0, xi).eval() == 0.0)
+
+
+def test_ppf_endpoints():
+    xi = np.array([-0.5, 0.0, 0.5])
+    with np.errstate(divide="ignore"):
+        expected_hi = np.where(xi < 0, 1.0 - 2.0 / xi, np.inf)
+    assert np.all(GenPareto.ppf(0.0, 1.0, 2.0, xi).eval() == 1.0)
+    np.testing.assert_allclose(GenPareto.ppf(1.0, 1.0, 2.0, xi).eval(), expected_hi)
+
+
+def test_ppf_outside_unit_interval_is_nan():
+    for q in (-0.1, 1.1):
+        assert np.isnan(GenPareto.ppf(q, 0.0, 1.0, 0.2).eval())
+
+
+@pytest.mark.parametrize("xi", [1.5, 5.0])
+def test_heavy_tail_logpdf_logcdf_ppf_match_scipy(xi):
+    mu, sigma = 0.0, 1.3
+    x = np.array([0.5, 2.0, 10.0, 1e4])
+    np.testing.assert_allclose(
+        GenPareto.logpdf(x, mu, sigma, xi).eval(),
+        sp.genpareto.logpdf(x, c=xi, loc=mu, scale=sigma),
+        rtol=1e-10,
+    )
+    np.testing.assert_allclose(
+        GenPareto.logcdf(x, mu, sigma, xi).eval(),
+        sp.genpareto.logcdf(x, c=xi, loc=mu, scale=sigma),
+        rtol=1e-10,
+    )
+    q = np.array([0.1, 0.5, 0.9, 0.99, 0.999])
+    np.testing.assert_allclose(
+        GenPareto.ppf(q, mu, sigma, xi).eval(),
+        sp.genpareto.ppf(q, c=xi, loc=mu, scale=sigma),
+        rtol=1e-9,
+    )
+
+
+def test_logsf_tail_is_stable():
+    x = np.array([1e2, 1e4, 1e6, 1e8])
+    for xi in (0.1, 0.3, 0.7):
+        got = GenPareto.logsf(x, 0.0, 1.0, xi).eval()
+        ref = sp.genpareto.logsf(x, c=xi)
+        np.testing.assert_allclose(got, ref, rtol=1e-12)
+
+
+def test_isf_keeps_the_upper_tail():
+    x = np.array([1e-8, 1e-12, 1e-15])
+    xi = pt.constant(0.0)
+    isf_val = GenPareto.isf(x, 0.0, 1.0, xi).eval()
+    np.testing.assert_allclose(isf_val, -np.log(x), rtol=1e-12)
+    naive = GenPareto.ppf(1 - x, 0.0, 1.0, xi).eval()
+    assert abs(isf_val[-1] - -np.log(x[-1])) < abs(naive[-1] - -np.log(x[-1]))
+
+
+def test_boundary_logp_value_holds_but_gradient_tracks_the_margin():
+    mu, sigma, xi = 0.4, 1.3, -0.3
+    eps = np.finfo(np.float64).eps
+    margins = [1e-2, 1e-6, 1e-12]
+
+    v, sig, xs = (pt.dscalar(n) for n in ("v", "sig", "xs"))
+    logp = GenPareto.logpdf(v, mu, sig, xs)
+    fn = pytensor.function([v, sig, xs], [logp, pt.grad(logp, sig), pt.grad(logp, xs)])
+
+    params = {"mu": Decimal(mu), "sigma": Decimal(sigma), "xi": Decimal(xi)}
+    prev_logp = np.inf
+    for s_target in margins:
+        value = mu + sigma * ((s_target - 1) / xi)
+        logp_f, *grads_f = (float(o) for o in fn(value, sigma, xi))
+        logp_ref = _gpd_ref_logp(value, **params)
+
+        assert np.isfinite(logp_f), s_target
+        assert all(np.isfinite(g) for g in grads_f), s_target
+        assert logp_f < prev_logp, s_target
+        prev_logp = logp_f
+        assert abs((Decimal(logp_f) - logp_ref) / logp_ref) < 1e-4, s_target
+
+        grad_bound = 100 * eps / s_target
+        for name, g in zip(["sigma", "xi"], grads_f):
+            g_ref = _gpd_ref_grad(value, params, name)
+            rel = abs((Decimal(g) - g_ref) / g_ref)
+            assert np.sign(g) == np.sign(float(g_ref)), (name, s_target)
+            assert rel < grad_bound, (name, s_target, float(rel))
+
+
+def test_logp_gradient_is_continuous_through_xi_zero():
+    xi = pt.dscalar("xi")
+    logp = GenPareto.logpdf(pt.constant(2.3), 0.0, 1.0, xi)
+    fn = pytensor.function([xi], [logp, pt.grad(logp, xi)], on_unused_input="ignore")
+
+    _, grad0 = fn(0.0)
+    assert np.isfinite(grad0)
+    _, grad_minus = fn(-1e-7)
+    _, grad_plus = fn(1e-7)
+    assert abs(grad_minus - grad0) < 1e-5
+    assert abs(grad_plus - grad0) < 1e-5
+    h = 1e-5
+    fd = (fn(h)[0] - fn(-h)[0]) / (2 * h)
+    assert abs(grad0 - fd) < 1e-5
+
+
+def test_value_continuous_through_xi_zero():
+    value = np.linspace(0.05, 6.0, 50)
+    lp0 = GenPareto.logpdf(value, 0.0, 2.0, 0.0).eval()
+    for xi in (1e-9, -1e-9, 1e-6):
+        lp = GenPareto.logpdf(value, 0.0, 2.0, xi).eval()
+        np.testing.assert_allclose(lp, lp0, atol=1e-5)
+    np.testing.assert_allclose(lp0, sp.expon.logpdf(value, scale=2.0), atol=1e-12)


### PR DESCRIPTION
## Summary

Adds two distributions to `pymc_extras.distributions`:

- `GenPareto`: Generalized Pareto distribution, parametrized like SciPy's `genpareto` (`c = ξ`).
- `ExtGenPareto`: Naveau et al. Type-1 extended GPD, `F = H**κ`, where `H` is the GPD CDF.

Both include PyTensor kernels for `logp`, `logcdf`, `logccdf`, `icdf`, inverse-CDF RNGs, support points, and default transforms for latent variables.

## Implementation

The implementation is split by layer:

- `_pytensor_genpareto.py` / `_pytensor_extgenpareto.py`: PyTensor-only math, shaped to match `pytensor-distributions`.
- `_pymc_genpareto.py` / `_pymc_extgenpareto.py`: PyMC wrappers, `SymbolicRandomVariable`s, parameter checks, support points, and transforms.
- `continuous.py`: re-exports the public classes.

The wrappers validate `σ > 0` and `κ > 0` with `check_parameters`.

## Transform

The default transform is `y = logit(F(x))`: `F` maps the support onto `(0, 1)` and `logit` onto the real line, so the unconstrained variable is standard Logistic for every `ξ`. In testing with random `ξ` it produced far fewer divergences than interval-style or lower-bound transforms.

It is bijective wherever the quantile is representable. For very small `κ`, ExtGPD numerically collapses toward `μ`; in that case `backward` floors the readout just inside support, while the transformed density remains Logistic.

## Tests

Tests mirror the split:

- `test_generalized_pareto.py`: PyMC integration, dispatch, parameter checks, RNG shape/size, support points, and transform behavior.
- `test_pytensor_genpareto.py` / `test_pytensor_extgenpareto.py`: formula checks against SciPy/high-precision references, tail stability, boundary behavior, gradients, and functional `ppf` / `isf` / `rvs`.

Supersedes #638 and follows up earlier GPD work in #294.

