### PR TITLE
fix(pathfinder): draw loop-invariant randoms outside the scan in vectorize_logp=False path

### DIFF
--- a/pymc_extras/inference/pathfinder/bfgs_sample.py
+++ b/pymc_extras/inference/pathfinder/bfgs_sample.py
@@ -9,8 +9,10 @@ from numpy.typing import NDArray
 from pymc import Model
 from pymc.pytensorf import compile
 from pytensor.compile.executor import Function
-from pytensor.graph import clone_replace, vectorize_graph
+from pytensor.graph import graph_replace, vectorize_graph
+from pytensor.graph.traversal import truncated_graph_inputs
 from pytensor.tensor import TensorVariable
+from pytensor.tensor.random.type import RandomType
 
 REGULARIZATION_TERM = 1e-8
 
@@ -181,11 +183,26 @@ def make_pathfinder_sample_fn(
     if vectorize:
         batched_logP_sym = vectorize_graph(logP_single, replace={single_input: phi_sym})
     else:
-        batched_logP_sym = pytensor.map(
-            fn=lambda x_i: clone_replace([logP_single], replace={single_input: x_i})[0],
+        # A random draw that is loop-invariant w.r.t. the scanned input (e.g. a Minibatch's
+        # batch) must be drawn outside the scan: inside, its RNG has no update output and
+        # pm.compile rejects the graph. Draw it once in the outer graph, as the vectorize
+        # path already does, so the same draw is shared across every row.
+        invariant_draws = [
+            v
+            for v in truncated_graph_inputs([logP_single], ancestors_to_include=[single_input])
+            if v.owner and any(isinstance(i.type, RandomType) for i in v.owner.inputs)
+        ]
+        placeholders = [d.type() for d in invariant_draws]
+        logP_pure = graph_replace(logP_single, dict(zip(invariant_draws, placeholders)))
+
+        batched_pure = pytensor.map(
+            fn=lambda x_i: graph_replace(logP_pure, {single_input: x_i}),
             sequences=[phi_sym],
             return_updates=False,
         )
+        # Graft the real draws back on outside the loop. Passing them into the scan as
+        # non_sequences doesn't work: scan re-clones the RNG into the loop body from them.
+        batched_logP_sym = graph_replace(batched_pure, dict(zip(placeholders, invariant_draws)))
 
     outputs = [phi_sym, logQ_sym, batched_logP_sym, inv_hessian_diag_sym]
 

--- a/tests/inference/pathfinder/test_bfgs_sample.py
+++ b/tests/inference/pathfinder/test_bfgs_sample.py
@@ -1,11 +1,15 @@
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
+
+from pymc.blocking import DictToArrayBijection
 
 from pymc_extras.inference.pathfinder.bfgs_sample import (
     alpha_step_numpy,
     get_logp_dlogp_of_ravel_inputs,
     get_neg_logp_dlogp_of_ravel_inputs,
+    make_pathfinder_sample_fn,
 )
 
 
@@ -74,3 +78,56 @@ def test_neg_logp_dlogp_negates(scalar_model):
 
     np.testing.assert_allclose(neg_logp, -_standard_normal_logp(np.array(2.0)))
     np.testing.assert_allclose(neg_dlogp, [2.0])
+
+
+@pytest.fixture
+def minibatch_model():
+    """A minibatched model, whose logp carries a shared RNG for the batch draw."""
+    y = np.random.default_rng(0).normal(size=100)
+    with pm.Model() as model:
+        observed = pm.Minibatch(pt.as_tensor_variable(y), batch_size=20)
+        mu = pm.Normal("mu", 0.0, 1.0)
+        pm.Normal("obs", mu=mu, sigma=1.0, observed=observed, total_size=100)
+    return model
+
+
+def _sample_fn_inputs(N, J, seed=1, M=8):
+    """Well-formed (x, g, alpha, s_win, z_win, u) for a sample fn of size N, history J."""
+    rng = np.random.default_rng(seed)
+    s_win = rng.normal(size=(N, J)) * 0.1
+    return (
+        rng.normal(size=N),
+        rng.normal(size=N),
+        np.ones(N),
+        s_win,
+        s_win.copy(),  # z_win == s_win keeps S.T @ Z positive definite
+        rng.normal(size=(M, N)),
+    )
+
+
+@pytest.mark.parametrize("vectorize", [False, True])
+def test_sample_fn_supports_minibatch(minibatch_model, vectorize):
+    """Both batching modes return a finite logP per draw for a minibatched model."""
+    N = DictToArrayBijection.map(minibatch_model.initial_point()).data.shape[0]
+    J = 6
+
+    fn = make_pathfinder_sample_fn(minibatch_model, N, J, jacobian=True, vectorize=vectorize)
+    phi, logQ, logP, inv_hessian_diag = fn(*_sample_fn_inputs(N, J))
+
+    assert logP.shape == (phi.shape[0],)
+    assert np.all(np.isfinite(logP))
+
+
+def test_sample_fn_map_scores_all_draws_against_one_minibatch(minibatch_model):
+    """The minibatch is drawn once per call and shared across the map, so two identical
+    draws are scored against the same batch and get the same logP."""
+    N = DictToArrayBijection.map(minibatch_model.initial_point()).data.shape[0]
+    J = 6
+    x, g, alpha, s_win, z_win, u = _sample_fn_inputs(N, J)
+    u[1] = u[0]
+
+    fn = make_pathfinder_sample_fn(minibatch_model, N, J, jacobian=True, vectorize=False)
+    phi, _, logP, _ = fn(x, g, alpha, s_win, z_win, u)
+
+    np.testing.assert_allclose(phi[0], phi[1])
+    np.testing.assert_allclose(logP[0], logP[1])


### PR DESCRIPTION
Closes #705

`pmx.fit(method="pathfinder", vectorize_logp=False)` crashed at compile time for any
model using `pm.Minibatch`:

    ValueError: No update found for at least one RNG used in Scan Op

The `vectorize_logp=False` path batches the model logp with `pytensor.map`, which clones
the whole single-point logp graph into the scan body — minibatch RNG included. That leaves
a shared RNG inside the scan with no update output, and `pm.compile` refuses it. The
`vectorize_logp=True` path never hit this because `vectorize_graph` leaves the minibatch
draw as a single node in the outer graph (it's loop-invariant w.r.t. the draw being scored).

We make the scan path do the same: draw each loop-invariant random once, outside the loop.
We find those draws (the loop-invariant inputs that feed off an RNG), swap them for
placeholders to get an RNG-free logp, map over that, then graft the real draws back on
outside the scan. The RNG update then lives in the outer graph where
`collect_default_updates` can thread it, and the one minibatch is shared across every row —
matching the vectorize semantics.

Models without a minibatch are unaffected: there are no loop-invariant random draws, so the
branch reduces to the plain `pytensor.map` it was before.

## Tests
- `test_sample_fn_supports_minibatch` — both batching modes return a finite logP per draw
  for a minibatched model.
- `test_sample_fn_map_scores_all_draws_against_one_minibatch` — two identical draws get the
  same logP, confirming the minibatch is drawn once and shared across the map.

Full inference suite passes (182 tests).