### PR TITLE
Implement time-varying P DiscreteMarkovChain and marginalized conditional/recover

### DIFF
--- a/pymc_extras/distributions/timeseries.py
+++ b/pymc_extras/distributions/timeseries.py
@@ -19,7 +19,7 @@ from pymc.distributions.shape_utils import (
 )
 from pymc.logprob.abstract import _logprob
 from pymc.logprob.basic import logp
-from pymc.pytensorf import constant_fold, intX
+from pymc.pytensorf import intX, resolve_shapes
 from pymc.step_methods import STEP_METHODS
 from pymc.step_methods.arraystep import ArrayStep
 from pymc.step_methods.compound import Competence
@@ -58,11 +58,13 @@ def _make_outputs_info(n_lags: int, init_dist: Distribution) -> list[Distributio
 
 class DiscreteMarkovChainRV(SymbolicRandomVariable):
     n_lags: int
+    time_varying_P: bool
     default_output = 1
     _print_name = ("DiscreteMC", "\\operatorname{DiscreteMC}")
 
-    def __init__(self, *args, n_lags, **kwargs):
+    def __init__(self, *args, n_lags, time_varying_P=False, **kwargs):
         self.n_lags = n_lags
+        self.time_varying_P = time_varying_P
         super().__init__(*args, **kwargs)
 
     def update(self, node: Node):
@@ -84,6 +86,15 @@ class DiscreteMarkovChain(Distribution):
     P: tensor
         Matrix of transition probabilities between states. Rows must sum to 1.
         One of P or P_logits must be provided.
+
+        When ``time_varying_P=False`` (default), ``P`` is a ``k x k`` matrix shared across
+        all transitions, with optional leading batch dimensions: ``(*batch, k, k)``.
+
+        When ``time_varying_P=True``, ``P`` carries an extra time axis just before the two
+        state axes: ``(*batch, steps, k, k)``. ``P[..., t, :, :]`` is the transition matrix
+        used to go from state ``t`` to state ``t + 1``, so the time axis must have length
+        ``steps`` (one transition matrix per step). When ``steps`` is not given explicitly,
+        it is inferred from this axis.
     P_logit: tensor, optional
         Matrix of transition logits. Converted to probabilities via Softmax activation.
         One of P or P_logits must be provided.
@@ -95,6 +106,10 @@ class DiscreteMarkovChain(Distribution):
         If not, it will be automatically resized.
 
         .. warning:: init_dist will be cloned, rendering it independent of the one passed as input.
+    time_varying_P : bool, default False
+        If ``True``, ``P`` is interpreted as a sequence of transition matrices, one per step,
+        with shape ``(*batch, steps, k, k)`` (see ``P`` above). This disambiguates the time
+        axis from a leading batch dimension. Only supported for ``n_lags=1``.
 
     Notes
     -----
@@ -108,6 +123,7 @@ class DiscreteMarkovChain(Distribution):
 
     .. code-block:: python
 
+        import numpy as np
         import pymc as pm
         import pymc_extras as pmx
 
@@ -116,6 +132,39 @@ class DiscreteMarkovChain(Distribution):
             init_dist = pm.Categorical.dist(p=np.full(3, 1 / 3))
             markov_chain = pmx.DiscreteMarkovChain(
                 "markov_chain", P=P, init_dist=init_dist, shape=(100,)
+            )
+
+    Use a time-varying transition matrix. ``P`` carries a leading time axis of length
+    ``steps`` (here 99 transitions for a chain of 100 states), so its shape is
+    ``(steps, k, k)``. Below the chain switches regime partway through: a "sticky" kernel
+    governs the first 40 transitions and a "mixing" kernel the remaining 59, assembled by
+    repeating each kernel along the time axis.
+
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        import pymc_extras as pmx
+        import pytensor.tensor as pt
+
+        with pm.Model() as regime_chain:
+            # Two 2 x 2 kernels: states persist under "sticky", shuffle under "mixing".
+            P_sticky = pm.Dirichlet("P_sticky", a=np.eye(2) * 8 + 1, size=2)
+            P_mixing = pm.Dirichlet("P_mixing", a=np.ones((2, 2)), size=2)
+
+            # Stack one kernel per step: 40 sticky then 59 mixing -> shape (99, 2, 2)
+            P = pt.concatenate(
+                [pt.repeat(P_sticky[None], 40, axis=0), pt.repeat(P_mixing[None], 59, axis=0)],
+                axis=0,
+            )
+
+            init_dist = pm.Categorical.dist(p=np.full(2, 0.5))
+            markov_chain = pmx.DiscreteMarkovChain(
+                "markov_chain",
+                P=P,
+                init_dist=init_dist,
+                time_varying_P=True,
+                shape=(100,),
             )
 
     """
@@ -134,22 +183,44 @@ class DiscreteMarkovChain(Distribution):
         return super().__new__(cls, *args, steps=steps, n_lags=n_lags, **kwargs)
 
     @classmethod
-    def dist(cls, P=None, logit_P=None, steps=None, init_dist=None, n_lags=1, **kwargs):
+    def dist(
+        cls,
+        P=None,
+        logit_P=None,
+        steps=None,
+        init_dist=None,
+        n_lags=1,
+        time_varying_P=False,
+        **kwargs,
+    ):
         steps = get_support_shape_1d(
             support_shape=steps, shape=kwargs.get("shape", None), support_shape_offset=n_lags
         )
 
-        if steps is None:
-            raise ValueError("Must specify steps or shape parameter")
         if P is None and logit_P is None:
             raise ValueError("Must specify P or logit_P parameter")
         if P is not None and logit_P is not None:
             raise ValueError("Must specify only one of either P or logit_P parameter")
+        # time_varying_P disambiguates a time axis in P (*batch, time, k, k) from a leading
+        # batch dimension; without it that axis would be treated as batch. See pymc-extras #392.
+        if time_varying_P and n_lags != 1:
+            raise NotImplementedError("time_varying_P is only supported for n_lags=1")
 
         if logit_P is not None:
             P = pm.math.softmax(logit_P, axis=-1)
 
         P = pt.as_tensor_variable(P)
+
+        if time_varying_P:
+            # P's transition axis (*batch, time, k, k) is itself an encoding of `steps`.
+            # Reconcile it through the same helper (zero offset — the time axis *is* the
+            # transition count): infers steps when only P is given, asserts when both are.
+            steps = get_support_shape_1d(
+                support_shape=steps, shape=(P.shape[-3],), support_shape_offset=0
+            )
+
+        if steps is None:
+            raise ValueError("Must specify steps or shape parameter")
         steps = pt.as_tensor_variable(intX(steps))
 
         if init_dist is not None:
@@ -177,15 +248,23 @@ class DiscreteMarkovChain(Distribution):
             k = P.shape[-1]
             init_dist = pm.Categorical.dist(p=pt.full((k,), 1 / k))
 
-        return super().dist([P, steps, init_dist], n_lags=n_lags, **kwargs)
+        return super().dist(
+            [P, steps, init_dist], n_lags=n_lags, time_varying_P=time_varying_P, **kwargs
+        )
 
     @classmethod
-    def rv_op(cls, P, steps, init_dist, n_lags, size=None):
+    def rv_op(cls, P, steps, init_dist, n_lags, size=None, time_varying_P=False):
+        if time_varying_P and n_lags != 1:
+            raise NotImplementedError("time_varying_P is only supported for n_lags=1")
+
+        # Trailing core axes of P: the (n_lags + 1) state axes, plus a leading time axis
+        # when P is time-varying. Everything to the left of those is batch.
+        n_core_P = (n_lags + 1) + (1 if time_varying_P else 0)
         if size is not None:
             batch_size = size
         else:
             batch_size = pt.broadcast_shape(
-                P[tuple([...] + [0] * (n_lags + 1))], pt.atleast_1d(init_dist)[..., 0]
+                P[tuple([...] + [0] * n_core_P)], pt.atleast_1d(init_dist)[..., 0]
             )
 
         init_dist = change_dist_size(init_dist, (*batch_size, n_lags))
@@ -195,11 +274,27 @@ class DiscreteMarkovChain(Distribution):
 
         state_rng = pytensor.shared(np.random.default_rng())
 
-        def transition(*args):
-            old_rng, *states, transition_probs = args
-            p = transition_probs[tuple(states)]
-            next_rng, next_state = pm.Categorical.dist(p=p, rng=old_rng, return_next_rng=True)
-            return next_rng, next_state
+        if time_varying_P:
+            # Move the time core axis (-3 for n_lags=1) to the front so scan iterates a
+            # distinct transition matrix per step. With a sequence, scan passes the sequence
+            # element first, then the recurring outputs (rng, state).
+            def transition(transition_probs, old_rng, *states):
+                p = transition_probs[tuple(states)]
+                next_rng, next_state = pm.Categorical.dist(p=p, rng=old_rng, return_next_rng=True)
+                return next_rng, next_state
+
+            # Pass n_steps too: steps is reconciled with P's time axis at construction, so
+            # this keeps steps live in the inner graph (its consistency Assert survives).
+            scan_kwargs = dict(sequences=[pt.moveaxis(P_, -3, 0)], n_steps=steps_)
+        else:
+
+            def transition(*args):
+                old_rng, *states, transition_probs = args
+                p = transition_probs[tuple(states)]
+                next_rng, next_state = pm.Categorical.dist(p=p, rng=old_rng, return_next_rng=True)
+                return next_rng, next_state
+
+            scan_kwargs = dict(non_sequences=[P_], n_steps=steps_)
 
         state_next_rng, markov_chain = pytensor.scan(
             transition,
@@ -208,19 +303,21 @@ class DiscreteMarkovChain(Distribution):
                 # Move lags to the front for scan
                 *_make_outputs_info(n_lags, pt.moveaxis(init_dist_, -1, 0)),
             ],
-            non_sequences=[P_],
-            n_steps=steps_,
             strict=True,
             return_updates=False,
+            **scan_kwargs,
         )
 
         discrete_mc_ = pt.concatenate([init_dist_, pt.moveaxis(markov_chain, 0, -1)], axis=-1)
 
+        # Time-varying P carries an extra leading core axis (the per-step matrices).
+        P_signature = "(u,p,p)" if time_varying_P else "(p,p)"
         discrete_mc_op = DiscreteMarkovChainRV(
             inputs=[P_, steps_, init_dist_, state_rng],
             outputs=[state_next_rng, discrete_mc_],
             n_lags=n_lags,
-            extended_signature="(p,p),(),(p),[rng]->[rng],(t)",
+            time_varying_P=time_varying_P,
+            extended_signature=f"{P_signature},(),(p),[rng]->[rng],(t)",
         )
 
         discrete_mc = discrete_mc_op(P, steps, init_dist, state_rng)
@@ -233,7 +330,12 @@ def change_mc_size(op, dist, new_size, expand=False):
         old_size = dist.shape[:-1]
         new_size = tuple(new_size) + tuple(old_size)
 
-    return DiscreteMarkovChain.rv_op(*dist.owner.inputs[:-1], size=new_size, n_lags=op.n_lags)
+    return DiscreteMarkovChain.rv_op(
+        *dist.owner.inputs[:-1],
+        size=new_size,
+        n_lags=op.n_lags,
+        time_varying_P=op.time_varying_P,
+    )
 
 
 @_support_point.register(DiscreteMarkovChainRV)
@@ -241,18 +343,28 @@ def discrete_mc_moment(op, rv, P, steps, init_dist, state_rng):
     init_dist_moment = support_point(init_dist)
     n_lags = op.n_lags
 
-    def greedy_transition(*args):
-        *states, transition_probs = args
-        p = transition_probs[tuple(states)]
-        return pt.argmax(p)
+    if op.time_varying_P:
+
+        def greedy_transition(transition_probs, *states):
+            p = transition_probs[tuple(states)]
+            return pt.argmax(p)
+
+        scan_kwargs = dict(sequences=[pt.moveaxis(P, -3, 0)], n_steps=steps)
+    else:
+
+        def greedy_transition(*args):
+            *states, transition_probs = args
+            p = transition_probs[tuple(states)]
+            return pt.argmax(p)
+
+        scan_kwargs = dict(non_sequences=[P], n_steps=steps)
 
     chain_moment = pytensor.scan(
         greedy_transition,
-        non_sequences=[P],
         outputs_info=_make_outputs_info(n_lags, init_dist),
-        n_steps=steps,
         strict=True,
         return_updates=False,
+        **scan_kwargs,
     )
     chain_moment = pt.concatenate([init_dist_moment, chain_moment])
     return chain_moment
@@ -263,16 +375,22 @@ def discrete_mc_logp(op, values, P, steps, init_dist, state_rng, **kwargs):
     value = values[0]
     n_lags = op.n_lags
 
-    indexes = [value[..., i : -(n_lags - i) if n_lags != i else None] for i in range(n_lags + 1)]
+    indices = [value[..., i : -(n_lags - i) if n_lags != i else None] for i in range(n_lags + 1)]
 
     mc_logprob = logp(init_dist, value[..., :n_lags]).sum(axis=-1)
-    mc_logprob += pt.log(P[tuple(indexes)]).sum(axis=-1)
+    if op.time_varying_P:
+        # P is (*batch, time, k, k); steps is baked into P's time axis at construction, so
+        # each transition just indexes its own matrix by the (from, to) states. n_lags == 1,
+        # so indexes == [from, to].
+        time_idx = pt.arange(P.shape[-3])
+        from_states, to_states = indices
+        mc_logprob += pt.log(P[..., time_idx, from_states, to_states]).sum(axis=-1)
+    else:
+        mc_logprob += pt.log(P[tuple(indices)]).sum(axis=-1)
 
     # We cannot leave any RV in the logp graph, even if just for an assert
     # If this is a core_dim, it should be part of the signature
-    [init_dist_core_dim] = constant_fold(
-        [pt.atleast_1d(init_dist).shape[-1]], raise_not_constant=False
-    )
+    [init_dist_core_dim] = resolve_shapes([pt.atleast_1d(init_dist).shape[-1]])
 
     return check_parameters(
         mc_logprob,

--- a/pymc_extras/model/marginal/distributions/__init__.py
+++ b/pymc_extras/model/marginal/distributions/__init__.py
@@ -1,3 +1,4 @@
+import pymc_extras.model.marginal.distributions.discrete_markov_chain
 import pymc_extras.model.marginal.distributions.enumerable
 import pymc_extras.model.marginal.distributions.laplace
 import pymc_extras.model.marginal.distributions.normal  # noqa: F401

--- a/pymc_extras/model/marginal/distributions/core.py
+++ b/pymc_extras/model/marginal/distributions/core.py
@@ -24,13 +24,23 @@ def inline_ofg_outputs(op: OpFromGraph, inputs: Sequence[Variable]) -> list[Vari
 class MarginalRV(OpFromGraph, MeasurableOp):
     """Base class for supported MarginalRVs.
 
-    The name of the marginalized model variable is stored explicitly as
-    ``marginalized_name`` (like ``marginalized_dims``), because pytensor makes
-    no guarantee that variable names survive cloning and rewrites.
+    The name and dims of the marginalized model variable, together with the
+    number of dependent RVs, are stored explicitly (``marginalized_name``,
+    ``marginalized_dims``, ``n_dependent_rvs``) because pytensor makes no
+    guarantee that variable names/metadata survive cloning and rewrites.
     """
 
-    def __init__(self, *args, marginalized_name: str, **kwargs) -> None:
+    def __init__(
+        self,
+        *args,
+        marginalized_name: str,
+        marginalized_dims,
+        n_dependent_rvs: int,
+        **kwargs,
+    ) -> None:
         self.marginalized_name = marginalized_name
+        self.marginalized_dims = marginalized_dims
+        self.n_dependent_rvs = n_dependent_rvs
         super().__init__(*args, **kwargs)
 
 

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -1,0 +1,132 @@
+import pytensor.tensor as pt
+
+from pymc.logprob.abstract import _logprob
+from pymc.logprob.basic import conditional_logp, logp
+from pymc.pytensorf import constant_fold
+from pytensor.graph import node_rewriter, vectorize_graph
+from pytensor.graph.replace import clone_replace
+from pytensor.scan import scan
+
+from pymc_extras.distributions import DiscreteMarkovChain
+from pymc_extras.model.marginal.distributions.core import inline_ofg_outputs
+from pymc_extras.model.marginal.distributions.enumerable import (
+    DUMMY_ZERO,
+    EnumerableMarginalRV,
+    align_logp_dims,
+    build_enumerable_marginal_rv,
+    reduce_batch_dependent_logps,
+    warn_non_separable_logp,
+)
+from pymc_extras.model.marginal.rewrites import (
+    MarginalSubgraph,
+    extract_marginal_subgraph,
+    marginal_rewrites_db,
+)
+
+
+class MarginalDiscreteMarkovChainRV(EnumerableMarginalRV):
+    """Base class for Marginalized Discrete Markov Chain RVs"""
+
+
+@_logprob.register(MarginalDiscreteMarkovChainRV)
+def marginal_hmm_logp(op, values, *inputs, **kwargs):
+    all_outputs = inline_ofg_outputs(op, inputs)
+    chain_rv = all_outputs[0]
+    dependent_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
+
+    P, n_steps_, init_dist_, rng = chain_rv.owner.inputs
+    domain = pt.arange(P.shape[-1], dtype="int32")
+
+    # Construct logp in two steps
+    # Step 1: Compute the probability of the data ("emissions") under every possible state (vec_logp_emission)
+
+    # First we need to vectorize the conditional logp graph of the data, in case there are batch dimensions floating
+    # around. To do this, we need to break the dependency between chain and the init_dist_ random variable. Otherwise,
+    # PyMC will detect a random variable in the logp graph (init_dist_), that isn't relevant at this step.
+    chain_value = chain_rv.clone()
+    dependent_rvs = clone_replace(dependent_rvs, {chain_rv: chain_value})
+    logp_emissions_dict = conditional_logp(dict(zip(dependent_rvs, values)))
+
+    # Reduce and add the batch dims beyond the chain dimension
+    reduced_logp_emissions = reduce_batch_dependent_logps(
+        dependent_dims_connections=op.dims_connections,
+        dependent_ops=[dependent_rv.owner.op for dependent_rv in dependent_rvs],
+        dependent_logps=[logp_emissions_dict[value] for value in values],
+    )
+
+    # Add a batch dimension for the domain of the chain
+    chain_shape = constant_fold(tuple(chain_rv.shape))
+    batch_chain_value = pt.moveaxis(pt.full((*chain_shape, domain.size), domain), -1, 0)
+    batch_logp_emissions = vectorize_graph(reduced_logp_emissions, {chain_value: batch_chain_value})
+
+    # Step 2: Compute the transition probabilities
+    # This is the "forward algorithm", alpha_t = p(y | s_t) * sum_{s_{t-1}}(p(s_t | s_{t-1}) * alpha_{t-1})
+    # We do it entirely in logs, though.
+
+    # To compute the prior probabilities of each state, we evaluate the logp of the domain (all possible states)
+    # under the initial distribution. This is robust to everything the user can throw at it.
+    init_dist_value = init_dist_.type()
+    logp_init_dist = logp(init_dist_, init_dist_value)
+    # Squeeze core dimension for n_lags=1 (only supported case)
+    batch_logp_init_dist = vectorize_graph(
+        logp_init_dist, {init_dist_value: batch_chain_value[..., :1]}
+    ).squeeze(-1)
+    log_alpha_init = batch_logp_init_dist + batch_logp_emissions[..., 0]
+
+    def step_alpha(logp_emission, log_alpha, log_P):
+        step_log_prob = pt.logsumexp(log_alpha[:, None, ...] + log_P, axis=0)
+        return logp_emission + step_log_prob
+
+    # Add implicit dimensions of P, and place core dimensions at the front
+    P = pt.atleast_Nd(P, n=len(chain_shape) + 1)
+    P = pt.moveaxis(P, (-2, -1), (0, 1))
+    log_P = pt.log(P)
+
+    log_alpha_seq = scan(
+        step_alpha,
+        non_sequences=[log_P],
+        outputs_info=[log_alpha_init],
+        # Scan needs the time dimension first, and we already consumed the 1st logp computing the initial value
+        sequences=pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0),
+        return_updates=False,
+    )
+    # Final logp is just the sum of the last scan state
+    joint_logp = pt.logsumexp(log_alpha_seq[-1], axis=0)
+
+    # Align logp with non-collapsed batch dimensions of first RV
+    remaining_dims_first_emission = list(op.dims_connections[0])
+    # The last dim of chain_rv was removed when computing the logp
+    remaining_dims_first_emission.remove(chain_rv.type.ndim - 1)
+    joint_logp = align_logp_dims(remaining_dims_first_emission, joint_logp)
+
+    # If there are multiple emission streams, we have to add dummy logps for the remaining value variables. The first
+    # return is the joint probability of everything together, but PyMC still expects one logp for each emission stream.
+    warn_non_separable_logp(values)
+    dummy_logps = (DUMMY_ZERO,) * (len(values) - 1)
+    return joint_logp, *dummy_logps
+
+
+@node_rewriter(tracks=[MarginalSubgraph])
+def discrete_markov_chain_marginal(fgraph, node):
+    inputs, outputs = extract_marginal_subgraph(node)
+    marginalized_rv = outputs[0]
+    marginalized_rv_op = marginalized_rv.owner.op
+    if not isinstance(marginalized_rv_op, DiscreteMarkovChain):
+        return None
+
+    if marginalized_rv_op.n_lags > 1:
+        raise NotImplementedError(
+            "Marginalization for DiscreteMarkovChain with n_lags > 1 is not supported"
+        )
+    if marginalized_rv.owner.inputs[0].type.ndim > 2:
+        raise NotImplementedError(
+            "Marginalization for DiscreteMarkovChain with non-matrix transition probability "
+            "is not supported"
+        )
+
+    return build_enumerable_marginal_rv(node, inputs, outputs, MarginalDiscreteMarkovChainRV)
+
+
+marginal_rewrites_db.register(
+    "discrete_markov_chain_marginal", discrete_markov_chain_marginal, "basic"
+)

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -1,14 +1,19 @@
 import pytensor.tensor as pt
 
+from pymc.distributions import Categorical
 from pymc.logprob.abstract import _logprob
 from pymc.logprob.basic import conditional_logp, logp
-from pymc.pytensorf import constant_fold
+from pymc.pytensorf import resolve_shapes
 from pytensor.graph import node_rewriter, vectorize_graph
-from pytensor.graph.replace import clone_replace
+from pytensor.graph.replace import clone_replace, graph_replace
 from pytensor.scan import scan
+from pytensor.tensor.special import log_softmax, softmax
 
 from pymc_extras.distributions import DiscreteMarkovChain
-from pymc_extras.model.marginal.distributions.core import inline_ofg_outputs
+from pymc_extras.model.marginal.distributions.core import (
+    inline_ofg_outputs,
+    marginalized_conditional,
+)
 from pymc_extras.model.marginal.distributions.enumerable import (
     DUMMY_ZERO,
     EnumerableMarginalRV,
@@ -28,23 +33,30 @@ class MarginalDiscreteMarkovChainRV(EnumerableMarginalRV):
     """Base class for Marginalized Discrete Markov Chain RVs"""
 
 
-@_logprob.register(MarginalDiscreteMarkovChainRV)
-def marginal_hmm_logp(op, values, *inputs, **kwargs):
-    all_outputs = inline_ofg_outputs(op, inputs)
-    chain_rv = all_outputs[0]
-    dependent_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
+def _hmm_emission_logp(op, chain, dependent_rvs, values):
+    """Emission log-probability of the data under every possible state at each step.
 
-    P, n_steps_, init_dist_, rng = chain_rv.owner.inputs
+    This is the "forward algorithm" Step 1, shared by the marginal logp and the
+    conditional (recovery) graph. We vectorize the conditional logp of the
+    dependents over the chain domain, after breaking the dependency between the
+    chain and its dependents (otherwise PyMC detects a leftover random variable
+    in the logp graph).
+
+    Returns
+    -------
+    batch_logp_emissions : TensorVariable
+        Shape ``(n_states, *chain_batch, n_steps)``.
+    batch_chain_value : TensorVariable
+        The chain domain broadcast to the chain shape, ``(n_states, *chain_shape)``.
+    chain_shape : tuple
+        Symbolic shape of the chain, resolved to expressions over the chain's
+        inputs (so it doesn't reference the RV itself).
+    """
+    P = chain.owner.inputs[0]
     domain = pt.arange(P.shape[-1], dtype="int32")
 
-    # Construct logp in two steps
-    # Step 1: Compute the probability of the data ("emissions") under every possible state (vec_logp_emission)
-
-    # First we need to vectorize the conditional logp graph of the data, in case there are batch dimensions floating
-    # around. To do this, we need to break the dependency between chain and the init_dist_ random variable. Otherwise,
-    # PyMC will detect a random variable in the logp graph (init_dist_), that isn't relevant at this step.
-    chain_value = chain_rv.clone()
-    dependent_rvs = clone_replace(dependent_rvs, {chain_rv: chain_value})
+    chain_value = chain.clone()
+    dependent_rvs = clone_replace(dependent_rvs, {chain: chain_value})
     logp_emissions_dict = conditional_logp(dict(zip(dependent_rvs, values)))
 
     # Reduce and add the batch dims beyond the chain dimension
@@ -55,43 +67,165 @@ def marginal_hmm_logp(op, values, *inputs, **kwargs):
     )
 
     # Add a batch dimension for the domain of the chain
-    chain_shape = constant_fold(tuple(chain_rv.shape))
+    chain_shape = resolve_shapes(tuple(chain.shape))
     batch_chain_value = pt.moveaxis(pt.full((*chain_shape, domain.size), domain), -1, 0)
     batch_logp_emissions = vectorize_graph(reduced_logp_emissions, {chain_value: batch_chain_value})
+    return batch_logp_emissions, batch_chain_value, chain_shape
 
-    # Step 2: Compute the transition probabilities
-    # This is the "forward algorithm", alpha_t = p(y | s_t) * sum_{s_{t-1}}(p(s_t | s_{t-1}) * alpha_{t-1})
-    # We do it entirely in logs, though.
 
-    # To compute the prior probabilities of each state, we evaluate the logp of the domain (all possible states)
-    # under the initial distribution. This is robust to everything the user can throw at it.
+def _hmm_log_init_and_transition(chain, chain_shape, batch_chain_value):
+    """Log initial-state probabilities (per state) and the log transition matrix.
+
+    Returns
+    -------
+    batch_logp_init_dist : TensorVariable
+        Shape ``(n_states, *chain_batch)``.
+    log_P : TensorVariable
+        Log transition matrix. Homogeneous chains place the two core (from, to)
+        axes at the front, ``(n_states, n_states, *batch)``. Time-varying chains
+        keep one matrix per transition, ``(n_transitions, n_states, n_states)`` =
+        ``(time, from, to)`` (unbatched), iterated as a scan sequence downstream.
+    """
+    P, n_steps_, init_dist_, rng = chain.owner.inputs
+    time_varying = chain.owner.op.time_varying_P
+
+    # To compute the prior probabilities of each state, we evaluate the logp of the domain (all
+    # possible states) under the initial distribution. This is robust to everything the user can
+    # throw at it.
     init_dist_value = init_dist_.type()
     logp_init_dist = logp(init_dist_, init_dist_value)
     # Squeeze core dimension for n_lags=1 (only supported case)
     batch_logp_init_dist = vectorize_graph(
         logp_init_dist, {init_dist_value: batch_chain_value[..., :1]}
     ).squeeze(-1)
-    log_alpha_init = batch_logp_init_dist + batch_logp_emissions[..., 0]
 
-    def step_alpha(logp_emission, log_alpha, log_P):
-        step_log_prob = pt.logsumexp(log_alpha[:, None, ...] + log_P, axis=0)
-        return logp_emission + step_log_prob
+    if time_varying:
+        # P is already (time, from, to); each transition uses its own matrix.
+        log_P = pt.log(P)
+    else:
+        # Add implicit dimensions of P, and place core (from, to) dimensions at the front
+        P = pt.atleast_Nd(P, n=len(chain_shape) + 1)
+        P = pt.moveaxis(P, (-2, -1), (0, 1))
+        log_P = pt.log(P)
+    return batch_logp_init_dist, log_P
 
-    # Add implicit dimensions of P, and place core dimensions at the front
-    P = pt.atleast_Nd(P, n=len(chain_shape) + 1)
-    P = pt.moveaxis(P, (-2, -1), (0, 1))
-    log_P = pt.log(P)
 
-    log_alpha_seq = scan(
-        step_alpha,
-        non_sequences=[log_P],
-        outputs_info=[log_alpha_init],
-        # Scan needs the time dimension first, and we already consumed the 1st logp computing the initial value
-        sequences=pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0),
+def _scan_messages(core, *, init, emissions_seq, log_P, time_varying):
+    """Run a forward/backward HMM message pass and return the full message trace.
+
+    ``core(emission, log_P_t, prev)`` is the per-step recurrence, where ``log_P_t``
+    is the transition matrix to use at that step. A homogeneous chain passes its
+    single matrix as a non-sequence; a time-varying chain iterates the per-step
+    matrices as a scan sequence. ``emissions_seq`` (and ``log_P`` when time-varying)
+    must already be in the desired scan order. Branching on ``time_varying`` lives
+    here so the recurrences themselves stay free of scan plumbing.
+
+    The returned trace includes the initial state: scan strips it from its output
+    (``seq = full_trace[1:]``), but the parent ``Scan`` buffer still holds it, so we
+    return that buffer directly instead of having callers concatenate ``init`` back on.
+    """
+    if time_varying:
+
+        def step(emission, log_P_t, prev):
+            return core(emission, log_P_t, prev)
+
+        sequences = [emissions_seq, log_P]
+        non_sequences = []
+    else:
+
+        def step(emission, prev, log_P_t):
+            return core(emission, log_P_t, prev)
+
+        sequences = [emissions_seq]
+        non_sequences = [log_P]
+
+    seq = scan(
+        step,
+        sequences=sequences,
+        outputs_info=[init],
+        non_sequences=non_sequences,
         return_updates=False,
     )
+    # scan returns full_trace[1:]; the parent Scan output is the full trace (init included).
+    return seq.owner.inputs[0]
+
+
+def _hmm_forward_log_alphas(batch_logp_emissions, batch_logp_init_dist, log_P, time_varying=False):
+    """Forward filter. Returns the full ``log_alpha`` trace, shape ``(T, n_states, *batch)``.
+
+    ``alpha_t(s) = p(y_{1:t}, s_t=s)`` computed entirely in logs:
+    ``alpha_t = p(y_t | s_t) * sum_{s_{t-1}}(p(s_t | s_{t-1}) * alpha_{t-1})``.
+    The trace is time first and includes ``alpha_0`` as the initial state.
+    """
+    log_alpha_init = batch_logp_init_dist + batch_logp_emissions[..., 0]
+
+    # Scan needs the time dimension first, and we already consumed the 1st logp computing the initial value
+    emissions_seq = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)
+
+    def step_alpha(logp_emission, log_P_t, log_alpha):
+        step_log_prob = pt.logsumexp(log_alpha[:, None, ...] + log_P_t, axis=0)
+        return logp_emission + step_log_prob
+
+    return _scan_messages(
+        step_alpha,
+        init=log_alpha_init,
+        emissions_seq=emissions_seq,
+        log_P=log_P,
+        time_varying=time_varying,
+    )
+
+
+def _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying=False):
+    """Backward messages ``log β_t(i) = log p(y_{t+1:} | s_t=i)``, shape ``(n_steps, n_states)``.
+
+    ``β_{T-1} = 1`` (0 in logs); ``log β_t(i) = logsumexp_j[log A_{t+1}(i,j) + log b_{t+1}(j) +
+    log β_{t+1}(j)]``. ``log_P`` is ``(n_states, n_states)`` for a homogeneous chain, or one
+    matrix per transition ``(n_transitions, n_states, n_states)`` when ``time_varying`` (the
+    transition into step ``t+1`` uses ``A_{t+1} = log_P[t]``). Unbatched chain.
+    """
+    n_states = batch_logp_emissions.shape[0]
+    log_beta_last = pt.zeros((n_states,))
+    # Emissions for the t+1 step, iterated backwards: b_{T-1}, ..., b_1
+    rev_next_emissions = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)[::-1]
+
+    def step_beta(logp_emission_next, log_P_t, log_beta_next):
+        v = logp_emission_next + log_beta_next  # (n_states,) over j
+        return pt.logsumexp(log_P_t + v[None, :], axis=1)  # (n_states,) over i
+
+    # Full backward trace in scan (reverse) order: β_{T-1}, β_{T-2}, ..., β_0
+    log_beta_seq = _scan_messages(
+        step_beta,
+        init=log_beta_last,
+        emissions_seq=rev_next_emissions,
+        # A_{t+1} in the same backwards order as the emissions: A_{T-1}, ..., A_1
+        log_P=log_P[::-1] if time_varying else log_P,
+        time_varying=time_varying,
+    )
+    return log_beta_seq[::-1]
+
+
+@_logprob.register(MarginalDiscreteMarkovChainRV)
+def marginal_discrete_markov_chain_logp(op, values, *inputs, **kwargs):
+    all_outputs = inline_ofg_outputs(op, inputs)
+    chain_rv = all_outputs[0]
+    dependent_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
+
+    # Step 1: Compute the probability of the data ("emissions") under every possible state
+    batch_logp_emissions, batch_chain_value, chain_shape = _hmm_emission_logp(
+        op, chain_rv, dependent_rvs, values
+    )
+
+    # Step 2: Run the forward algorithm over the transition probabilities
+    batch_logp_init_dist, log_P = _hmm_log_init_and_transition(
+        chain_rv, chain_shape, batch_chain_value
+    )
+    time_varying = chain_rv.owner.op.time_varying_P
+    log_alphas = _hmm_forward_log_alphas(
+        batch_logp_emissions, batch_logp_init_dist, log_P, time_varying
+    )
+
     # Final logp is just the sum of the last scan state
-    joint_logp = pt.logsumexp(log_alpha_seq[-1], axis=0)
+    joint_logp = pt.logsumexp(log_alphas[-1], axis=0)
 
     # Align logp with non-collapsed batch dimensions of first RV
     remaining_dims_first_emission = list(op.dims_connections[0])
@@ -106,6 +240,69 @@ def marginal_hmm_logp(op, values, *inputs, **kwargs):
     return joint_logp, *dummy_logps
 
 
+@marginalized_conditional.register(MarginalDiscreteMarkovChainRV)
+def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
+    """Conditional ``p(chain | emissions, inputs)`` of a marginalized DiscreteMarkovChain.
+
+    The posterior over the latent path is itself a (time-inhomogeneous) Markov
+    chain, so we return a :class:`DiscreteMarkovChain` with a time-varying
+    transition matrix — which already has both an exact logp and a sampler, so
+    we get a loggable *and* sampleable conditional without a bespoke Op.
+    Forward-backward yields the smoothed initial distribution ``γ₀ ∝ α₀·β₀`` and
+    the forward-smoothed transitions
+    ``p(s_t | s_{t-1}, y) ∝ P(s_{t-1}, s_t)·b_t(s_t)·β_t(s_t)``.
+
+    Mirrors :func:`finite_discrete_marginalized_conditional`: built on the inner
+    (nominal) graph with value dummies for the dependents, then the real
+    ``inputs`` / ``dep_rvs`` are substituted once at the end.
+    """
+    chain = op.inner_outputs[0]
+    dependents = list(op.inner_outputs[1 : 1 + op.n_dependent_rvs])
+
+    if chain.type.ndim > 1:
+        raise NotImplementedError(
+            "Recovering a batched DiscreteMarkovChain (more than one chain) is not yet supported."
+        )
+
+    dep_dummies = [dep.type() for dep in dependents]
+
+    batch_logp_emissions, batch_chain_value, chain_shape = _hmm_emission_logp(
+        op, chain, dependents, dep_dummies
+    )
+    batch_logp_init_dist, log_P = _hmm_log_init_and_transition(
+        chain, chain_shape, batch_chain_value
+    )
+    time_varying = chain.owner.op.time_varying_P
+    log_alphas = _hmm_forward_log_alphas(
+        batch_logp_emissions, batch_logp_init_dist, log_P, time_varying
+    )  # (T, k)
+    log_betas = _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying)  # (T, k)
+
+    # Smoothed initial distribution γ₀ ∝ α₀·β₀
+    log_gamma_0 = log_softmax(log_alphas[0] + log_betas[0], axis=-1)  # (k,)
+    init_dist = Categorical.dist(logit_p=log_gamma_0)
+
+    # Forward-smoothed time-varying transitions for steps t = 1 .. T-1:
+    #   p(s_t=j | s_{t-1}=i, y) ∝ A_t(i,j) · b_t(j) · β_t(j)   (normalized over j)
+    emissions_jt = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)  # (T-1, k) over (t, j)
+    log_terms = emissions_jt + log_betas[1:]  # (T-1, k): b_t(j) + β_t(j)
+    # log_A_t: a single matrix broadcast over steps (homogeneous), or the per-step prior
+    # transition (already (T-1, k, k), where log_P[t] is the transition into state t+1).
+    log_A_t = log_P[None, :, :] if not time_varying else log_P
+    log_P_t = log_A_t + log_terms[:, None, :]  # (T-1, k, k) over (t, i, j)
+    P_t = softmax(log_P_t, axis=-1)  # row-stochastic transition matrix per step
+
+    steps = chain_shape[0] - 1
+    cond_chain = DiscreteMarkovChain.dist(
+        P=P_t, init_dist=init_dist, steps=steps, time_varying_P=True
+    )
+
+    replacements = dict(zip(op.inner_inputs, inputs))
+    replacements.update(zip(dep_dummies, dep_rvs))
+    [cond_chain] = graph_replace([cond_chain], replace=replacements, strict=False)
+    return cond_chain
+
+
 @node_rewriter(tracks=[MarginalSubgraph])
 def discrete_markov_chain_marginal(fgraph, node):
     inputs, outputs = extract_marginal_subgraph(node)
@@ -118,7 +315,15 @@ def discrete_markov_chain_marginal(fgraph, node):
         raise NotImplementedError(
             "Marginalization for DiscreteMarkovChain with n_lags > 1 is not supported"
         )
-    if marginalized_rv.owner.inputs[0].type.ndim > 2:
+    P_ndim = marginalized_rv.owner.inputs[0].type.ndim
+    # A time-varying chain has an extra (time, k, k) core axis, so ndim == 3 is expected
+    # there; the flag disambiguates it from a genuine batch dimension.
+    if marginalized_rv_op.time_varying_P:
+        if P_ndim > 3:
+            raise NotImplementedError(
+                "Marginalization for batched time-varying DiscreteMarkovChain is not supported"
+            )
+    elif P_ndim > 2:
         raise NotImplementedError(
             "Marginalization for DiscreteMarkovChain with non-matrix transition probability "
             "is not supported"

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -36,13 +36,9 @@ class EnumerableMarginalRV(MarginalRV):
         self,
         *args,
         dims_connections: tuple[tuple[int | None], ...],
-        marginalized_dims,
-        n_dependent_rvs: int,
         **kwargs,
     ) -> None:
         self.dims_connections = dims_connections
-        self.marginalized_dims = marginalized_dims
-        self.n_dependent_rvs = n_dependent_rvs
         super().__init__(*args, **kwargs)
 
     @property

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -7,13 +7,12 @@ import pytensor.tensor as pt
 
 from pymc.distributions import Bernoulli, Categorical, DiscreteUniform
 from pymc.logprob.abstract import _logprob
-from pymc.logprob.basic import conditional_logp, logp
+from pymc.logprob.basic import conditional_logp
 from pymc.pytensorf import constant_fold
 from pytensor.compile.mode import Mode
 from pytensor.graph import Op, node_rewriter, vectorize_graph
-from pytensor.graph.replace import clone_replace, graph_replace
+from pytensor.graph.replace import graph_replace
 from pytensor.scan import map as scan_map
-from pytensor.scan import scan
 from pytensor.tensor import TensorVariable
 
 from pymc_extras.distributions import DiscreteMarkovChain
@@ -89,10 +88,6 @@ def align_logp_dims(dims: tuple[int | None, ...], logp: TensorVariable) -> Tenso
 
 class MarginalFiniteDiscreteRV(EnumerableMarginalRV):
     """Base class for Marginalized Finite Discrete RVs"""
-
-
-class MarginalDiscreteMarkovChainRV(EnumerableMarginalRV):
-    """Base class for Marginalized Discrete Markov Chain RVs"""
 
 
 def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> tuple[int, ...]:
@@ -230,84 +225,6 @@ def finite_discrete_marginal_rv_logp(op: MarginalFiniteDiscreteRV, values, *inpu
     return joint_logp, *dummy_logps
 
 
-@_logprob.register(MarginalDiscreteMarkovChainRV)
-def marginal_hmm_logp(op, values, *inputs, **kwargs):
-    all_outputs = inline_ofg_outputs(op, inputs)
-    chain_rv = all_outputs[0]
-    dependent_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
-
-    P, n_steps_, init_dist_, rng = chain_rv.owner.inputs
-    domain = pt.arange(P.shape[-1], dtype="int32")
-
-    # Construct logp in two steps
-    # Step 1: Compute the probability of the data ("emissions") under every possible state (vec_logp_emission)
-
-    # First we need to vectorize the conditional logp graph of the data, in case there are batch dimensions floating
-    # around. To do this, we need to break the dependency between chain and the init_dist_ random variable. Otherwise,
-    # PyMC will detect a random variable in the logp graph (init_dist_), that isn't relevant at this step.
-    chain_value = chain_rv.clone()
-    dependent_rvs = clone_replace(dependent_rvs, {chain_rv: chain_value})
-    logp_emissions_dict = conditional_logp(dict(zip(dependent_rvs, values)))
-
-    # Reduce and add the batch dims beyond the chain dimension
-    reduced_logp_emissions = reduce_batch_dependent_logps(
-        dependent_dims_connections=op.dims_connections,
-        dependent_ops=[dependent_rv.owner.op for dependent_rv in dependent_rvs],
-        dependent_logps=[logp_emissions_dict[value] for value in values],
-    )
-
-    # Add a batch dimension for the domain of the chain
-    chain_shape = constant_fold(tuple(chain_rv.shape))
-    batch_chain_value = pt.moveaxis(pt.full((*chain_shape, domain.size), domain), -1, 0)
-    batch_logp_emissions = vectorize_graph(reduced_logp_emissions, {chain_value: batch_chain_value})
-
-    # Step 2: Compute the transition probabilities
-    # This is the "forward algorithm", alpha_t = p(y | s_t) * sum_{s_{t-1}}(p(s_t | s_{t-1}) * alpha_{t-1})
-    # We do it entirely in logs, though.
-
-    # To compute the prior probabilities of each state, we evaluate the logp of the domain (all possible states)
-    # under the initial distribution. This is robust to everything the user can throw at it.
-    init_dist_value = init_dist_.type()
-    logp_init_dist = logp(init_dist_, init_dist_value)
-    # Squeeze core dimension for n_lags=1 (only supported case)
-    batch_logp_init_dist = vectorize_graph(
-        logp_init_dist, {init_dist_value: batch_chain_value[..., :1]}
-    ).squeeze(-1)
-    log_alpha_init = batch_logp_init_dist + batch_logp_emissions[..., 0]
-
-    def step_alpha(logp_emission, log_alpha, log_P):
-        step_log_prob = pt.logsumexp(log_alpha[:, None, ...] + log_P, axis=0)
-        return logp_emission + step_log_prob
-
-    # Add implicit dimensions of P, and place core dimensions at the front
-    P = pt.atleast_Nd(P, n=len(chain_shape) + 1)
-    P = pt.moveaxis(P, (-2, -1), (0, 1))
-    log_P = pt.log(P)
-
-    log_alpha_seq = scan(
-        step_alpha,
-        non_sequences=[log_P],
-        outputs_info=[log_alpha_init],
-        # Scan needs the time dimension first, and we already consumed the 1st logp computing the initial value
-        sequences=pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0),
-        return_updates=False,
-    )
-    # Final logp is just the sum of the last scan state
-    joint_logp = pt.logsumexp(log_alpha_seq[-1], axis=0)
-
-    # Align logp with non-collapsed batch dimensions of first RV
-    remaining_dims_first_emission = list(op.dims_connections[0])
-    # The last dim of chain_rv was removed when computing the logp
-    remaining_dims_first_emission.remove(chain_rv.type.ndim - 1)
-    joint_logp = align_logp_dims(remaining_dims_first_emission, joint_logp)
-
-    # If there are multiple emission streams, we have to add dummy logps for the remaining value variables. The first
-    # return is the joint probability of everything together, but PyMC still expects one logp for each emission stream.
-    warn_non_separable_logp(values)
-    dummy_logps = (DUMMY_ZERO,) * (len(values) - 1)
-    return joint_logp, *dummy_logps
-
-
 @marginalized_conditional.register(MarginalFiniteDiscreteRV)
 def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
     # The logp must be derived over root placeholders, not the real
@@ -367,30 +284,16 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
     return sample_graph
 
 
-@node_rewriter(tracks=[MarginalSubgraph])
-def finite_discrete_marginal(fgraph, node):
+def build_enumerable_marginal_rv(node, inputs, outputs, constructor):
+    """Build an :class:`EnumerableMarginalRV` of type ``constructor`` from a marginal subgraph.
+
+    Shared by the per-distribution rewriters (e.g. finite discrete and DiscreteMarkovChain).
+    Computes the dependent-RV dim connections, instantiates the typed op, and returns the
+    replacement outptus aligned with ``node``.
+    """
     op = node.op
     n_dep = op.n_dependent_rvs
-
-    inputs, outputs = extract_marginal_subgraph(node)
     marginalized_rv = outputs[0]
-
-    marginalized_rv_op = marginalized_rv.owner.op
-    if not isinstance(
-        marginalized_rv_op, Bernoulli | Categorical | DiscreteUniform | DiscreteMarkovChain
-    ):
-        return None
-
-    if isinstance(marginalized_rv_op, DiscreteMarkovChain):
-        if marginalized_rv_op.n_lags > 1:
-            raise NotImplementedError(
-                "Marginalization for DiscreteMarkovChain with n_lags > 1 is not supported"
-            )
-        if marginalized_rv.owner.inputs[0].type.ndim > 2:
-            raise NotImplementedError(
-                "Marginalization for DiscreteMarkovChain with non-matrix transition probability "
-                "is not supported"
-            )
 
     try:
         dependent_rvs_dim_connections = subgraph_batch_dim_connection(
@@ -402,11 +305,6 @@ def finite_discrete_marginal(fgraph, node):
             "You can try splitting the marginalized RV into separate components and marginalizing "
             f"them separately. {e}"
         ) from e
-
-    if isinstance(marginalized_rv_op, DiscreteMarkovChain):
-        constructor = MarginalDiscreteMarkovChainRV
-    else:
-        constructor = MarginalFiniteDiscreteRV
 
     typed_op = constructor(
         inputs=inputs,
@@ -421,6 +319,15 @@ def finite_discrete_marginal(fgraph, node):
     if not isinstance(new_outputs, list):
         new_outputs = list(new_outputs)
     return new_outputs[: len(node.outputs)]
+
+
+@node_rewriter(tracks=[MarginalSubgraph])
+def finite_discrete_marginal(fgraph, node):
+    inputs, outputs = extract_marginal_subgraph(node)
+    marginalized_rv_op = outputs[0].owner.op
+    if not isinstance(marginalized_rv_op, Bernoulli | Categorical | DiscreteUniform):
+        return None
+    return build_enumerable_marginal_rv(node, inputs, outputs, MarginalFiniteDiscreteRV)
 
 
 marginal_rewrites_db.register("finite_discrete_marginal", finite_discrete_marginal, "basic")

--- a/pymc_extras/model/marginal/distributions/laplace.py
+++ b/pymc_extras/model/marginal/distributions/laplace.py
@@ -35,13 +35,9 @@ class MarginalLaplaceRV(MarginalRV):
     def __init__(
         self,
         *args,
-        marginalized_dims,
-        n_dependent_rvs: int,
         minimizer_kwargs: dict = DEFAULT_MINIMIZER_KWARGS,
         **kwargs,
     ) -> None:
-        self.marginalized_dims = marginalized_dims
-        self.n_dependent_rvs = n_dependent_rvs
         self.minimizer_kwargs = minimizer_kwargs
         super().__init__(*args, **kwargs)
 

--- a/pymc_extras/model/marginal/distributions/normal.py
+++ b/pymc_extras/model/marginal/distributions/normal.py
@@ -25,10 +25,9 @@ class NormalNormalMarginalRV(MarginalRV):
     Inner graph: [marginalized_normal, dependent_normal, *rng_updates]
     """
 
-    def __init__(self, *args, marginalized_dims, **kwargs):
-        self.marginalized_dims = marginalized_dims
-        self.n_dependent_rvs = 1
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, **kwargs):
+        # Normal-Normal conjugacy always has exactly one dependent RV
+        super().__init__(*args, n_dependent_rvs=1, **kwargs)
 
 
 @_logprob.register(NormalNormalMarginalRV)

--- a/tests/distributions/test_discrete_markov_chain.py
+++ b/tests/distributions/test_discrete_markov_chain.py
@@ -118,6 +118,56 @@ class TestDiscreteMarkovRV:
         logp = pm.logp(chain, [0, 1, 2]).eval()
         assert logp == np.log(0.2 * 0.5 * 0.3)
 
+    def test_time_varying_P(self):
+        """Time-inhomogeneous chain: a distinct transition matrix per step (#392)."""
+        pi0 = np.array([0.6, 0.4])
+        # shape (T, k, k): one transition matrix per step
+        P_t = np.array(
+            [
+                [[0.9, 0.1], [0.2, 0.8]],
+                [[0.5, 0.5], [0.5, 0.5]],
+                [[0.1, 0.9], [0.7, 0.3]],
+                [[0.3, 0.7], [0.6, 0.4]],
+            ]
+        )
+        T = P_t.shape[0]
+        x0 = pm.Categorical.dist(p=pi0)
+        # steps is left unspecified: it is inferred from P's time axis.
+        chain = DiscreteMarkovChain.dist(
+            P=pt.as_tensor_variable(P_t), init_dist=x0, time_varying_P=True
+        )
+
+        # Shape: init state + T transitions
+        draw = pm.draw(chain, random_seed=1)
+        assert draw.shape == (T + 1,)
+
+        # logp uses the per-step matrix at each transition
+        path = np.array([0, 1, 1, 0, 1])
+        logp = pm.logp(chain, path).eval()
+        expected = np.log(pi0[path[0]]) + sum(
+            np.log(P_t[t, path[t], path[t + 1]]) for t in range(T)
+        )
+        np.testing.assert_allclose(logp, expected)
+
+        # Sampling honours the step-0 transition (0 -> 0 with prob 0.9)
+        draws = pm.draw(chain, draws=20_000, random_seed=2)
+        from_0 = draws[:, 0] == 0
+        np.testing.assert_allclose((draws[from_0, 1] == 0).mean(), 0.9, atol=0.02)
+
+    def test_time_varying_P_requires_single_lag(self):
+        P_t = np.zeros((3, 2, 2, 2))
+        x0 = pm.Categorical.dist(p=[0.5, 0.5])
+        with pytest.raises(NotImplementedError, match="time_varying_P is only supported"):
+            DiscreteMarkovChain.dist(P=P_t, init_dist=x0, steps=3, time_varying_P=True, n_lags=2)
+
+    def test_time_varying_P_steps_conflict(self):
+        """An explicit steps inconsistent with P's time axis is rejected."""
+        P_t = np.zeros((3, 2, 2))  # 3 transitions
+        x0 = pm.Categorical.dist(p=[0.5, 0.5])
+        chain = DiscreteMarkovChain.dist(P=P_t, init_dist=x0, steps=5, time_varying_P=True)
+        with pytest.raises(AssertionError, match="support_shape does not match"):
+            pm.draw(chain)
+
     def test_moment_function(self):
         P_np = np.array([[0.1, 0.5, 0.4], [0.3, 0.4, 0.3], [0.9, 0.05, 0.05]])
 

--- a/tests/model/marginal/test_discrete_markov_chain.py
+++ b/tests/model/marginal/test_discrete_markov_chain.py
@@ -1,12 +1,17 @@
+import itertools
+
 import numpy as np
 import pymc as pm
 import pytensor.tensor as pt
 import pytest
+import scipy
 
+from arviz_base import from_dict
+from scipy.special import logsumexp
 from scipy.stats import norm
 
 from pymc_extras.distributions import DiscreteMarkovChain
-from pymc_extras.marginal import marginalize
+from pymc_extras.marginal import conditional, marginalize, recover
 
 
 @pytest.mark.parametrize("batch_chain", (False, True), ids=lambda x: f"batch_chain={x}")
@@ -104,3 +109,164 @@ def test_marginalized_discrete_markov_chain_multiple_emissions(
     res_logp, dummy_logp = logp_fn(test_point)
     assert res_logp.shape == ((3, 1) if batch_chain else ())
     np.testing.assert_allclose(res_logp.sum(), expected_logp)
+
+
+def test_recover_discrete_markov_chain_propagates_noise():
+    """recover() propagates the emission noise from the posterior.
+
+    The emission sigma is a free RV; we feed a posterior alternating between a
+    low and a high value. Under low noise the emissions pin the states, so the
+    recovered path is deterministic and matches the observations; under high
+    noise the emissions are uninformative and the recovered path is not.
+    """
+    P = np.array([[0.7, 0.3], [0.3, 0.7]])
+    low, high = 0.05, 5.0
+    obs = np.array([0, 0, 1, 1, 0])
+    with pm.Model() as m:
+        sigma_rv = pm.HalfNormal("sigma", 1.0, default_transform=None)
+        init_dist = pm.Categorical.dist(p=[0.5, 0.5])
+        states = DiscreteMarkovChain("states", P=P, init_dist=init_dist, steps=len(obs) - 1)
+        pm.Normal("emission", mu=states, sigma=sigma_rv, observed=obs)
+
+    marginal_m = marginalize(m, [states])
+
+    sigmas = np.tile([low, high], 50)
+    idata = from_dict({"posterior": {"sigma": sigmas[None, :]}})
+    out = recover(idata, model=marginal_m, random_seed=42)
+
+    post = out.posterior
+    assert "states" in post
+    assert post["states"].shape == (1, 100, len(obs))
+
+    rec = post["states"].isel(chain=0).values
+    # Low-noise draws: deterministic, every draw is exactly the observations.
+    np.testing.assert_array_equal(rec[sigmas == low], np.broadcast_to(obs, (50, len(obs))))
+    # High-noise draws: not all equal to the observations.
+    assert not np.array_equal(rec[sigmas == high], np.broadcast_to(obs, (50, len(obs))))
+
+
+def test_conditional_discrete_markov_chain():
+    """conditional() logp and recover() marginals for an HMM both match brute force."""
+    P = np.array([[0.8, 0.2], [0.3, 0.7]])
+    pi0 = np.array([0.6, 0.4])
+    sigma = 0.9
+    obs = np.array([0.2, 1.1, 0.9, -0.3])
+    n_steps = len(obs)
+
+    with pm.Model() as m:
+        sigma_rv = pm.HalfNormal("sigma", 1.0, default_transform=None)
+        init_dist = pm.Categorical.dist(p=pi0)
+        states = DiscreteMarkovChain("states", P=P, init_dist=init_dist, steps=n_steps - 1)
+        pm.Normal("emission", mu=states, sigma=sigma_rv, observed=obs)
+    marginal_m = marginalize(m, [states])
+    cond_m = conditional(marginal_m)
+
+    # Brute-force log joint over all 2^T paths -> normalizer -> marginals.
+    log_joint = {}
+    for path in itertools.product([0, 1], repeat=n_steps):
+        lp = np.log(pi0[path[0]])
+        for t in range(1, n_steps):
+            lp += np.log(P[path[t - 1], path[t]])
+        lp += scipy.stats.norm.logpdf(obs, loc=np.array(path), scale=sigma).sum()
+        log_joint[path] = lp
+    log_z = logsumexp(list(log_joint.values()))
+    brute_marginal = np.array(
+        [sum(np.exp(log_joint[s] - log_z) for s in log_joint if s[t] == 1) for t in range(n_steps)]
+    )
+
+    # Exact conditional logp p(s | y, sigma)
+    logp_fn = cond_m.compile_logp(vars=[cond_m["states"]])
+    for path in [(0, 0, 1, 0), (1, 1, 0, 1), (0, 1, 1, 0)]:
+        got = logp_fn({"sigma": sigma, "states": np.array(path)})
+        np.testing.assert_allclose(got, log_joint[path] - log_z, atol=1e-5)
+
+    # Recovered marginals match brute force; sigma is propagated from the
+    # posterior (states are 0/1, so mean == P(s=1)).
+    idata = from_dict({"posterior": {"sigma": np.full((2, 2000), sigma)}})
+    recovered = (
+        recover(idata, model=marginal_m, random_seed=0).posterior["states"].mean(("chain", "draw"))
+    )
+    np.testing.assert_allclose(recovered, brute_marginal, atol=0.02)
+
+
+def test_marginalized_discrete_markov_chain_time_varying_P():
+    """Marginalizing a non-homogeneous (time-varying P) chain matches brute force."""
+    pi0 = np.array([0.6, 0.4])
+    sigma = 0.8
+    obs = np.array([0.1, 1.2, 0.8, -0.2, 0.9])
+    T, k = len(obs), 2
+    A_t = np.array(
+        [
+            [[0.9, 0.1], [0.2, 0.8]],
+            [[0.4, 0.6], [0.3, 0.7]],
+            [[0.1, 0.9], [0.5, 0.5]],
+            [[0.7, 0.3], [0.6, 0.4]],
+        ]
+    )
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0)
+        # steps inferred from A_t's time axis
+        states = DiscreteMarkovChain("states", P=A_t, init_dist=init, time_varying_P=True)
+        pm.Normal("emission", mu=states, sigma=sigma, observed=obs)
+
+    marginal_m = marginalize(m, [states])
+
+    # Brute-force marginal likelihood log p(y) over all k^T paths.
+    log_joint = []
+    for s in itertools.product(range(k), repeat=T):
+        lp = np.log(pi0[s[0]]) + sum(np.log(A_t[t - 1, s[t - 1], s[t]]) for t in range(1, T))
+        lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
+        log_joint.append(lp)
+    expected = logsumexp(log_joint)
+
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
+def test_conditional_discrete_markov_chain_time_varying_P():
+    """conditional()/recover() for a non-homogeneous (time-varying P) HMM."""
+    pi0 = np.array([0.6, 0.4])
+    sigma = 0.8
+    obs = np.array([0.1, 1.2, 0.8, -0.2, 0.9])
+    n_steps, k = len(obs), 2
+    A_t = np.array(
+        [
+            [[0.9, 0.1], [0.2, 0.8]],
+            [[0.4, 0.6], [0.3, 0.7]],
+            [[0.1, 0.9], [0.5, 0.5]],
+            [[0.7, 0.3], [0.6, 0.4]],
+        ]
+    )
+
+    with pm.Model() as m:
+        sigma_rv = pm.HalfNormal("sigma", 1.0, default_transform=None)
+        init_dist = pm.Categorical.dist(p=pi0)
+        # steps inferred from A_t's time axis
+        states = DiscreteMarkovChain("states", P=A_t, init_dist=init_dist, time_varying_P=True)
+        pm.Normal("emission", mu=states, sigma=sigma_rv, observed=obs)
+
+    marginal_m = marginalize(m, [states])
+    cond_m = conditional(marginal_m)
+
+    log_joint = {}
+    for s in itertools.product(range(k), repeat=n_steps):
+        lp = np.log(pi0[s[0]]) + sum(np.log(A_t[t - 1, s[t - 1], s[t]]) for t in range(1, n_steps))
+        lp += scipy.stats.norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
+        log_joint[s] = lp
+    log_z = logsumexp(list(log_joint.values()))
+    brute_marginal = np.array(
+        [sum(np.exp(log_joint[s] - log_z) for s in log_joint if s[t] == 1) for t in range(n_steps)]
+    )
+
+    logp_fn = cond_m.compile_logp(vars=[cond_m["states"]])
+    for path in [(0, 0, 1, 0, 1), (1, 1, 0, 1, 0), (0, 1, 1, 0, 1)]:
+        got = logp_fn({"sigma": sigma, "states": np.array(path)})
+        np.testing.assert_allclose(got, log_joint[path] - log_z, atol=1e-5)
+
+    # Recovered marginals match brute force; sigma is propagated from the
+    # posterior (states are 0/1, so mean == P(s=1)).
+    idata = from_dict({"posterior": {"sigma": np.full((1, 5000), sigma)}})
+    recovered = (
+        recover(idata, model=marginal_m, random_seed=0).posterior["states"].mean(("chain", "draw"))
+    )
+    np.testing.assert_allclose(recovered, brute_marginal, atol=0.02)

--- a/tests/model/marginal/test_discrete_markov_chain.py
+++ b/tests/model/marginal/test_discrete_markov_chain.py
@@ -1,0 +1,106 @@
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+import pytest
+
+from scipy.stats import norm
+
+from pymc_extras.distributions import DiscreteMarkovChain
+from pymc_extras.marginal import marginalize
+
+
+@pytest.mark.parametrize("batch_chain", (False, True), ids=lambda x: f"batch_chain={x}")
+@pytest.mark.parametrize("batch_emission", (False, True), ids=lambda x: f"batch_emission={x}")
+def test_marginalized_discrete_markov_chain_normal_emission(batch_chain, batch_emission):
+    if batch_chain and not batch_emission:
+        pytest.skip("Redundant implicit combination")
+
+    with pm.Model() as m:
+        P = [[0, 1], [1, 0]]
+        init_dist = pm.Categorical.dist(p=[1, 0])
+        chain = DiscreteMarkovChain(
+            "chain", P=P, init_dist=init_dist, steps=3, shape=(3, 4) if batch_chain else None
+        )
+        emission = pm.Normal(
+            "emission", mu=chain * 2 - 1, sigma=1e-1, shape=(3, 4) if batch_emission else None
+        )
+
+    marginal_m = marginalize(m, [chain])
+    logp_fn = marginal_m.compile_logp()
+
+    test_value = np.array([-1, 1, -1, 1])
+    expected_logp = pm.logp(pm.Normal.dist(0, 1e-1), np.zeros_like(test_value)).sum().eval()
+    if batch_emission:
+        test_value = np.broadcast_to(test_value, (3, 4))
+        expected_logp *= 3
+    np.testing.assert_allclose(logp_fn({"emission": test_value}), expected_logp)
+
+
+@pytest.mark.parametrize(
+    "categorical_emission",
+    [False, True],
+)
+def test_marginalized_discrete_markov_chain_categorical_emission(categorical_emission):
+    """Example adapted from https://www.youtube.com/watch?v=9-sPm4CfcD0"""
+    with pm.Model() as m:
+        P = np.array([[0.5, 0.5], [0.3, 0.7]])
+        init_dist = pm.Categorical.dist(p=[0.375, 0.625])
+        chain = DiscreteMarkovChain("chain", P=P, init_dist=init_dist, steps=2)
+        if categorical_emission:
+            emission = pm.Categorical("emission", p=pt.constant([[0.8, 0.2], [0.4, 0.6]])[chain])
+        else:
+            emission = pm.Bernoulli("emission", p=pt.where(pt.eq(chain, 0), 0.2, 0.6))
+    marginal_m = marginalize(m, [chain])
+
+    test_value = np.array([0, 0, 1])
+    expected_logp = np.log(0.1344)  # Shown at the 10m22s mark in the video
+    logp_fn = marginal_m.compile_logp()
+    np.testing.assert_allclose(logp_fn({"emission": test_value}), expected_logp)
+
+
+@pytest.mark.filterwarnings("ignore:invalid value encountered in multiply:RuntimeWarning")
+@pytest.mark.parametrize("batch_chain", (False, True))
+@pytest.mark.parametrize("batch_emission1", (False, True))
+@pytest.mark.parametrize("batch_emission2", (False, True))
+def test_marginalized_discrete_markov_chain_multiple_emissions(
+    batch_chain, batch_emission1, batch_emission2
+):
+    chain_shape = (3, 1, 4) if batch_chain else (4,)
+    emission1_shape = (
+        (2, *reversed(chain_shape)) if batch_emission1 else tuple(reversed(chain_shape))
+    )
+    emission2_shape = (*chain_shape, 2) if batch_emission2 else chain_shape
+    with pm.Model() as m:
+        P = [[0, 1], [1, 0]]
+        init_dist = pm.Categorical.dist(p=[1, 0])
+        chain = DiscreteMarkovChain("chain", P=P, init_dist=init_dist, shape=chain_shape)
+        emission_1 = pm.Normal(
+            "emission_1", mu=(chain * 2 - 1).T, sigma=1e-1, shape=emission1_shape
+        )
+
+        emission2_mu = (1 - chain) * 2 - 1
+        if batch_emission2:
+            emission2_mu = emission2_mu[..., None]
+        emission_2 = pm.Normal("emission_2", mu=emission2_mu, sigma=1e-1, shape=emission2_shape)
+
+    marginal_m = marginalize(m, [chain])
+
+    with pytest.warns(UserWarning, match="multiple dependent variables"):
+        logp_fn = marginal_m.compile_logp(sum=False)
+
+    test_value = np.array([-1, 1, -1, 1])
+    multiplier = 2 + batch_emission1 + batch_emission2
+    if batch_chain:
+        multiplier *= 3
+    expected_logp = norm.logpdf(np.zeros_like(test_value), 0, 1e-1).sum() * multiplier
+
+    test_value = np.broadcast_to(test_value, chain_shape)
+    test_value_emission1 = np.broadcast_to(test_value.T, emission1_shape)
+    if batch_emission2:
+        test_value_emission2 = np.broadcast_to(-test_value[..., None], emission2_shape)
+    else:
+        test_value_emission2 = np.broadcast_to(-test_value, emission2_shape)
+    test_point = {"emission_1": test_value_emission1, "emission_2": test_value_emission2}
+    res_logp, dummy_logp = logp_fn(test_point)
+    assert res_logp.shape == ((3, 1) if batch_chain else ())
+    np.testing.assert_allclose(res_logp.sum(), expected_logp)

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -1,13 +1,9 @@
 import numpy as np
 import pymc as pm
-import pytest
 
 from pymc.logprob.abstract import _logprob
 from pytensor import tensor as pt
-from scipy.stats import norm
 
-from pymc_extras import marginalize
-from pymc_extras.distributions import DiscreteMarkovChain
 from pymc_extras.model.marginal.distributions import MarginalFiniteDiscreteRV
 
 
@@ -38,98 +34,3 @@ def test_marginalized_bernoulli_logp():
         logp.eval({mu: [-1, 1], y_vv: 2}),
         ref_logp.eval({mu: [-1, 1], y_vv: 2}),
     )
-
-
-@pytest.mark.parametrize("batch_chain", (False, True), ids=lambda x: f"batch_chain={x}")
-@pytest.mark.parametrize("batch_emission", (False, True), ids=lambda x: f"batch_emission={x}")
-def test_marginalized_hmm_normal_emission(batch_chain, batch_emission):
-    if batch_chain and not batch_emission:
-        pytest.skip("Redundant implicit combination")
-
-    with pm.Model() as m:
-        P = [[0, 1], [1, 0]]
-        init_dist = pm.Categorical.dist(p=[1, 0])
-        chain = DiscreteMarkovChain(
-            "chain", P=P, init_dist=init_dist, steps=3, shape=(3, 4) if batch_chain else None
-        )
-        emission = pm.Normal(
-            "emission", mu=chain * 2 - 1, sigma=1e-1, shape=(3, 4) if batch_emission else None
-        )
-
-    marginal_m = marginalize(m, [chain])
-    logp_fn = marginal_m.compile_logp()
-
-    test_value = np.array([-1, 1, -1, 1])
-    expected_logp = pm.logp(pm.Normal.dist(0, 1e-1), np.zeros_like(test_value)).sum().eval()
-    if batch_emission:
-        test_value = np.broadcast_to(test_value, (3, 4))
-        expected_logp *= 3
-    np.testing.assert_allclose(logp_fn({"emission": test_value}), expected_logp)
-
-
-@pytest.mark.parametrize(
-    "categorical_emission",
-    [False, True],
-)
-def test_marginalized_hmm_categorical_emission(categorical_emission):
-    """Example adapted from https://www.youtube.com/watch?v=9-sPm4CfcD0"""
-    with pm.Model() as m:
-        P = np.array([[0.5, 0.5], [0.3, 0.7]])
-        init_dist = pm.Categorical.dist(p=[0.375, 0.625])
-        chain = DiscreteMarkovChain("chain", P=P, init_dist=init_dist, steps=2)
-        if categorical_emission:
-            emission = pm.Categorical("emission", p=pt.constant([[0.8, 0.2], [0.4, 0.6]])[chain])
-        else:
-            emission = pm.Bernoulli("emission", p=pt.where(pt.eq(chain, 0), 0.2, 0.6))
-    marginal_m = marginalize(m, [chain])
-
-    test_value = np.array([0, 0, 1])
-    expected_logp = np.log(0.1344)  # Shown at the 10m22s mark in the video
-    logp_fn = marginal_m.compile_logp()
-    np.testing.assert_allclose(logp_fn({"emission": test_value}), expected_logp)
-
-
-@pytest.mark.filterwarnings("ignore:invalid value encountered in multiply:RuntimeWarning")
-@pytest.mark.parametrize("batch_chain", (False, True))
-@pytest.mark.parametrize("batch_emission1", (False, True))
-@pytest.mark.parametrize("batch_emission2", (False, True))
-def test_marginalized_hmm_multiple_emissions(batch_chain, batch_emission1, batch_emission2):
-    chain_shape = (3, 1, 4) if batch_chain else (4,)
-    emission1_shape = (
-        (2, *reversed(chain_shape)) if batch_emission1 else tuple(reversed(chain_shape))
-    )
-    emission2_shape = (*chain_shape, 2) if batch_emission2 else chain_shape
-    with pm.Model() as m:
-        P = [[0, 1], [1, 0]]
-        init_dist = pm.Categorical.dist(p=[1, 0])
-        chain = DiscreteMarkovChain("chain", P=P, init_dist=init_dist, shape=chain_shape)
-        emission_1 = pm.Normal(
-            "emission_1", mu=(chain * 2 - 1).T, sigma=1e-1, shape=emission1_shape
-        )
-
-        emission2_mu = (1 - chain) * 2 - 1
-        if batch_emission2:
-            emission2_mu = emission2_mu[..., None]
-        emission_2 = pm.Normal("emission_2", mu=emission2_mu, sigma=1e-1, shape=emission2_shape)
-
-    marginal_m = marginalize(m, [chain])
-
-    with pytest.warns(UserWarning, match="multiple dependent variables"):
-        logp_fn = marginal_m.compile_logp(sum=False)
-
-    test_value = np.array([-1, 1, -1, 1])
-    multiplier = 2 + batch_emission1 + batch_emission2
-    if batch_chain:
-        multiplier *= 3
-    expected_logp = norm.logpdf(np.zeros_like(test_value), 0, 1e-1).sum() * multiplier
-
-    test_value = np.broadcast_to(test_value, chain_shape)
-    test_value_emission1 = np.broadcast_to(test_value.T, emission1_shape)
-    if batch_emission2:
-        test_value_emission2 = np.broadcast_to(-test_value[..., None], emission2_shape)
-    else:
-        test_value_emission2 = np.broadcast_to(-test_value, emission2_shape)
-    test_point = {"emission_1": test_value_emission1, "emission_2": test_value_emission2}
-    res_logp, dummy_logp = logp_fn(test_point)
-    assert res_logp.shape == ((3, 1) if batch_chain else ())
-    np.testing.assert_allclose(res_logp.sum(), expected_logp)


### PR DESCRIPTION
This PR includes adding support for conditional/recover DiscreteMarkovChain in recover_marginals

It adds time_varying_P option to DiscreteMarkovChain, which allows closure under these operations.

Closes #322 
Closes #392 