### PR TITLE
Support more affine graphs in normal-normal marginal

### DIFF
--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -26,7 +26,7 @@ from pymc_extras.model.marginal.distributions.enumerable import (
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
-    marginal_rewrites_db,
+    marginal_ir_rewrites_db,
 )
 
 
@@ -411,6 +411,6 @@ def discrete_markov_chain_marginal(fgraph, node):
     return build_enumerable_marginal_rv(node, inputs, outputs, MarginalDiscreteMarkovChainRV)
 
 
-marginal_rewrites_db.register(
+marginal_ir_rewrites_db.register(
     "discrete_markov_chain_marginal", discrete_markov_chain_marginal, "basic"
 )

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -25,7 +25,7 @@ from pymc_extras.model.marginal.graph_analysis import subgraph_batch_dim_connect
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
-    marginal_rewrites_db,
+    marginal_ir_rewrites_db,
 )
 
 
@@ -331,4 +331,4 @@ def finite_discrete_marginal(fgraph, node):
     return build_enumerable_marginal_rv(node, inputs, outputs, MarginalFiniteDiscreteRV)
 
 
-marginal_rewrites_db.register("finite_discrete_marginal", finite_discrete_marginal, "basic")
+marginal_ir_rewrites_db.register("finite_discrete_marginal", finite_discrete_marginal, "basic")

--- a/pymc_extras/model/marginal/distributions/laplace.py
+++ b/pymc_extras/model/marginal/distributions/laplace.py
@@ -186,8 +186,14 @@ def laplace_marginal(fgraph, node):
     # of the OpFromGraph (popped again by the logp implementation)
     inputs, outputs = extract_marginal_subgraph(node)
 
+    # Q may coincide with another boundary input (e.g. Q=tau where tau is also a
+    # parameter of the marginalized RV). OpFromGraph requires distinct inputs, and
+    # the inner graph never uses Q, so stand in a dummy variable for it.
+    *rest_inputs, Q = inputs
+    ofg_inputs = [*rest_inputs, Q.type()]
+
     typed_op = MarginalLaplaceRV(
-        inputs=inputs,
+        inputs=ofg_inputs,
         outputs=outputs,
         marginalized_name=op.marginalized_name,
         marginalized_dims=op.marginalized_dims,

--- a/pymc_extras/model/marginal/distributions/laplace.py
+++ b/pymc_extras/model/marginal/distributions/laplace.py
@@ -19,7 +19,7 @@ from pymc_extras.model.marginal.rewrites import (
     DEFAULT_MINIMIZER_KWARGS,
     LaplaceMarginalSubgraph,
     extract_marginal_subgraph,
-    marginal_rewrites_db,
+    marginal_ir_rewrites_db,
 )
 
 
@@ -201,4 +201,4 @@ def laplace_marginal(fgraph, node):
     return new_outputs[: len(node.outputs)]
 
 
-marginal_rewrites_db.register("laplace_marginal", laplace_marginal, "basic")
+marginal_ir_rewrites_db.register("laplace_marginal", laplace_marginal, "basic")

--- a/pymc_extras/model/marginal/distributions/normal.py
+++ b/pymc_extras/model/marginal/distributions/normal.py
@@ -16,7 +16,7 @@ from pymc_extras.model.marginal.distributions.core import (
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
-    marginal_rewrites_db,
+    marginal_ir_rewrites_db,
 )
 
 
@@ -130,4 +130,4 @@ def normal_normal_marginal_rewrite(fgraph, node):
     return new_outputs[: len(node.outputs)]
 
 
-marginal_rewrites_db.register("normal_normal_marginal", normal_normal_marginal_rewrite, "basic")
+marginal_ir_rewrites_db.register("normal_normal_marginal", normal_normal_marginal_rewrite, "basic")

--- a/pymc_extras/model/marginal/distributions/normal.py
+++ b/pymc_extras/model/marginal/distributions/normal.py
@@ -6,6 +6,7 @@ from pytensor.graph import node_rewriter
 from pytensor.graph.replace import graph_replace
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor import broadcast_to, constant, sqrt
+from pytensor.tensor.rewriting.basic import broadcasted_by
 
 from pymc_extras.model.marginal.distributions.core import (
     MarginalRV,
@@ -86,6 +87,15 @@ def normal_normal_marginal_rewrite(fgraph, node):
     if not (
         isinstance(marginalized_rv.owner.op, Normal) and isinstance(dependent_rv.owner.op, Normal)
     ):
+        return None
+
+    # Deny broadcasting of the marginalized RV into the dependent. The closed
+    # form is elementwise: each dependent draw depends on its own marginalized
+    # draw. If the marginalized RV is broadcast (stretched) to a wider dependent,
+    # one latent is shared across several dependents and the true marginal is a
+    # correlated MvNormal, not the elementwise Normal we emit. Unknown (None)
+    # dependent dims count as broadcasting since they may be >1 at runtime.
+    if broadcasted_by(marginalized_rv, dependent_rv):
         return None
 
     mu_dep, sigma_dep = dependent_rv.owner.op.dist_params(dependent_rv.owner)

--- a/pymc_extras/model/marginal/distributions/normal.py
+++ b/pymc_extras/model/marginal/distributions/normal.py
@@ -5,7 +5,8 @@ from pymc.pytensorf import get_symbolic_rv_shapes
 from pytensor.graph import node_rewriter
 from pytensor.graph.replace import graph_replace
 from pytensor.graph.traversal import ancestors
-from pytensor.tensor import broadcast_to, constant, sqrt
+from pytensor.tensor import broadcast_to, sqrt
+from pytensor.tensor.math import add, mul, variadic_add, variadic_mul
 from pytensor.tensor.rewriting.basic import broadcasted_by
 
 from pymc_extras.model.marginal.distributions.core import (
@@ -18,6 +19,42 @@ from pymc_extras.model.marginal.rewrites import (
     extract_marginal_subgraph,
     marginal_ir_rewrites_db,
 )
+
+
+def affine_coefficients(mu, x):
+    """Return ``(offset, slope)`` with ``mu == offset + slope * x``, or ``None`` if
+    ``mu`` is not affine in ``x``. ``slope`` is ``None`` if ``mu`` lacks ``x``.
+
+    Assumes Add/Mul are already flattened into variadic nodes by the pre-canonicalize
+    pass, so ``mu`` is read as one flat sum of terms, each either constant in ``x`` or
+    ``x`` scaled by constants (``x`` or ``Mul(*consts, x)``).
+
+    Callers must gate on both failure modes before using the result: a ``None``
+    return (not affine) and a ``None`` slope (``x`` absent). Only the rewrite that
+    builds the NormalNormalMarginalRV does so; the logp and conditional run after
+    it and may unpack unconditionally.
+    """
+    if x not in ancestors([mu]):
+        # x absent: mu is pure offset
+        return mu, None
+
+    terms = mu.owner.inputs if mu.owner.op == add else [mu]
+
+    offsets, slopes = [], []
+    for term in terms:
+        if x not in ancestors([term]):
+            # constant term contributes to the offset
+            offsets.append(term)
+            continue
+        # x-dependent term must be x scaled by constants (x or Mul(*consts, x))
+        factors = term.owner.inputs if term.owner.op == mul else [term]
+        const_factors = [f for f in factors if f is not x]
+        if sum(f is x for f in factors) != 1 or any(x in ancestors([f]) for f in const_factors):
+            # x*x, exp(x), or a non-flat op: not affine
+            return None
+        slopes.append(variadic_mul(*const_factors))
+
+    return variadic_add(*offsets), variadic_add(*slopes)
 
 
 class NormalNormalMarginalRV(MarginalRV):
@@ -49,8 +86,12 @@ def normal_normal_marginal_rv_logp(op: NormalNormalMarginalRV, values, *inputs, 
     if marginalized_rv.type.broadcastable != mu_m.type.broadcastable:
         mu_m = broadcast_to(mu_m, get_symbolic_rv_shapes([marginalized_rv])[0])
 
+    # mu_d is affine in the marginalized RV, mu_d = offset + slope * rv, so
+    # marginalizing gives y ~ Normal(offset + slope * mu_m, sqrt(sigma_d**2 +
+    # (slope * sigma_m)**2)). new_mu falls out of substituting mu_m for the rv.
+    _, slope = affine_coefficients(mu_d, marginalized_rv)
     new_mu = graph_replace(mu_d, {marginalized_rv: mu_m})
-    new_sigma = sqrt(sigma_d**2 + sigma_m**2)
+    new_sigma = sqrt(sigma_d**2 + (slope * sigma_m) ** 2)
     return logp(Normal.dist(mu=new_mu, sigma=new_sigma), value)
 
 
@@ -62,13 +103,18 @@ def normal_normal_conditional(op, inputs, dep_rvs):
     mu_m, sigma_m = marginalized.owner.op.dist_params(marginalized.owner)
     mu_d, sigma_d = dependent.owner.op.dist_params(dependent.owner)
 
-    offset = graph_replace(mu_d, {marginalized: constant(0, dtype=marginalized.type.dtype)})
+    # dep_rv ~ Normal(offset + slope * marginalized, sigma_d), so as a likelihood
+    # for the marginalized variable it contributes precision slope**2 / sigma_d**2
+    # with effective observation (dep_rv - offset) / slope.
+    offset, slope = affine_coefficients(mu_d, marginalized)
 
     precision_m = 1 / sigma_m**2
     precision_d = 1 / sigma_d**2
-    posterior_precision = precision_m + precision_d
+    posterior_precision = precision_m + slope**2 * precision_d
     posterior_sigma = sqrt(1 / posterior_precision)
-    posterior_mu = (mu_m * precision_m + (dep_rv - offset) * precision_d) / posterior_precision
+    posterior_mu = (
+        mu_m * precision_m + slope * (dep_rv - offset) * precision_d
+    ) / posterior_precision
 
     return Normal.dist(mu=posterior_mu, sigma=posterior_sigma)
 
@@ -103,19 +149,13 @@ def normal_normal_marginal_rewrite(fgraph, node):
     if marginalized_rv in ancestors([sigma_dep]):
         return None
 
-    if mu_dep is not marginalized_rv:
-        match mu_dep.owner_op_and_inputs:
-            case (_, a, b):
-                if a is marginalized_rv:
-                    if marginalized_rv in ancestors([b]):
-                        return None
-                elif b is marginalized_rv:
-                    if marginalized_rv in ancestors([a]):
-                        return None
-                else:
-                    return None
-            case _:
-                return None
+    # The dependent mean must be affine in the marginalized RV (mu_dep = a + b*rv);
+    # otherwise the marginal is not Normal in closed form. A None slope means the
+    # pre-canonicalize pass eliminated the rv from mu_dep (e.g. x - x), so the pair
+    # the marker was built for no longer exists and there is nothing to resolve.
+    coeffs = affine_coefficients(mu_dep, marginalized_rv)
+    if coeffs is None or coeffs[1] is None:
+        return None
 
     typed_op = NormalNormalMarginalRV(
         inputs=inputs,

--- a/pymc_extras/model/marginal/marginalize.py
+++ b/pymc_extras/model/marginal/marginalize.py
@@ -26,7 +26,7 @@ from pytensor.graph.traversal import ancestors, io_toposort
 from pytensor.tensor import TensorVariable
 
 # Importing the distributions package registers the strategy rewrites
-# (enumerable, laplace, normal) into marginal_rewrites_db.
+# (enumerable, laplace, normal) into marginal_ir_rewrites_db.
 import pymc_extras.model.marginal.distributions  # noqa: F401
 
 from pymc_extras.model.marginal.distributions.core import (
@@ -47,7 +47,7 @@ from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     MarginalSubgraphBase,
     local_unmarginalize,
-    marginal_rewrites_db,
+    marginal_ir_rewrites_db,
 )
 
 ModelRVs = TensorVariable | Sequence[TensorVariable] | str | Sequence[str]
@@ -259,7 +259,7 @@ def marginalize_fgraph(
 
         _replace_marginal_subgraph(fg, rv_to_marginalize, dependent_rvs, input_rvs, laplace_options)
 
-    rewriter = marginal_rewrites_db.query(rewrite_query)
+    rewriter = marginal_ir_rewrites_db.query(rewrite_query)
     rewriter.rewrite(fg)
 
     remaining = [node for node in fg.toposort() if isinstance(node.op, MarginalSubgraphBase)]

--- a/pymc_extras/model/marginal/marginalize.py
+++ b/pymc_extras/model/marginal/marginalize.py
@@ -47,7 +47,7 @@ from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     MarginalSubgraphBase,
     local_unmarginalize,
-    marginal_ir_rewrites_db,
+    marginalize_rewrites_db,
 )
 
 ModelRVs = TensorVariable | Sequence[TensorVariable] | str | Sequence[str]
@@ -259,7 +259,7 @@ def marginalize_fgraph(
 
         _replace_marginal_subgraph(fg, rv_to_marginalize, dependent_rvs, input_rvs, laplace_options)
 
-    rewriter = marginal_ir_rewrites_db.query(rewrite_query)
+    rewriter = marginalize_rewrites_db.query(rewrite_query)
     rewriter.rewrite(fg)
 
     remaining = [node for node in fg.toposort() if isinstance(node.op, MarginalSubgraphBase)]

--- a/pymc_extras/model/marginal/rewrites.py
+++ b/pymc_extras/model/marginal/rewrites.py
@@ -1,10 +1,10 @@
-from pymc.model.fgraph import model_free_rv
+from pymc.model.fgraph import ModelValuedVar, model_free_rv
 from pymc.pytensorf import collect_default_updates
 from pytensor.compile import SharedVariable
 from pytensor.graph import Apply, Op, node_rewriter
 from pytensor.graph.replace import graph_replace
 from pytensor.graph.rewriting.db import EquilibriumDB
-from pytensor.graph.traversal import graph_inputs
+from pytensor.graph.traversal import ancestors, graph_inputs
 
 from pymc_extras.model.marginal.distributions.core import MarginalRV, inline_ofg_outputs
 
@@ -173,7 +173,17 @@ def local_unmarginalize(fgraph, node):
     # import_missing imports the new value variable as an input.
     fgraph.add_output(unmarginalized_free_rv, reason="unmarginalize", import_missing=True)
 
-    dependent_rvs = graph_replace(dependent_rvs, {unmarginalized_rv: unmarginalized_free_rv})
+    # Pin already-built model-var wrappers (opaque ModelValuedVar) as boundaries so
+    # graph_replace does not clone their subgraphs, otherwise a shared upstream RV
+    # they wrap (e.g. a previously unmarginalized parent) gets duplicated.
+    pinned = {
+        a: a
+        for a in ancestors(dependent_rvs)
+        if a.owner is not None and isinstance(a.owner.op, ModelValuedVar)
+    }
+    dependent_rvs = graph_replace(
+        dependent_rvs, {**pinned, unmarginalized_rv: unmarginalized_free_rv}
+    )
 
     return [unmarginalized_free_rv, *dependent_rvs, *rngs]
 

--- a/pymc_extras/model/marginal/rewrites.py
+++ b/pymc_extras/model/marginal/rewrites.py
@@ -1,9 +1,10 @@
 from pymc.model.fgraph import ModelValuedVar, model_free_rv
 from pymc.pytensorf import collect_default_updates
 from pytensor.compile import SharedVariable
+from pytensor.compile.mode import optdb
 from pytensor.graph import Apply, Op, node_rewriter
 from pytensor.graph.replace import graph_replace
-from pytensor.graph.rewriting.db import EquilibriumDB
+from pytensor.graph.rewriting.db import EquilibriumDB, SequenceDB
 from pytensor.graph.traversal import ancestors, graph_inputs
 
 from pymc_extras.model.marginal.distributions.core import MarginalRV, inline_ofg_outputs
@@ -193,6 +194,27 @@ marginal_ir_rewrites_db.name = "marginal_ir_rewrites_db"
 # The strategy-specific rewrites (finite discrete, Laplace, Normal-Normal)
 # live next to their MarginalRV subclasses in ``distributions/`` and register
 # themselves here on import.
+
+# Canonicalize (flattening Add/Mul, folding constants, ...) before resolving the
+# markers, mirroring pymc.logprob's pre-canonicalize -> IR sequence. The structure
+# detectors (e.g. affine_coefficients) can then assume canonical graphs instead of
+# re-implementing canonicalization. Note this runs over the whole model fgraph, not
+# just the marker subgraphs, so the model marginalize() returns is canonicalized
+# too; equivalent_models(..., canonicalize=True) compares against such a model.
+marginalize_rewrites_db = SequenceDB()
+marginalize_rewrites_db.name = "marginalize_rewrites_db"
+marginalize_rewrites_db.register(
+    "pre-canonicalize",
+    optdb.query("+canonicalize", "-local_eager_useless_unbatched_blockwise"),
+    "basic",
+    position=1,
+)
+marginalize_rewrites_db.register(
+    "marginal_ir_rewrites",
+    marginal_ir_rewrites_db,
+    "basic",
+    position=2,
+)
 
 
 @node_rewriter(tracks=[MarginalSubgraph, LaplaceMarginalSubgraph])

--- a/pymc_extras/model/marginal/rewrites.py
+++ b/pymc_extras/model/marginal/rewrites.py
@@ -188,8 +188,8 @@ def local_unmarginalize(fgraph, node):
     return [unmarginalized_free_rv, *dependent_rvs, *rngs]
 
 
-marginal_rewrites_db = EquilibriumDB()
-marginal_rewrites_db.name = "marginal_rewrites_db"
+marginal_ir_rewrites_db = EquilibriumDB()
+marginal_ir_rewrites_db.name = "marginal_ir_rewrites_db"
 # The strategy-specific rewrites (finite discrete, Laplace, Normal-Normal)
 # live next to their MarginalRV subclasses in ``distributions/`` and register
 # themselves here on import.
@@ -315,7 +315,7 @@ def remarginalize_absorbed_dependent(fgraph, node):
     return [inner_outs[0], *outer_outs[1 : len(node.outputs)]]
 
 
-marginal_rewrites_db.register(
+marginal_ir_rewrites_db.register(
     "remarginalize_absorbed_dependent", remarginalize_absorbed_dependent, "basic"
 )
 
@@ -340,7 +340,7 @@ def resolve_deferred_marginal_subgraph(fgraph, node):
     return new_outputs
 
 
-marginal_rewrites_db.register(
+marginal_ir_rewrites_db.register(
     "resolve_deferred_marginal_subgraph",
     resolve_deferred_marginal_subgraph,
     "basic",

--- a/pymc_extras/utils/model_equivalence.py
+++ b/pymc_extras/utils/model_equivalence.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from pymc.model.core import Model
 from pymc.model.fgraph import fgraph_from_model
 from pytensor.compile import SharedVariable
+from pytensor.compile.mode import optdb
 from pytensor.graph.basic import Constant, Variable, equal_computations
 from pytensor.graph.traversal import graph_inputs
 from pytensor.tensor.random.type import RandomType
@@ -35,8 +36,14 @@ def equal_computations_up_to_root(
     )
 
 
-def equivalent_models(model1: Model, model2: Model, *, strict_dtype: bool = True) -> bool:
+def equivalent_models(
+    model1: Model, model2: Model, *, strict_dtype: bool = True, canonicalize: bool = False
+) -> bool:
     """Check whether two PyMC models are equivalent.
+
+    With ``canonicalize=True`` both model graphs are canonicalized before the
+    comparison, so models that differ only by canonicalization (e.g. one that
+    went through a rewrite pass and one that did not) compare equal.
 
     Examples
     --------
@@ -64,6 +71,10 @@ def equivalent_models(model1: Model, model2: Model, *, strict_dtype: bool = True
     """
     fgraph1, _ = fgraph_from_model(model1)
     fgraph2, _ = fgraph_from_model(model2)
+    if canonicalize:
+        canon = optdb.query("+canonicalize", "-local_eager_useless_unbatched_blockwise")
+        canon.rewrite(fgraph1)
+        canon.rewrite(fgraph2)
     # Model variable order is incidental (it follows graph construction
     # history); model variables are uniquely named, so compare by name.
     outputs1 = sorted(fgraph1.outputs, key=lambda var: var.name)

--- a/tests/model/marginal/test_marginalize.py
+++ b/tests/model/marginal/test_marginalize.py
@@ -684,18 +684,20 @@ def test_unmarginalize():
     marginal_m = marginalize(m, [idx, sub_idx])
     assert not equivalent_models(marginal_m, m)
 
+    # marginalize canonicalizes the model graph, so the round-tripped models
+    # match the originals only up to canonicalization.
     unmarginal_m = unmarginalize(marginal_m)
-    assert equivalent_models(unmarginal_m, m)
+    assert equivalent_models(unmarginal_m, m, canonicalize=True)
 
     unmarginal_idx_explicit = unmarginalize(marginal_m, ("idx", "sub_idx"))
-    assert equivalent_models(unmarginal_idx_explicit, m)
+    assert equivalent_models(unmarginal_idx_explicit, m, canonicalize=True)
 
     # Test partial unmarginalize
     unmarginal_idx = unmarginalize(marginal_m, "idx")
-    assert equivalent_models(unmarginal_idx, marginalize(m, "sub_idx"))
+    assert equivalent_models(unmarginal_idx, marginalize(m, "sub_idx"), canonicalize=True)
 
     unmarginal_sub_idx = unmarginalize(marginal_m, "sub_idx")
-    assert equivalent_models(unmarginal_sub_idx, marginalize(m, "idx"))
+    assert equivalent_models(unmarginal_sub_idx, marginalize(m, "idx"), canonicalize=True)
 
 
 def test_forward_after_sampling():

--- a/tests/model/marginal/test_normal.py
+++ b/tests/model/marginal/test_normal.py
@@ -61,6 +61,18 @@ def test_normal_normal_nonlinear_in_sigma():
         marginalize(m, m["x"])
 
 
+@pytest.mark.parametrize("x_shape", [(), (1,)], ids=["scalar", "size-1"])
+def test_normal_normal_broadcast_dependent_not_supported(x_shape):
+    """A marginalized rv broadcast across a wider dependent shares one latent,
+    so the true marginal is a correlated MvNormal, not the elementwise Normal."""
+    with pm.Model() as m:
+        x = pm.Normal("x", mu=0, sigma=1, shape=x_shape)
+        y = pm.Normal("y", mu=x, sigma=1.0, shape=(3,))
+
+    with pytest.raises(NotImplementedError):
+        marginalize(m, m["x"])
+
+
 def test_normal_normal_conditional_logp():
     """Test that conditional gives correct conjugate posterior logp for Normal-Normal."""
     sigma_prior = 3.0

--- a/tests/model/marginal/test_normal.py
+++ b/tests/model/marginal/test_normal.py
@@ -35,20 +35,61 @@ def test_normal_normal_batched_integer_mu():
     )
 
 
-@pytest.mark.parametrize("mu_fn", [lambda x: x + x, lambda x: 2 * x], ids=["x+x", "2*x"])
-@pytest.mark.xfail(reason="Affine f(x)=a*x+b not yet supported")
-def test_normal_normal_affine(mu_fn):
+@pytest.mark.parametrize(
+    "mu_fn, a, b",
+    [
+        (lambda x: x + x, 0, 2),
+        (lambda x: 2 * x, 0, 2),
+        (lambda x: 3 * x + 1, 1, 3),
+        (lambda x: 1 + x * 3, 1, 3),
+        (lambda x: x * 2 + x, 0, 3),
+        (lambda x: x + x + x, 0, 3),
+        (lambda x: 1 + 2 + 3 * x, 3, 3),
+    ],
+    ids=["x+x", "2x", "3x+1", "1+x3", "2x+x", "x+x+x", "1+2+3x"],
+)
+def test_normal_normal_affine(mu_fn, a, b):
+    """Dependent mean affine in the marginalized rv, mu = a + b*x, over the
+    flattened variadic Add/Mul forms (operand order and repetition vary)."""
     with pm.Model() as m:
         x = pm.Normal("x", mu=1, sigma=2)
         y = pm.Normal("y", mu=mu_fn(x), sigma=3)
 
     marginal_m = marginalize(m, m["x"])
 
-    # 2x: mu=2, sigma=sqrt(4*4 + 9)=5
+    expected_mu = a + b * 1
+    expected_sigma = np.sqrt(3**2 + (b * 2) ** 2)
     np.testing.assert_allclose(
         marginal_m.compile_logp()({"y": 5.0}),
-        scipy.stats.norm.logpdf(5.0, 2, 5),
+        scipy.stats.norm.logpdf(5.0, expected_mu, expected_sigma),
     )
+
+
+def test_normal_normal_affine_conditional():
+    """The conjugate posterior of an affine Normal-Normal accounts for the slope."""
+    sigma_prior = 3.0
+    a, b = 1.5, 2.0
+    sigma_lik = 4.0
+    y_obs = 10.0
+
+    with pm.Model() as m:
+        mu = pm.Normal("mu", 0, 10)
+        x = pm.Normal("x", mu=mu, sigma=sigma_prior)
+        y = pm.Normal("y", mu=b * x + a, sigma=sigma_lik, observed=y_obs)
+
+    marginal_m = marginalize(m, "x")
+    cond_m = conditional(marginal_m)
+
+    mu_val = 1.0
+    x_test = 3.0
+    prec_p = 1 / sigma_prior**2
+    post_prec = prec_p + b**2 / sigma_lik**2
+    post_sigma = np.sqrt(1 / post_prec)
+    post_mu = (mu_val * prec_p + b * (y_obs - a) / sigma_lik**2) / post_prec
+
+    expected = scipy.stats.norm.logpdf(x_test, post_mu, post_sigma)
+    actual = cond_m.compile_logp(vars=[cond_m["x"]])({"mu": mu_val, "x": x_test})
+    np.testing.assert_allclose(actual, expected)
 
 
 def test_normal_normal_nonlinear_in_sigma():
@@ -56,6 +97,16 @@ def test_normal_normal_nonlinear_in_sigma():
     with pm.Model() as m:
         x = pm.Normal("x", mu=0, sigma=1)
         y = pm.Normal("y", mu=0, sigma=x**2 + 1)
+
+    with pytest.raises(NotImplementedError):
+        marginalize(m, m["x"])
+
+
+def test_normal_normal_nonlinear_in_mu():
+    """Marginalized rv entering mu nonlinearly (x**2) has no closed-form Normal marginal."""
+    with pm.Model() as m:
+        x = pm.Normal("x", mu=0, sigma=1)
+        y = pm.Normal("y", mu=x**2, sigma=1)
 
     with pytest.raises(NotImplementedError):
         marginalize(m, m["x"])


### PR DESCRIPTION
- **Avoid duplicating shared RVs when unmarginalizing**
- **Control for broadcasting in normal-normal marginalization**
- **Support affine dependent means in normal-normal marginalization**

There's a more general approach for chains of Normal-Normal (with one to many, many to one and so on, and several links deep) that I might pursue in later that would subsume these "hand-crafted" restricted cases. But right now this is mostly demonstration purpose and ironing out rough edges through experimentation
