### PR TITLE
Bump and cap preliz version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           python -m pytest --color=yes -vv --cov=pymc_extras --cov-append --cov-report=xml --cov-report term --durations=50 $TEST_SUBSET
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           env_vars: TEST_SUBSET
           name: ${{ matrix.os }}
@@ -133,7 +133,7 @@ jobs:
         run: >-
           python -m pytest --color=yes -vv --cov=pymc_extras --cov-append --cov-report=xml --cov-report term --durations=50 %TEST_SUBSET%
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2  # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           env_vars: TEST_SUBSET
           name: ${{ matrix.os }}

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -14,7 +14,7 @@ dependencies:
   - pydantic>=2.0.0
   - h5netcdf
   - pymc>=6.0,<7.0
-  - preliz>=0.25
+  - preliz>=0.26,<0.27
   - pip
   - pip:
       - jax

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,9 +105,6 @@ filterwarnings =[
     # OpenMP library warning on windows CI
     'ignore::RuntimeWarning:threadpoolctl',
 
-    # ArviZ warning related to 1.0 release
-    'ignore:\nArviZ is undergoing a major refactor.*:FutureWarning',
-
     # Numba warnings that are filtered by PyTensor but re-introduced by pytest
     'ignore::numba.core.errors.NumbaPerformanceWarning',
     'ignore:.*Cannot cache compiled function.*:numba.core.errors.NumbaWarning',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
   "arviz>=1.1",
   "better-optimize>=0.4.2,<1.0",
   "pydantic>=2.0.0",
-  "preliz>=0.25.0",
+  "preliz>=0.26.0,<0.27.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,12 +102,6 @@ filterwarnings =[
     # JAX issues an over-eager warning if os.fork() is called when the JAX module is loaded, even if JAX isn't being used
     'ignore:os\.fork\(\) was called\.:RuntimeWarning',
 
-    # Preliz needs to update for pytensor > 2.35
-    'ignore:.*`pytensor\.graph\.basic\.ancestors`.*`pytensor\.graph\.traversal\.ancestors`.*:FutureWarning:^preliz(\.$)',
-
-    # Preliz triggers pytensor broadcastable deprecation internally
-    'ignore:The `broadcastable` keyword is deprecated:DeprecationWarning:pytensor',
-
     # OpenMP library warning on windows CI
     'ignore::RuntimeWarning:threadpoolctl',
 


### PR DESCRIPTION
I was hitting transitive failures due to a versioning mismatch between preliz and pytensor-distributions. This is fixed by preliz 0.26. I also added an upper pin to preliz to avoid future issues.