### PR TITLE
Deprecate save_kalman_filter_outputs_in_idata and always register data

### DIFF
--- a/pymc_extras/statespace/core/dummy_graph.py
+++ b/pymc_extras/statespace/core/dummy_graph.py
@@ -109,7 +109,6 @@ def kalman_filter_outputs_from_dummy_graph(
         n_obs=ss_mod.ssm.k_endog,
         obs_coords=obs_coords,
         data_dims=data_dims,
-        register_data=True,
     )
 
     filter_outputs = ss_mod.kalman_filter.build_graph(

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -491,7 +491,6 @@ def sample_filter_outputs(
             data,
             n_obs=ss_mod.ssm.k_endog,
             obs_coords=obs_coords,
-            register_data=True,
         )
 
         filter_outputs = ss_mod.kalman_filter.build_graph(

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -941,7 +941,6 @@ class PyMCStateSpace:
     def build_statespace_graph(
         self,
         data: np.ndarray | pd.DataFrame | pt.TensorVariable,
-        register_data: bool = True,
         missing_fill_value: float | None = None,
         cov_jitter: float | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
@@ -958,10 +957,6 @@ class PyMCStateSpace:
         data : Union[np.ndarray, pd.DataFrame, pt.TensorVariable]
             The observed data used to fit the state space model. It can be a NumPy array, a Pandas DataFrame,
             or a Pytensor tensor variable.
-
-        register_data : bool, optional, default=True
-            If True, the observed data will be registered with PyMC as a pm.Data variable. In addition,
-            a "time" dim will be created an added to the model's coords.
 
         mode : Optional[str], optional, default=None
             The Pytensor mode used for the computation graph construction. If None, the default mode will be used.
@@ -1043,7 +1038,6 @@ class PyMCStateSpace:
             data,
             n_obs=self.ssm.k_endog,
             obs_coords=obs_coords,
-            register_data=register_data,
             missing_fill_value=self.missing_fill_value,
         )
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -6,7 +6,6 @@ from typing import Any, Literal
 
 import numpy as np
 import pandas as pd
-import pymc as pm
 import pytensor
 import pytensor.tensor as pt
 
@@ -912,39 +911,12 @@ class PyMCStateSpace:
         replacement_dict = {var: step for var in n_timestep_variables}
         return graph_replace(matrices, replace=replacement_dict, strict=False)
 
-    @staticmethod
-    def _register_kalman_filter_outputs_with_pymc_model(outputs: tuple[pt.TensorVariable]) -> None:
-        mod = modelcontext(None)
-        coords = mod.coords
-
-        states, covs = outputs[:4], outputs[4:]
-
-        state_names = [
-            "filtered_states",
-            "predicted_states",
-            "predicted_observed_states",
-            "smoothed_states",
-        ]
-        cov_names = [
-            "filtered_covariances",
-            "predicted_covariances",
-            "predicted_observed_covariances",
-            "smoothed_covariances",
-        ]
-
-        with mod:
-            for var, name in zip(states + covs, state_names + cov_names):
-                dim_names = FILTER_OUTPUT_DIMS.get(name, None)
-                dims = tuple([dim if dim in coords.keys() else None for dim in dim_names])
-                pm.Deterministic(name, var, dims=dims)
-
     def build_statespace_graph(
         self,
         data: np.ndarray | pd.DataFrame | pt.TensorVariable,
         missing_fill_value: float | None = None,
         cov_jitter: float | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
-        save_kalman_filter_outputs_in_idata: bool = False,
         mode: str | None = None,
     ) -> None:
         """
@@ -998,10 +970,6 @@ class PyMCStateSpace:
             In general, if your model has measurement error, "cholesky" will be safe to use. Otherwise, "svd" is
             recommended. "eigh" can also be tried if sampling with "svd" is very slow, but it is not as robust as "svd".
 
-        save_kalman_filter_outputs_in_idata: bool, optional, default=False
-            If True, Kalman Filter outputs will be saved in the model as deterministics. Useful for debugging, but
-            should not be necessary for the majority of users.
-
         mode: str, optional
             Pytensor mode to use when compiling the graph. This will be saved as a model attribute and used when
             compiling sampling functions (e.g. ``sample_conditional_prior``).
@@ -1053,15 +1021,8 @@ class PyMCStateSpace:
         )
 
         logp = filter_outputs.pop(-1)
-        states, covs = filter_outputs[:3], filter_outputs[3:]
-        filtered_states, predicted_states, observed_states = states
-        filtered_covariances, predicted_covariances, observed_covariances = covs
-        if save_kalman_filter_outputs_in_idata:
-            smooth_states, smooth_covariances = self._build_smoother_graph(
-                filtered_states, filtered_covariances, self.unpack_statespace()
-            )
-            all_kf_outputs = [*states, smooth_states, *covs, smooth_covariances]
-            self._register_kalman_filter_outputs_with_pymc_model(all_kf_outputs)
+        *_, observed_states = filter_outputs[:3]
+        *_, observed_covariances = filter_outputs[3:]
 
         obs_dims = FILTER_OUTPUT_DIMS["predicted_observed_states"]
         obs_dims = obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
@@ -1089,62 +1050,6 @@ class PyMCStateSpace:
         than overriding :meth:`build_statespace_graph`. It runs inside the active model context, after the ``obs``
         likelihood is registered. The base implementation registers nothing.
         """
-
-    def _build_smoother_graph(
-        self,
-        filtered_states: pt.TensorVariable,
-        filtered_covariances: pt.TensorVariable,
-        matrices,
-        mode: str | None = None,
-        cov_jitter=JITTER_DEFAULT,
-    ):
-        """
-        Build the computation graph for the Kalman smoother.
-
-        This method constructs the computation graph for applying the Kalman smoother to the filtered states
-        and covariances obtained from the Kalman filter. The Kalman smoother is used to generate smoothed
-        estimates of the latent states and their covariances in a state space model.
-
-        The Kalman smoother provides a more accurate estimate of the latent states by incorporating future
-        information in the backward pass, resulting in smoothed state trajectories.
-
-        Parameters
-        ----------
-        filtered_states : pytensor.tensor.TensorVariable
-            The filtered states obtained from the Kalman filter. Returned by the `build_statespace_graph` method.
-
-        filtered_covariances : pytensor.tensor.TensorVariable
-            The filtered state covariances obtained from the Kalman filter. Returned by the `build_statespace_graph`
-            method.
-
-        mode : Optional[str], default=None
-            The mode used by pytensor for the construction of the logp graph. If None, the mode provided to
-            `build_statespace_graph` will be used.
-
-        Returns
-        -------
-        Tuple[pytensor.tensor.TensorVariable, pytensor.tensor.TensorVariable]
-            A tuple containing TensorVariables representing the smoothed states and smoothed state covariances
-            obtained from the Kalman smoother.
-        """
-
-        pymc_model = modelcontext(None)
-        with pymc_model:
-            *_, T, Z, R, H, Q = matrices
-
-            smooth_states, smooth_covariances = self.kalman_smoother.build_graph(
-                T,
-                R,
-                Q,
-                filtered_states,
-                filtered_covariances,
-                cov_jitter=self.cov_jitter,
-                time_varying_names=self.ssm.time_varying_names,
-            )
-            smooth_states.name = "smooth_states"
-            smooth_covariances.name = "smooth_covariances"
-
-            return smooth_states, smooth_covariances
 
     def _build_dummy_graph(self) -> None:
         return dummy_graph.build_dummy_graph(self)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1082,8 +1082,19 @@ class PyMCStateSpace:
             method=mvn_method,
         )
 
+        self._register_additional_statespace_variables()
+
         self._fit_coords = pm_mod.coords.copy()
         self._fit_dims = pm_mod.named_vars_to_dims.copy()
+
+    def _register_additional_statespace_variables(self) -> None:
+        """
+        Register model-specific variables into the active PyMC model.
+
+        Override this hook in a subclass that adds its own ``pm.Deterministic`` or ``pm.Potential`` nodes, rather
+        than overriding :meth:`build_statespace_graph`. It runs inside the active model context, after the ``obs``
+        likelihood is registered. The base implementation registers nothing.
+        """
 
     def _build_smoother_graph(
         self,

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1,5 +1,4 @@
 import logging
-import warnings
 
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
@@ -917,7 +916,6 @@ class PyMCStateSpace:
         missing_fill_value: float | None = None,
         cov_jitter: float | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
-        mode: str | None = None,
     ) -> None:
         """
         Given a parameter vector `theta`, constructs the full computational graph describing the state space model and
@@ -929,10 +927,6 @@ class PyMCStateSpace:
         data : Union[np.ndarray, pd.DataFrame, pt.TensorVariable]
             The observed data used to fit the state space model. It can be a NumPy array, a Pandas DataFrame,
             or a Pytensor tensor variable.
-
-        mode : Optional[str], optional, default=None
-            The Pytensor mode used for the computation graph construction. If None, the default mode will be used.
-            Other options include "JAX" and "NUMBA".
 
         missing_fill_value: float, optional
             A value to mask in missing values. NaN values in the data need to be filled with an arbitrary value to
@@ -970,23 +964,7 @@ class PyMCStateSpace:
             In general, if your model has measurement error, "cholesky" will be safe to use. Otherwise, "svd" is
             recommended. "eigh" can also be tried if sampling with "svd" is very slow, but it is not as robust as "svd".
 
-        mode: str, optional
-            Pytensor mode to use when compiling the graph. This will be saved as a model attribute and used when
-            compiling sampling functions (e.g. ``sample_conditional_prior``).
-
-            .. deprecated:: 0.2.5
-                The `mode` argument is deprecated and will be removed in a future version. Pass ``mode`` to the
-                model constructor, or manually specify ``compile_kwargs`` in sampling functions instead.
         """
-        if mode is not None:
-            warnings.warn(
-                "The `mode` argument is deprecated and will be removed in a future version. "
-                "Pass `mode` to the model constructor, or manually specify `compile_kwargs` in sampling functions"
-                " instead.",
-                DeprecationWarning,
-            )
-            self.mode = mode
-
         # Recorded on the model so post-estimation graphs are filtered the same way the fit was.
         if cov_jitter is not None:
             self.cov_jitter = cov_jitter

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -924,7 +924,7 @@ class PyMCStateSpace:
 
         Parameters
         ----------
-        data : Union[np.ndarray, pd.DataFrame, pt.TensorVariable]
+        data : numpy array, pandas DataFrame, or pytensor tensor
             The observed data used to fit the state space model. It can be a NumPy array, a Pandas DataFrame,
             or a Pytensor tensor variable.
 

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -216,7 +216,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             obs_sigma = pm.HalfNormal("sigma_obs", dims=["k_endog"])
 
             # Build the symbolic graph and attach it to the model
-            dfm_mod.build_statespace_graph(data=data, mode="JAX")
+            dfm_mod.build_statespace_graph(data=data)
 
             # Sampling
             idata = pm.sample(

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -3,7 +3,6 @@ import warnings
 import numpy as np
 import pandas as pd
 import pymc as pm
-import pytensor
 import pytensor.tensor as pt
 
 from pymc import modelcontext
@@ -181,9 +180,7 @@ def mask_missing_values_in_data(values, missing_fill_value=None):
     return filled_values, nan_mask
 
 
-def register_data_with_pymc(
-    data, n_obs, obs_coords, register_data=True, missing_fill_value=None, data_dims=None
-):
+def register_data_with_pymc(data, n_obs, obs_coords, missing_fill_value=None, data_dims=None):
     if isinstance(data, pt.TensorVariable | TensorSharedVariable):
         values, index = preprocess_tensor_data(data, n_obs, obs_coords)
     elif isinstance(data, np.ndarray):
@@ -193,10 +190,7 @@ def register_data_with_pymc(
     else:
         raise ValueError("Data should be one of pytensor tensor, numpy array, or pandas dataframe")
 
-    data, nan_mask = mask_missing_values_in_data(values, missing_fill_value)
+    filled_values, nan_mask = mask_missing_values_in_data(values, missing_fill_value)
+    data_variable = add_data_to_active_model(filled_values, index, data_dims)
 
-    if register_data:
-        data = add_data_to_active_model(data, index, data_dims)
-    else:
-        data = pytensor.shared(data, name="data")
-    return data, nan_mask
+    return data_variable, nan_mask

--- a/tests/statespace/core/conftest.py
+++ b/tests/statespace/core/conftest.py
@@ -66,7 +66,7 @@ def pymc_mod(ss_mod):
         rho = pm.Beta("rho", 1, 1)
         zeta = pm.Deterministic("zeta", 1 - rho)
 
-        ss_mod.build_statespace_graph(data=nile, save_kalman_filter_outputs_in_idata=True)
+        ss_mod.build_statespace_graph(data=nile)
         names = ["x0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
         for name, matrix in zip(names, ss_mod.unpack_statespace()):
             pm.Deterministic(name, matrix)
@@ -229,7 +229,7 @@ def exog_pymc_mod(exog_ss_mod, exog_data):
         )
         beta_exog = pm.Normal("beta_exog", mu=0, sigma=1, dims=["state_exog"])
 
-        exog_ss_mod.build_statespace_graph(exog_data["y"], save_kalman_filter_outputs_in_idata=True)
+        exog_ss_mod.build_statespace_graph(exog_data["y"])
 
     return struct_model
 
@@ -250,9 +250,7 @@ def exog_pymc_mod_mv(exog_ss_mod_mv, exog_data_mv):
         )
         beta_exog = pm.Normal("beta_exog", mu=0, sigma=1, dims=["endog_exog", "state_exog"])
 
-        exog_ss_mod_mv.build_statespace_graph(
-            exog_data_mv[["y1", "y2"]], save_kalman_filter_outputs_in_idata=True
-        )
+        exog_ss_mod_mv.build_statespace_graph(exog_data_mv[["y1", "y2"]])
 
     return struct_model
 

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -578,6 +578,13 @@ def test_build_forecast_model(rng, exog_ss_mod, exog_pymc_mod, exog_data, idata_
         scenario=scenario,
     )
 
+    # Fetched before the forecast model mutates any shared data.
+    predicted = exog_ss_mod.sample_filter_outputs(
+        idata_exog,
+        filter_output_names=["predicted_states", "predicted_covariances"],
+        group="posterior",
+    ).posterior_predictive
+
     test_forecast_model = exog_ss_mod._build_forecast_model(
         time_index=time_index,
         t0=t0,
@@ -632,11 +639,11 @@ def test_build_forecast_model(rng, exog_ss_mod, exog_pymc_mod, exog_data, idata_
 
     # Check that the frozen states and covariances correctly match the sliced index
     np.testing.assert_allclose(
-        idata_exog.posterior["predicted_covariances"].sel(time=t0).mean(("chain", "draw")).values,
+        predicted["predicted_covariances"].sel(time=t0).mean(("chain", "draw")).values,
         idata_forecast.posterior_predictive["P0_slice"].mean(("chain", "draw")).values,
     )
     np.testing.assert_allclose(
-        idata_exog.posterior["predicted_states"].sel(time=t0).mean(("chain", "draw")).values,
+        predicted["predicted_states"].sel(time=t0).mean(("chain", "draw")).values,
         idata_forecast.posterior_predictive["x0_slice"].mean(("chain", "draw")).values,
     )
 

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -8,17 +8,11 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
-from pymc_extras.statespace.utils.constants import (
-    FILTER_OUTPUT_NAMES,
-    MATRIX_NAMES,
-    SMOOTHER_OUTPUT_NAMES,
-)
-
-ALL_SAMPLE_OUTPUTS = MATRIX_NAMES + FILTER_OUTPUT_NAMES + SMOOTHER_OUTPUT_NAMES
+from pymc_extras.statespace.utils.constants import MATRIX_NAMES
 
 
 @pytest.mark.parametrize("group", ["posterior", "prior"])
-@pytest.mark.parametrize("matrix", ALL_SAMPLE_OUTPUTS)
+@pytest.mark.parametrize("matrix", MATRIX_NAMES)
 def test_no_nans_in_sampling_output(group, matrix, idata):
     assert not np.any(np.isnan(idata[group][matrix].values))
 
@@ -111,6 +105,9 @@ def test_sample_filter_outputs(rng, exog_ss_mod, idata_exog):
     idata_filter_prior = exog_ss_mod.sample_filter_outputs(
         idata_exog, filter_output_names=None, group="prior"
     )
+
+    for name, values in idata_filter_prior.posterior_predictive.data_vars.items():
+        assert not np.any(np.isnan(values)), f"{name} contains NaNs"
 
     specific_outputs = ["filtered_states", "filtered_covariances"]
     idata_filter_specific = exog_ss_mod.sample_filter_outputs(

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -82,9 +82,7 @@ def test_build_statespace_graph_warns_if_data_has_nans():
         initial_trend = pm.Normal("initial_trend", shape=(1,))
         P0 = pm.Deterministic("P0", pt.eye(1, dtype=floatX))
         with pytest.warns(ImputationWarning):
-            ss_mod.build_statespace_graph(
-                data=np.full((10, 1), np.nan, dtype=floatX), register_data=False
-            )
+            ss_mod.build_statespace_graph(data=np.full((10, 1), np.nan, dtype=floatX))
 
 
 def test_build_statespace_graph_raises_if_data_has_missing_fill():
@@ -97,7 +95,7 @@ def test_build_statespace_graph_raises_if_data_has_missing_fill():
         with pytest.raises(ValueError, match=r"Provided data contains the value 1.0"):
             data = np.ones((10, 1), dtype=floatX)
             data[3] = np.nan
-            ss_mod.build_statespace_graph(data=data, missing_fill_value=1.0, register_data=False)
+            ss_mod.build_statespace_graph(data=data, missing_fill_value=1.0)
 
 
 def test_param_dims_coords(ss_mod_multi_component):

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -98,22 +98,6 @@ def test_build_statespace_graph_raises_if_data_has_missing_fill():
             ss_mod.build_statespace_graph(data=data, missing_fill_value=1.0, register_data=False)
 
 
-def test_build_statespace_graph(pymc_mod):
-    for name in [
-        "filtered_states",
-        "predicted_states",
-        "predicted_covariances",
-        "filtered_covariances",
-    ]:
-        assert name in [x.name for x in pymc_mod.deterministics]
-
-
-def test_build_smoother_graph(pymc_mod):
-    names = ["smoothed_states", "smoothed_covariances"]
-    for name in names:
-        assert name in [x.name for x in pymc_mod.deterministics]
-
-
 def test_param_dims_coords(ss_mod_multi_component):
     for param in ss_mod_multi_component.param_names:
         shape = ss_mod_multi_component.param_info[param]["shape"]

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -1,3 +1,5 @@
+import pickle
+
 import numpy as np
 import pymc as pm
 import pytensor
@@ -226,4 +228,19 @@ def test_register_additional_statespace_variables_hook():
 
     assert "subclass_det" in [x.name for x in pymc_mod.deterministics]
     assert "subclass_check" in [x.name for x in pymc_mod.potentials]
+    assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_statespace_model_survives_pickling():
+    """A statespace model holds no PyMC-model references, so it round-trips and still builds."""
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)
+    unpickled = pickle.loads(pickle.dumps(ss_mod))
+
+    with pm.Model(coords=unpickled.coords) as pymc_mod:
+        pm.Normal("initial_trend", shape=(1,))
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX))
+        pm.Exponential("sigma_trend", 1, shape=(1,))
+        unpickled.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
     assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -193,3 +193,37 @@ def test_shipped_models_accept_filter_config(make_model):
 
     assert ss_mod.cov_jitter == 1e-3
     assert ss_mod.missing_fill_value == -777.0
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_register_additional_statespace_variables_hook():
+    """A subclass adds its own nodes through the hook, not by overriding build_statespace_graph."""
+
+    class SubclassStateSpace(PyMCStateSpace):
+        def make_symbolic_graph(self):
+            rho = self.make_and_register_variable("rho", ())
+            self.ssm["transition", 0, 0] = rho
+            self.ssm["design", 0, 0] = 1.0
+            self.ssm["selection", 0, 0] = 1.0
+            self.ssm["state_cov", 0, 0] = 1.0
+            self.ssm["initial_state_cov", 0, 0] = 1.0
+
+        @property
+        def param_names(self):
+            return ["rho"]
+
+        def _register_additional_statespace_variables(self):
+            pm.Deterministic("subclass_det", pm.modelcontext(None)["data"].sum())
+            pm.Potential("subclass_check", pt.zeros(()))
+
+    ss_mod = SubclassStateSpace(
+        k_endog=1, k_states=1, k_posdef=1, filter_type="standard", verbose=False
+    )
+
+    with pm.Model() as pymc_mod:
+        pm.Normal("rho")
+        ss_mod.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
+    assert "subclass_det" in [x.name for x in pymc_mod.deterministics]
+    assert "subclass_check" in [x.name for x in pymc_mod.potentials]
+    assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -190,7 +190,7 @@ def pymc_mod(arima_mod):
         ar_params = pm.Normal("ar_params", sigma=0.1, dims=["lag_ar"])
         ma_params = pm.Normal("ma_params", sigma=1, dims=["lag_ma"])
         sigma_state = pm.Exponential("sigma_state", 0.5)
-        arima_mod.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
+        arima_mod.build_statespace_graph(data=data)
 
     return pymc_mod
 
@@ -221,7 +221,7 @@ def pymc_mod_interp(arima_mod_interp):
         sigma_state = pm.Exponential("sigma_state", 0.5)
         sigma_obs = pm.Exponential("sigma_obs", 0.1)
 
-        arima_mod_interp.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
+        arima_mod_interp.build_statespace_graph(data=data)
 
     return pymc_mod
 
@@ -329,9 +329,17 @@ def test_SARIMAX_update_matches_statsmodels(p, d, q, P, D, Q, S, data, rng):
 
 
 @pytest.mark.parametrize("filter_output", ["filtered", "predicted", "smoothed"])
-def test_all_prior_covariances_are_PSD(filter_output, pymc_mod, rng):
-    rv = pymc_mod[f"{filter_output}_covariances"]
-    cov_mats = pm.draw(rv, 100, random_seed=rng)
+def test_all_prior_covariances_are_PSD(filter_output, arima_mod, pymc_mod, rng):
+    with pymc_mod:
+        idata = pm.sample_prior_predictive(draws=10, random_seed=rng)
+
+    cov_name = f"{filter_output}_covariances"
+    filter_idata = arima_mod.sample_filter_outputs(
+        idata, filter_output_names=[cov_name], group="prior", random_seed=rng
+    )
+    cov_mats = filter_idata.posterior_predictive[cov_name].values.reshape(
+        -1, arima_mod.k_states, arima_mod.k_states
+    )
     w, v = np.linalg.eig(cov_mats)
     assert_array_less(0, w, err_msg=f"Smallest eigenvalue: {min(w.ravel())}")
 
@@ -459,7 +467,7 @@ def test_SARIMA_with_exogenous(rng, mock_sample):
 
         sigma_state = pm.Exponential("sigma_state", 1.0)
 
-        ss_mod.build_statespace_graph(data=data_df, save_kalman_filter_outputs_in_idata=True)
+        ss_mod.build_statespace_graph(data=data_df)
         idata = pm.sample(chains=2, draws=100)
 
     assert "exogenous_data" in idata.constant_data

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -471,6 +471,8 @@ def test_SARIMA_with_exogenous(rng, mock_sample):
         idata = pm.sample(chains=2, draws=100)
 
     assert "exogenous_data" in idata.constant_data
+    # Observed data is always registered as a pm.Data, so post-estimation can recover it.
+    assert "data" in idata.constant_data
     assert idata.posterior.beta_exog.shape == (
         2,
         100,

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -68,7 +68,7 @@ def pymc_mod(varma_mod, data):
         )
         sigma_obs = pm.Exponential("sigma_obs", 1, dims=["observed_state"])
 
-        varma_mod.build_statespace_graph(data=data, save_kalman_filter_outputs_in_idata=True)
+        varma_mod.build_statespace_graph(data=data)
 
     return pymc_mod
 
@@ -161,9 +161,14 @@ def test_VARMAX_update_matches_statsmodels(data, order, rng):
 
 
 @pytest.mark.parametrize("filter_output", ["filtered", "predicted", "smoothed"])
-def test_all_prior_covariances_are_PSD(filter_output, pymc_mod, rng):
-    rv = pymc_mod[f"{filter_output}_covariances"]
-    cov_mats = pm.draw(rv, 100, random_seed=rng)
+def test_all_prior_covariances_are_PSD(filter_output, varma_mod, idata, rng):
+    cov_name = f"{filter_output}_covariances"
+    filter_idata = varma_mod.sample_filter_outputs(
+        idata, filter_output_names=[cov_name], group="prior", random_seed=rng
+    )
+    cov_mats = filter_idata.posterior_predictive[cov_name].values.reshape(
+        -1, varma_mod.k_states, varma_mod.k_states
+    )
     w, v = np.linalg.eig(cov_mats)
     assert_array_less(0, w, err_msg=f"Smallest eigenvalue: {min(w.ravel())}")
 

--- a/tests/statespace/utils/test_coord_assignment.py
+++ b/tests/statespace/utils/test_coord_assignment.py
@@ -82,19 +82,27 @@ def create_model(load_dataset):
             P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=("state", "state_aux"))
             initial_trend = pm.Normal("initial_level_trend", dims="state_level_trend")
             sigma_trend = pm.Exponential("sigma_level_trend", 1, dims="shock_level_trend")
-            ss_mod.build_statespace_graph(data, save_kalman_filter_outputs_in_idata=True)
-        return mod
+            ss_mod.build_statespace_graph(data)
+        return ss_mod, mod
 
     return _create_model
 
 
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data.")
+@pytest.mark.filterwarnings("ignore:No frequency was specific on the data's DateTimeIndex.")
 @pytest.mark.parametrize("f, warning", func_inputs, ids=function_names)
 def test_filter_output_coord_assignment(f, warning, create_model):
     with warning:
-        pymc_model = create_model(f)
+        ss_mod, pymc_model = create_model(f)
+
+    with pymc_model:
+        prior = pm.sample_prior_predictive(draws=1)
+    filter_idata = ss_mod.sample_filter_outputs(prior, group="prior")
 
     for output in FILTER_OUTPUT_NAMES + SMOOTHER_OUTPUT_NAMES + ["predicted_observed_states"]:
-        assert pymc_model.named_vars_to_dims[output] == FILTER_OUTPUT_DIMS[output]
+        expected_dims = tuple(FILTER_OUTPUT_DIMS[output])
+        result_dims = filter_idata.posterior_predictive[output].dims
+        assert result_dims[-len(expected_dims) :] == expected_dims
 
 
 def test_model_build_without_coords(load_dataset):
@@ -113,7 +121,7 @@ def test_model_build_without_coords(load_dataset):
 @pytest.mark.parametrize("f, warning", func_inputs, ids=function_names)
 def test_data_index_is_coord(f, warning, create_model):
     with warning:
-        pymc_model = create_model(f)
+        _, pymc_model = create_model(f)
     assert TIME_DIM in pymc_model.coords
 
 

--- a/tests/statespace/utils/test_coord_assignment.py
+++ b/tests/statespace/utils/test_coord_assignment.py
@@ -12,6 +12,7 @@ from pymc_extras.statespace.models.structural import LevelTrend
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_DIMS,
     FILTER_OUTPUT_NAMES,
+    OBS_STATE_DIM,
     SMOOTHER_OUTPUT_NAMES,
     TIME_DIM,
 )
@@ -113,9 +114,10 @@ def test_model_build_without_coords(load_dataset):
         P0 = pm.Deterministic("P0", pt.diag(P0_diag))
         initial_trend = pm.Normal("initial_level_trend", shape=(2,))
         sigma_trend = pm.Exponential("sigma_level_trend", 1, shape=(2,))
-        ss_mod.build_statespace_graph(data, register_data=False)
+        ss_mod.build_statespace_graph(data)
 
-    assert mod.coords == {}
+    assert set(mod.coords) == {TIME_DIM, OBS_STATE_DIM}
+    assert mod["data"].get_value().shape[0] == len(mod.coords[TIME_DIM])
 
 
 @pytest.mark.parametrize("f, warning", func_inputs, ids=function_names)

--- a/tests/statespace/utils/test_coord_assignment.py
+++ b/tests/statespace/utils/test_coord_assignment.py
@@ -101,9 +101,8 @@ def test_filter_output_coord_assignment(f, warning, create_model):
     filter_idata = ss_mod.sample_filter_outputs(prior, group="prior")
 
     for output in FILTER_OUTPUT_NAMES + SMOOTHER_OUTPUT_NAMES + ["predicted_observed_states"]:
-        expected_dims = tuple(FILTER_OUTPUT_DIMS[output])
-        result_dims = filter_idata.posterior_predictive[output].dims
-        assert result_dims[-len(expected_dims) :] == expected_dims
+        expected_dims = ("chain", "draw", *FILTER_OUTPUT_DIMS[output])
+        assert filter_idata.posterior_predictive[output].dims == expected_dims
 
 
 def test_model_build_without_coords(load_dataset):


### PR DESCRIPTION
Fetch filter and smoother outputs after sampling with `sample_filter_outputs(idata)` instead of the `save_kalman_filter_outputs_in_idata` build flag, now deprecated. Data is always registered as a `pm.Data`, so a model built without coords picks up `time` and `observed_state` coords. Subclasses get `_register_additional_statespace_variables` as a place to register their own nodes rather than overriding `build_statespace_graph`.

Idempotency is out of scope here — a second build still raises on the duplicate `data` name. Making it work needs the fit-state off the model first, which is separate work.
