### PR TITLE
Support marginalization of HMM with lags>1

### DIFF
--- a/docs/api/distributions.rst
+++ b/docs/api/distributions.rst
@@ -11,6 +11,7 @@ like regular PyMC distributions and can be used directly inside a model.
    Chi
    Maxwell
    DiscreteMarkovChain
+   JointCategorical
    GeneralizedPoisson
    BetaNegativeBinomial
    GenExtreme

--- a/pymc_extras/distributions/__init__.py
+++ b/pymc_extras/distributions/__init__.py
@@ -24,7 +24,7 @@ from pymc_extras.distributions.discrete import (
     Skellam,
 )
 from pymc_extras.distributions.histogram_utils import histogram_approximation
-from pymc_extras.distributions.multivariate import R2D2M2CP
+from pymc_extras.distributions.multivariate import R2D2M2CP, JointCategorical
 from pymc_extras.distributions.timeseries import DiscreteMarkovChain
 from pymc_extras.distributions.transforms import PartialOrder
 
@@ -35,6 +35,7 @@ __all__ = [
     "DiscreteMarkovChain",
     "GenExtreme",
     "GeneralizedPoisson",
+    "JointCategorical",
     "Maxwell",
     "PartialOrder",
     "Skellam",

--- a/pymc_extras/distributions/multivariate/__init__.py
+++ b/pymc_extras/distributions/multivariate/__init__.py
@@ -1,3 +1,4 @@
+from pymc_extras.distributions.multivariate.joint_categorical import JointCategorical
 from pymc_extras.distributions.multivariate.r2d2m2cp import R2D2M2CP
 
-__all__ = ["R2D2M2CP"]
+__all__ = ["R2D2M2CP", "JointCategorical"]

--- a/pymc_extras/distributions/multivariate/joint_categorical.py
+++ b/pymc_extras/distributions/multivariate/joint_categorical.py
@@ -1,0 +1,183 @@
+#   Copyright 2024 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+import numpy as np
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+
+from pymc.distributions.distribution import (
+    Distribution,
+    SymbolicRandomVariable,
+    _support_point,
+)
+from pymc.distributions.shape_utils import rv_size_is_none
+from pymc.logprob.abstract import _logprob
+from pymc.logprob.basic import logp
+from pytensor.tensor import TensorVariable
+from pytensor.tensor.random.utils import normalize_size_param
+
+__all__ = ["JointCategorical"]
+
+
+def _unravel_states(
+    flat: TensorVariable, n_states: TensorVariable, n_lags: int
+) -> list[TensorVariable]:
+    """Base-``n_states`` digits of ``flat`` (most-significant state first)."""
+    return [(flat // n_states ** (n_lags - 1 - i)) % n_states for i in range(n_lags)]
+
+
+class JointCategoricalRV(SymbolicRandomVariable):
+    """Joint distribution over ``n_lags`` categorical states."""
+
+    n_lags: int
+    default_output = 1
+    _print_name = ("JointCategorical", "\\operatorname{JointCategorical}")
+
+    def __init__(self, *args, n_lags, **kwargs):
+        self.n_lags = n_lags
+        # One core axis per lag, all of the same length (the repeated name enforces that).
+        self.extended_signature = f"[size],({','.join('s' * n_lags)}),[rng]->[rng],(l)"
+        super().__init__(*args, **kwargs)
+
+    def rebuild_rv(self, *args, **kwargs):
+        # rv_op is a classmethod, so it can't see n_lags on the instance; inject it so the default
+        # change_dist_size (which calls rebuild_rv) can resize the RV automatically.
+        return self.rv_op(*args, n_lags=self.n_lags, **kwargs)
+
+    @classmethod
+    def rv_op(cls, logit_p, *, n_lags, size=None, rng=None):
+        logit_p = pt.as_tensor_variable(logit_p)
+        size = normalize_size_param(size)
+        if rng is None:
+            rng = pytensor.shared(np.random.default_rng())
+
+        # A leading size broadcasts logit_p to (*size, *core_shape); raveling the state axes turns
+        # it into a flat Categorical, which draws one joint state per batch element.
+        if rv_size_is_none(size):
+            bcast_logit_p = logit_p
+        else:
+            bcast_logit_p = pt.broadcast_to(
+                logit_p, pt.concatenate([size, logit_p.shape[-n_lags:]])
+            )
+
+        next_rng, flat = pm.Categorical.dist(
+            logit_p=pt.join_dims(bcast_logit_p, start_axis=-n_lags), rng=rng, return_next_rng=True
+        )
+        states = pt.stack(_unravel_states(flat, logit_p.shape[-1], n_lags), axis=-1)
+
+        return cls(
+            inputs=[size, logit_p, rng],
+            outputs=[next_rng, states],
+            n_lags=n_lags,
+        )(size, logit_p, rng)
+
+
+class JointCategorical(Distribution):
+    r"""Joint distribution over ``n_lags`` categorical states.
+
+    A draw is a vector :math:`(x_0, \dots, x_{n\_lags - 1})`, each entry taking one of ``n_states``
+    values. Unlike a product of independent categoricals, the entries can be arbitrarily correlated:
+    the distribution is parameterized by the probability of every one of the ``n_states ** n_lags``
+    configurations, one array axis per entry.
+
+    .. math::
+
+        \Pr(x_0, \dots, x_{n\_lags - 1}) = p[x_0, \dots, x_{n\_lags - 1}]
+
+    Parameters
+    ----------
+    p : tensor_like of float
+        Probability of each state configuration, with shape ``(n_states,) * n_lags``: one axis per
+        entry of a draw, so ``p[i, j, ...]`` is the probability of drawing ``[i, j, ...]``. Any
+        leading axes are batch dimensions. Note the parameter grows exponentially in ``n_lags``,
+        as the joint is stored explicitly.
+    logit_p : tensor_like of float
+        Alternative parametrization, as unnormalized log-probabilities of the same shape. Only one
+        of ``p`` or ``logit_p`` may be given.
+    n_lags : int
+        Number of states in the joint. This is the support dimensionality: a single draw is a
+        vector of length ``n_lags``. The number of values each entry can take is taken from the
+        trailing axes of ``p`` / ``logit_p``.
+
+    Examples
+    --------
+    A joint over two binary states. Of the four possible paths, only the two that stay put,
+    ``[0, 0]`` and ``[1, 1]``, carry appreciable mass, so the pair is strongly correlated even
+    though each state is marginally 50/50:
+
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        import pymc_extras as pmx
+
+        # One axis per lag, so p[i, j] is the probability of drawing [i, j].
+        p = np.array(
+            [
+                [0.45, 0.05],  # [0, 0], [0, 1]
+                [0.05, 0.45],  # [1, 0], [1, 1]
+            ]
+        )
+        dist = pmx.JointCategorical.dist(p=p, n_lags=2)
+
+        pm.draw(dist, draws=5)
+        # array([[1, 1],
+        #        [0, 0],
+        #        [0, 0],
+        #        [1, 1],
+        #        [0, 1]])
+
+    Each row is one draw: a vector of ``n_lags=2`` states, the first entry being :math:`x_0` and
+    the second :math:`x_1`. Switching paths like ``[0, 1]`` show up in roughly one draw in ten.
+    Setting those entries to exactly ``0.0`` instead would make them impossible, leaving a joint
+    supported on two configurations only.
+
+    Notes
+    -----
+    This is the distribution of the smoothed initial states of a marginalized
+    :class:`~pymc_extras.distributions.DiscreteMarkovChain` with ``n_lags > 1``, where the first
+    ``n_lags`` states are correlated a posteriori.
+    """
+
+    rv_type = JointCategoricalRV
+    rv_op = JointCategoricalRV.rv_op
+
+    @classmethod
+    def dist(cls, p=None, *, logit_p=None, n_lags, **kwargs):
+        if (p is None) == (logit_p is None):
+            raise ValueError("Must specify exactly one of p or logit_p.")
+        if p is not None:
+            logit_p = pt.log(p)
+        logit_p = pt.as_tensor_variable(logit_p)
+        return super().dist([logit_p], n_lags=n_lags, **kwargs)
+
+
+@_support_point.register(JointCategoricalRV)
+def joint_categorical_moment(op, rv, size, logit_p, state_rng):
+    n_lags = op.n_lags
+    k = logit_p.shape[-1]
+    if not rv_size_is_none(size):
+        logit_p = pt.broadcast_to(logit_p, pt.concatenate([size, logit_p.shape[-n_lags:]]))
+    flat = pt.argmax(pt.join_dims(logit_p, start_axis=-n_lags), axis=-1)
+    return pt.stack(_unravel_states(flat, k, n_lags), axis=-1)
+
+
+@_logprob.register(JointCategoricalRV)
+def joint_categorical_logp(op, values, size, logit_p, state_rng, **kwargs):
+    value = values[0]
+    n_lags = op.n_lags
+    k = logit_p.shape[-1]
+    flat = sum(value[..., i] * k ** (n_lags - 1 - i) for i in range(n_lags))
+    return logp(pm.Categorical.dist(logit_p=pt.join_dims(logit_p, start_axis=-n_lags)), flat)

--- a/pymc_extras/distributions/timeseries.py
+++ b/pymc_extras/distributions/timeseries.py
@@ -28,6 +28,7 @@ from pymc.util import check_dist_not_registered, get_value_vars_from_user_vars
 from pytensor.compile.mode import Mode
 from pytensor.graph.basic import Node
 from pytensor.tensor import TensorVariable
+from pytensor.tensor.basic import ix_
 from pytensor.tensor.random.op import RandomVariable
 
 
@@ -56,6 +57,20 @@ def _make_outputs_info(n_lags: int, init_dist: Distribution) -> list[Distributio
         return [init_dist[0]]
 
 
+def _index_transition_probs(transition_probs: TensorVariable, states) -> TensorVariable:
+    """Select the next-state distribution ``p(x_t | states)`` for each batch element.
+
+    ``transition_probs`` is ``(*batch, k, ..., k)``: ``len(states)`` "from" state axes then the
+    "to" axis (a single per-step slice, so no time axis here). ``states`` are the previous states,
+    each ``(*batch,)``. The batch axes are indexed with an open mesh of aranges (:func:`ix_`) so
+    they pair element-wise with ``states``; the trailing "to" axis is kept, giving ``(*batch, k)``.
+    """
+    batch_ndim = transition_probs.ndim - (len(states) + 1)
+    tp_shape = tuple(transition_probs.shape)
+    batch_index = ix_(*(pt.arange(tp_shape[axis]) for axis in range(batch_ndim)))
+    return transition_probs[(*batch_index, *states)]
+
+
 class DiscreteMarkovChainRV(SymbolicRandomVariable):
     n_lags: int
     time_varying_P: bool
@@ -65,6 +80,9 @@ class DiscreteMarkovChainRV(SymbolicRandomVariable):
     def __init__(self, *args, n_lags, time_varying_P=False, **kwargs):
         self.n_lags = n_lags
         self.time_varying_P = time_varying_P
+        # Core (non-batch) axes of P: the n_lags + 1 state axes, plus a leading time axis
+        # when the chain is time-varying.
+        self.P_core_ndim = (n_lags + 1) + time_varying_P
         super().__init__(*args, **kwargs)
 
     def update(self, node: Node):
@@ -79,7 +97,10 @@ class DiscreteMarkovChain(Distribution):
 
         \{x_t\}_{t=0}^T
 
-    Where transition probability :math:`P(x_t | x_{t-1})` depends only on the state of the system at :math:`x_{t-1}`.
+    Where transition probability :math:`P(x_t | x_{t-1})` depends only on the state of the system at
+    :math:`x_{t-1}`. With ``n_lags > 1`` the chain is of higher order, and the transition
+    probability :math:`P(x_t | x_{t-1}, \dots, x_{t-n\_lags})` depends on the last ``n_lags``
+    states.
 
     Parameters
     ----------
@@ -95,6 +116,10 @@ class DiscreteMarkovChain(Distribution):
         used to go from state ``t`` to state ``t + 1``, so the time axis must have length
         ``steps`` (one transition matrix per step). When ``steps`` is not given explicitly,
         it is inferred from this axis.
+
+        With ``n_lags > 1`` the two state axes become ``n_lags + 1`` axes, all of length ``k``:
+        ``P[..., x_{t-n_lags}, ..., x_{t-1}, x_t]``, so the shape is ``(*batch, k, ..., k)`` (or
+        ``(*batch, steps, k, ..., k)`` when time-varying).
     P_logit: tensor, optional
         Matrix of transition logits. Converted to probabilities via Softmax activation.
         One of P or P_logits must be provided.
@@ -106,10 +131,15 @@ class DiscreteMarkovChain(Distribution):
         If not, it will be automatically resized.
 
         .. warning:: init_dist will be cloned, rendering it independent of the one passed as input.
+    n_lags : int, default 1
+        Order of the chain: how many previous states the transition probability conditions on.
+        ``P`` gains one state axis per extra lag (see ``P`` above) and the chain starts from
+        ``n_lags`` initial states drawn from ``init_dist``, so it has ``n_lags + steps`` states in
+        total.
     time_varying_P : bool, default False
         If ``True``, ``P`` is interpreted as a sequence of transition matrices, one per step,
         with shape ``(*batch, steps, k, k)`` (see ``P`` above). This disambiguates the time
-        axis from a leading batch dimension. Only supported for ``n_lags=1``.
+        axis from a leading batch dimension.
 
     Notes
     -----
@@ -167,6 +197,27 @@ class DiscreteMarkovChain(Distribution):
                 shape=(100,),
             )
 
+    Use a second-order chain, where each state depends on the previous two. ``P`` gains one
+    state axis per lag, so it is ``(2, 2, 2)`` here: ``P[x_{t-2}, x_{t-1}, x_t]``. The chain starts
+    from ``n_lags=2`` initial states, so ``shape=(100,)`` means 98 transitions.
+
+    .. code-block:: python
+
+        import numpy as np
+        import pymc as pm
+        import pymc_extras as pmx
+
+        with pm.Model() as second_order_chain:
+            P = pm.Dirichlet("P", a=np.ones((2, 2, 2)))
+            init_dist = pm.Categorical.dist(p=np.full(2, 0.5))
+            markov_chain = pmx.DiscreteMarkovChain(
+                "markov_chain",
+                P=P,
+                init_dist=init_dist,
+                n_lags=2,
+                shape=(100,),
+            )
+
     """
 
     rv_type = DiscreteMarkovChainRV
@@ -201,10 +252,6 @@ class DiscreteMarkovChain(Distribution):
             raise ValueError("Must specify P or logit_P parameter")
         if P is not None and logit_P is not None:
             raise ValueError("Must specify only one of either P or logit_P parameter")
-        # time_varying_P disambiguates a time axis in P (*batch, time, k, k) from a leading
-        # batch dimension; without it that axis would be treated as batch. See pymc-extras #392.
-        if time_varying_P and n_lags != 1:
-            raise NotImplementedError("time_varying_P is only supported for n_lags=1")
 
         if logit_P is not None:
             P = pm.math.softmax(logit_P, axis=-1)
@@ -212,11 +259,14 @@ class DiscreteMarkovChain(Distribution):
         P = pt.as_tensor_variable(P)
 
         if time_varying_P:
-            # P's transition axis (*batch, time, k, k) is itself an encoding of `steps`.
-            # Reconcile it through the same helper (zero offset — the time axis *is* the
-            # transition count): infers steps when only P is given, asserts when both are.
+            # time_varying_P disambiguates a time axis in P (*batch, time, k, ..., k) from a
+            # leading batch dimension; without it that axis would be treated as batch. See
+            # pymc-extras #392. The time axis sits just left of the (n_lags + 1) state axes and
+            # is itself an encoding of `steps`. Reconcile it through the same helper (zero offset,
+            # the time axis *is* the transition count): infers steps when only P is given, asserts
+            # when both are.
             steps = get_support_shape_1d(
-                support_shape=steps, shape=(P.shape[-3],), support_shape_offset=0
+                support_shape=steps, shape=(P.shape[-(n_lags + 2)],), support_shape_offset=0
             )
 
         if steps is None:
@@ -254,9 +304,6 @@ class DiscreteMarkovChain(Distribution):
 
     @classmethod
     def rv_op(cls, P, steps, init_dist, n_lags, size=None, time_varying_P=False):
-        if time_varying_P and n_lags != 1:
-            raise NotImplementedError("time_varying_P is only supported for n_lags=1")
-
         # Trailing core axes of P: the (n_lags + 1) state axes, plus a leading time axis
         # when P is time-varying. Everything to the left of those is batch.
         n_core_P = (n_lags + 1) + (1 if time_varying_P else 0)
@@ -275,22 +322,23 @@ class DiscreteMarkovChain(Distribution):
         state_rng = pytensor.shared(np.random.default_rng())
 
         if time_varying_P:
-            # Move the time core axis (-3 for n_lags=1) to the front so scan iterates a
-            # distinct transition matrix per step. With a sequence, scan passes the sequence
-            # element first, then the recurring outputs (rng, state).
+            # Move the time core axis (at -(n_lags + 2), just left of the n_lags + 1 state axes)
+            # to the front so scan iterates a distinct transition matrix per step. With a
+            # sequence, scan passes the sequence element first, then the recurring outputs
+            # (rng, state).
             def transition(transition_probs, old_rng, *states):
-                p = transition_probs[tuple(states)]
+                p = _index_transition_probs(transition_probs, states)
                 next_rng, next_state = pm.Categorical.dist(p=p, rng=old_rng, return_next_rng=True)
                 return next_rng, next_state
 
             # Pass n_steps too: steps is reconciled with P's time axis at construction, so
             # this keeps steps live in the inner graph (its consistency Assert survives).
-            scan_kwargs = dict(sequences=[pt.moveaxis(P_, -3, 0)], n_steps=steps_)
+            scan_kwargs = dict(sequences=[pt.moveaxis(P_, -(n_lags + 2), 0)], n_steps=steps_)
         else:
 
             def transition(*args):
                 old_rng, *states, transition_probs = args
-                p = transition_probs[tuple(states)]
+                p = _index_transition_probs(transition_probs, states)
                 next_rng, next_state = pm.Categorical.dist(p=p, rng=old_rng, return_next_rng=True)
                 return next_rng, next_state
 
@@ -308,10 +356,17 @@ class DiscreteMarkovChain(Distribution):
             **scan_kwargs,
         )
 
-        discrete_mc_ = pt.concatenate([init_dist_, pt.moveaxis(markov_chain, 0, -1)], axis=-1)
+        # The scan's full buffer already carries the n_lags initial taps in front of the sampled
+        # states (scan itself returns buffer[n_lags:]); grab it instead of concatenating init_dist_
+        # back on. The buffer is time-first, so move time to the last axis.
+        discrete_mc_ = pt.moveaxis(markov_chain.owner.inputs[0], 0, -1)
 
-        # Time-varying P carries an extra leading core axis (the per-step matrices).
-        P_signature = "(u,p,p)" if time_varying_P else "(p,p)"
+        # P is the full transition tensor P[s_{t-n}, ..., s_{t-1}, s_t] with n_lags + 1 state axes,
+        # plus a leading time axis (u) when time-varying. Repeating "p" enforces all state axes are
+        # k (the squareness constraint). The output chain (t) is n_lags longer than the u
+        # transitions.
+        core_states = ",".join(["p"] * (n_lags + 1))
+        P_signature = f"(u,{core_states})" if time_varying_P else f"({core_states})"
         discrete_mc_op = DiscreteMarkovChainRV(
             inputs=[P_, steps_, init_dist_, state_rng],
             outputs=[state_next_rng, discrete_mc_],
@@ -346,28 +401,29 @@ def discrete_mc_moment(op, rv, P, steps, init_dist, state_rng):
     if op.time_varying_P:
 
         def greedy_transition(transition_probs, *states):
-            p = transition_probs[tuple(states)]
-            return pt.argmax(p)
+            p = _index_transition_probs(transition_probs, states)
+            return pt.argmax(p, axis=-1)
 
-        scan_kwargs = dict(sequences=[pt.moveaxis(P, -3, 0)], n_steps=steps)
+        scan_kwargs = dict(sequences=[pt.moveaxis(P, -(n_lags + 2), 0)], n_steps=steps)
     else:
 
         def greedy_transition(*args):
             *states, transition_probs = args
-            p = transition_probs[tuple(states)]
-            return pt.argmax(p)
+            p = _index_transition_probs(transition_probs, states)
+            return pt.argmax(p, axis=-1)
 
         scan_kwargs = dict(non_sequences=[P], n_steps=steps)
 
     chain_moment = pytensor.scan(
         greedy_transition,
-        outputs_info=_make_outputs_info(n_lags, init_dist),
+        # Seed with the moment of the initial states (lags first for scan).
+        outputs_info=_make_outputs_info(n_lags, pt.moveaxis(init_dist_moment, -1, 0)),
         strict=True,
         return_updates=False,
         **scan_kwargs,
     )
-    chain_moment = pt.concatenate([init_dist_moment, chain_moment])
-    return chain_moment
+    # Full scan buffer (n_lags initial states + steps greedy states), time-first -> move time last.
+    return pt.moveaxis(chain_moment.owner.inputs[0], 0, -1)
 
 
 @_logprob.register(DiscreteMarkovChainRV)
@@ -375,18 +431,25 @@ def discrete_mc_logp(op, values, P, steps, init_dist, state_rng, **kwargs):
     value = values[0]
     n_lags = op.n_lags
 
+    # The n_lags + 1 state indices per transition: x_{t-n_lags}, ..., x_{t-1}, x_t.
     indices = [value[..., i : -(n_lags - i) if n_lags != i else None] for i in range(n_lags + 1)]
 
     mc_logprob = logp(init_dist, value[..., :n_lags]).sum(axis=-1)
-    if op.time_varying_P:
-        # P is (*batch, time, k, k); steps is baked into P's time axis at construction, so
-        # each transition just indexes its own matrix by the (from, to) states. n_lags == 1,
-        # so indexes == [from, to].
-        time_idx = pt.arange(P.shape[-3])
-        from_states, to_states = indices
-        mc_logprob += pt.log(P[..., time_idx, from_states, to_states]).sum(axis=-1)
-    else:
-        mc_logprob += pt.log(P[tuple(indices)]).sum(axis=-1)
+
+    # Gather the transition log-probabilities by advanced-indexing P's trailing state axes with
+    # `indices`. P's leading batch axes (and the time axis, when time-varying) are indexed with
+    # aranges so they pair element-wise with the value; leaving them to broadcast would instead
+    # produce a spurious extra axis (P's batch crossed with the value's batch).
+    log_P = pt.log(P)
+    p_shape = tuple(P.shape)
+    batch_ndim = log_P.ndim - op.P_core_ndim
+
+    # Index the transition tensor per batch element: an open mesh of aranges over the batch axes
+    # (each with a trailing axis to line up with the transition axis in `indices`), then the time
+    # axis 1:1 with the transitions when time-varying, then the n_lags + 1 state coordinates.
+    batch_index = [b[..., None] for b in ix_(*(pt.arange(p_shape[a]) for a in range(batch_ndim)))]
+    time_index = [pt.arange(p_shape[batch_ndim])] if op.time_varying_P else []
+    mc_logprob += log_P[(*batch_index, *time_index, *indices)].sum(axis=-1)
 
     # We cannot leave any RV in the logp graph, even if just for an assert
     # If this is a core_dim, it should be part of the signature
@@ -394,7 +457,7 @@ def discrete_mc_logp(op, values, P, steps, init_dist, state_rng, **kwargs):
 
     return check_parameters(
         mc_logprob,
-        pt.all(pt.eq(P.shape[-(n_lags + 1) :], P.shape[-1])),
+        pt.all(pt.eq(pt.stack(p_shape[-(n_lags + 1) :]), p_shape[-1])),
         pt.all(pt.allclose(P.sum(axis=-1), 1.0)),
         pt.eq(init_dist_core_dim, n_lags),
         msg="Last (n_lags + 1) dimensions of P must be square, "

--- a/pymc_extras/distributions/timeseries.py
+++ b/pymc_extras/distributions/timeseries.py
@@ -126,9 +126,11 @@ class DiscreteMarkovChain(Distribution):
     steps: tensor, optional
         Length of the markov chain. Only needed if state is not provided.
     init_dist : unnamed distribution, optional
-        Vector distribution for initial values. Unnamed refers to distributions
-        created with the ``.dist()`` API. Distribution should have shape n_states.
-        If not, it will be automatically resized.
+        Distribution over the ``n_lags`` initial states. Unnamed refers to distributions
+        created with the ``.dist()`` API. A scalar-support distribution (e.g. ``Categorical``)
+        is broadcast IID across the initial states; a vector-support distribution (e.g.
+        :class:`JointCategorical`) provides their joint distribution and must have support
+        length ``n_lags``.
 
         .. warning:: init_dist will be cloned, rendering it independent of the one passed as input.
     n_lags : int, default 1
@@ -314,7 +316,13 @@ class DiscreteMarkovChain(Distribution):
                 P[tuple([...] + [0] * n_core_P)], pt.atleast_1d(init_dist)[..., 0]
             )
 
-        init_dist = change_dist_size(init_dist, (*batch_size, n_lags))
+        # A scalar init_dist is broadcast IID across the n_lags initial states; a vector
+        # (multivariate) init_dist instead provides them jointly through its own support
+        # dimension, which must cover n_lags. Mirrors pymc's AR.
+        if init_dist.owner.op.ndim_supp == 0:
+            init_dist = change_dist_size(init_dist, (*batch_size, n_lags))
+        else:
+            init_dist = change_dist_size(init_dist, batch_size)
         init_dist_ = init_dist.type()
         P_ = P.type()
         steps_ = steps.type()
@@ -434,7 +442,15 @@ def discrete_mc_logp(op, values, P, steps, init_dist, state_rng, **kwargs):
     # The n_lags + 1 state indices per transition: x_{t-n_lags}, ..., x_{t-1}, x_t.
     indices = [value[..., i : -(n_lags - i) if n_lags != i else None] for i in range(n_lags + 1)]
 
-    mc_logprob = logp(init_dist, value[..., :n_lags]).sum(axis=-1)
+    init_logp = logp(init_dist, value[..., :n_lags])
+    # A scalar init_dist scores each of the n_lags initial states independently (per-position
+    # logp, with the lag axis to sum over); a vector (multivariate) init_dist already returns
+    # their joint logp. Mirrors pymc's AR. Decided by the logp dimensionality rather than the
+    # op's ndim_supp, so inits rewritten into measurable graphs (e.g. an inlined
+    # JointCategorical lookup) are handled too.
+    if init_logp.type.ndim == value.type.ndim:
+        init_logp = init_logp.sum(axis=-1)
+    mc_logprob = init_logp
 
     # Gather the transition log-probabilities by advanced-indexing P's trailing state axes with
     # `indices`. P's leading batch axes (and the time axis, when time-varying) are indexed with

--- a/pymc_extras/model/marginal/conditional.py
+++ b/pymc_extras/model/marginal/conditional.py
@@ -10,6 +10,7 @@ from pymc.model.fgraph import (
     model_free_rv,
     model_from_fgraph,
 )
+from pymc.pytensorf import resolve_backend_compile_kwargs
 from pymc.sampling.forward import sample_posterior_predictive
 from pymc.util import RandomState
 from pytensor.graph import FunctionGraph, Variable
@@ -284,6 +285,8 @@ def recover(
     var_names: Sequence[str] | None = None,
     extend_inferencedata: bool = True,
     random_seed: RandomState = None,
+    backend: str | None = None,
+    compile_kwargs: dict | None = None,
 ):
     """Sample marginalized variables from their conditional posterior.
 
@@ -303,6 +306,12 @@ def recover(
         Whether to extend the original DataTree or return a new Dataset.
     random_seed : int, array-like of int or SeedSequence, optional
         Seed for generating samples.
+    backend : str, optional
+        Which computational backend to use. Recommended to be one of "numba", "c", and "jax".
+        Cannot be combined with ``compile_kwargs["mode"]``.
+    compile_kwargs : dict, optional
+        Extra arguments passed to the sampling function's compilation, e.g.
+        ``dict(mode=...)`` to select a backend.
 
     Returns
     -------
@@ -348,6 +357,7 @@ def recover(
 
     freeze = [rv.name for rv in cond_model.free_RVs if rv.name not in var_names_to_recover]
 
+    compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
     sample_result = sample_posterior_predictive(
         idata,
         model=cond_model,
@@ -355,6 +365,7 @@ def recover(
         freeze_vars=freeze,
         random_seed=random_seed,
         progressbar=False,
+        compile_kwargs=compile_kwargs,
     )
     pp = sample_result.posterior_predictive
     pp_ds = pp.dataset if isinstance(pp, DataTree) else pp

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -74,40 +74,48 @@ def _hmm_emission_logp(op, chain, dependent_rvs, values):
 
 
 def _hmm_log_init_and_transition(chain, chain_shape, batch_chain_value):
-    """Log initial-state probabilities (per state) and the log transition matrix.
+    """Joint log-prob of the initial states and the log transition matrix.
 
     Returns
     -------
-    batch_logp_init_dist : TensorVariable
-        Shape ``(n_states, *chain_batch)``.
+    log_init_joint : TensorVariable
+        Joint log-prob of the ``n_lags`` initial states, one leading axis per lag,
+        ``((n_states,) * n_lags, *chain_batch)``.
     log_P : TensorVariable
-        Log transition matrix. Homogeneous chains place the two core (from, to)
-        axes at the front, ``(n_states, n_states, *batch)``. Time-varying chains
-        keep one matrix per transition, ``(n_transitions, n_states, n_states)`` =
-        ``(time, from, to)`` (unbatched), iterated as a scan sequence downstream.
+        Log transition matrix. Homogeneous chains place the ``n_lags + 1`` core state
+        axes at the front, ``((n_states,) * (n_lags + 1), *batch)``. Time-varying chains
+        keep one matrix per transition, ``(time, (n_states,) * (n_lags + 1), *batch)``,
+        iterated as a scan sequence downstream.
     """
     P, n_steps_, init_dist_, rng = chain.owner.inputs
-    time_varying = chain.owner.op.time_varying_P
+    op = chain.owner.op
+    n_lags = op.n_lags
+    time_varying = op.time_varying_P
 
-    # To compute the prior probabilities of each state, we evaluate the logp of the domain (all
-    # possible states) under the initial distribution. This is robust to everything the user can
-    # throw at it.
     init_dist_value = init_dist_.type()
     logp_init_dist = logp(init_dist_, init_dist_value)
-    # Squeeze core dimension for n_lags=1 (only supported case)
-    batch_logp_init_dist = vectorize_graph(
-        logp_init_dist, {init_dist_value: batch_chain_value[..., :1]}
-    ).squeeze(-1)
+    # The n_lags initial states are independent (IID scalar init). Evaluate the domain at every
+    # lag position and outer-sum the per-position terms, one leading state axis per lag.
+    logp_init_per_position = vectorize_graph(
+        logp_init_dist, {init_dist_value: batch_chain_value[..., :n_lags]}
+    )  # (n_states, *batch, n_lags)
+    log_init_joint = 0
+    for j in range(n_lags):
+        g_j = logp_init_per_position[..., j]  # (n_states, *batch) over state j
+        insert = tuple(i for i in range(n_lags) if i != j)
+        log_init_joint = log_init_joint + (pt.expand_dims(g_j, insert) if insert else g_j)
 
-    if time_varying:
-        # P is already (time, from, to); each transition uses its own matrix.
-        log_P = pt.log(P)
-    else:
-        # Add implicit dimensions of P, and place core (from, to) dimensions at the front
-        P = pt.atleast_Nd(P, n=len(chain_shape) + 1)
-        P = pt.moveaxis(P, (-2, -1), (0, 1))
-        log_P = pt.log(P)
-    return batch_logp_init_dist, log_P
+    # Bring P's n_lags + 1 state axes (and the time axis, when time-varying) to the front so the
+    # message pass indexes them directly; batch dims trail. Homogeneous P becomes
+    # (n_states,) * (n_lags + 1) + batch; time-varying becomes (time, (n_states,) * (n_lags + 1),
+    # batch), iterated as a scan sequence downstream.
+    batch_ndim = len(chain_shape) - 1
+    core_ndim = op.P_core_ndim
+    P = pt.atleast_Nd(P, n=core_ndim + batch_ndim)
+    state_axes = list(range(-(n_lags + 1), 0))
+    source = [-(n_lags + 2), *state_axes] if time_varying else state_axes
+    log_P = pt.log(pt.moveaxis(P, source, list(range(core_ndim))))
+    return log_init_joint, log_P
 
 
 def _scan_messages(core, *, init, emissions_seq, log_P, time_varying):
@@ -150,21 +158,37 @@ def _scan_messages(core, *, init, emissions_seq, log_P, time_varying):
     return seq.owner.inputs[0]
 
 
-def _hmm_forward_log_alphas(batch_logp_emissions, batch_logp_init_dist, log_P, time_varying=False):
-    """Forward filter. Returns the full ``log_alpha`` trace, shape ``(T, n_states, *batch)``.
+def _hmm_forward_log_alphas(
+    batch_logp_emissions, log_init_joint, log_P, n_lags, time_varying=False
+):
+    """Forward filter. Returns the full ``log_alpha`` trace, time first.
 
-    ``alpha_t(s) = p(y_{1:t}, s_t=s)`` computed entirely in logs:
-    ``alpha_t = p(y_t | s_t) * sum_{s_{t-1}}(p(s_t | s_{t-1}) * alpha_{t-1})``.
-    The trace is time first and includes ``alpha_0`` as the initial state.
+    ``alpha_t`` is a message over the last ``n_lags`` states,
+    ``p(y_{0:t}, s_{t-n_lags+1}, ..., s_t)``, held with the ``n_lags`` state axes leading and batch
+    trailing. The seed ``alpha_{n_lags-1}`` is the joint over the first ``n_lags`` initial states
+    with their emissions; each transition then sums out the oldest state ``s_{t-n_lags}`` and
+    folds in the newest emission ``p(y_t | s_t)``. For ``n_lags == 1`` this is the standard filter.
     """
-    log_alpha_init = batch_logp_init_dist + batch_logp_emissions[..., 0]
+    # Seed: joint init logp over the n_lags leading state axes, plus each position's emission
+    # placed on its own axis.
+    log_alpha_init = log_init_joint
+    for j in range(n_lags):
+        e_j = batch_logp_emissions[..., j]  # (n_states, *batch) over state j
+        insert = tuple(i for i in range(n_lags) if i != j)
+        log_alpha_init = log_alpha_init + (pt.expand_dims(e_j, insert) if insert else e_j)
 
-    # Scan needs the time dimension first, and we already consumed the 1st logp computing the initial value
-    emissions_seq = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)
+    # Transitions consume the emissions for steps n_lags .. T-1 (the seed used 0 .. n_lags-1).
+    emissions_seq = pt.moveaxis(batch_logp_emissions[..., n_lags:], -1, 0)
 
     def step_alpha(logp_emission, log_P_t, log_alpha):
-        step_log_prob = pt.logsumexp(log_alpha[:, None, ...] + log_P_t, axis=0)
-        return logp_emission + step_log_prob
+        # log_alpha is (n_states,) * n_lags + batch over (s_{t-n_lags}, ..., s_{t-1}); add the s_t
+        # axis, weight by the transition tensor, and sum out the oldest state s_{t-n_lags}.
+        step_log_prob = pt.logsumexp(pt.expand_dims(log_alpha, n_lags) + log_P_t, axis=0)
+        # Emission depends on s_t only -> broadcast onto the newest (last) state axis.
+        emission = (
+            pt.expand_dims(logp_emission, tuple(range(n_lags - 1))) if n_lags > 1 else logp_emission
+        )
+        return emission + step_log_prob
 
     return _scan_messages(
         step_alpha,
@@ -206,6 +230,20 @@ def _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying=False):
 
 @_logprob.register(MarginalDiscreteMarkovChainRV)
 def marginal_discrete_markov_chain_logp(op, values, *inputs, **kwargs):
+    """Marginal ``log p(emissions | inputs)`` of a marginalized DiscreteMarkovChain.
+
+    Standard forward algorithm, generalized to ``n_lags`` and run in log space:
+
+    1. Emissions. The conditional logp of the dependent RVs is vectorized over the chain domain,
+       giving ``log p(y_t | s_t)`` for every state at every step.
+    2. Forward filter. ``alpha_t`` is the joint ``log p(y_{0:t}, s_{t-n_lags+1}, ..., s_t)``, seeded
+       from the init distribution and advanced one step at a time by a scan.
+    3. Termination. The last message is logsumexp-ed over its ``n_lags`` state axes.
+
+    A chain with ``n_lags > 1`` is *not* rewritten into an equivalent first-order chain over
+    ``n_states ** n_lags`` compound states. The message keeps one axis per lag and the transition
+    tensor is indexed directly, which avoids materializing the compound transition matrix.
+    """
     all_outputs = inline_ofg_outputs(op, inputs)
     chain_rv = all_outputs[0]
     dependent_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
@@ -216,16 +254,14 @@ def marginal_discrete_markov_chain_logp(op, values, *inputs, **kwargs):
     )
 
     # Step 2: Run the forward algorithm over the transition probabilities
-    batch_logp_init_dist, log_P = _hmm_log_init_and_transition(
-        chain_rv, chain_shape, batch_chain_value
-    )
-    time_varying = chain_rv.owner.op.time_varying_P
+    log_init_joint, log_P = _hmm_log_init_and_transition(chain_rv, chain_shape, batch_chain_value)
+    chain_op = chain_rv.owner.op
     log_alphas = _hmm_forward_log_alphas(
-        batch_logp_emissions, batch_logp_init_dist, log_P, time_varying
+        batch_logp_emissions, log_init_joint, log_P, chain_op.n_lags, chain_op.time_varying_P
     )
 
-    # Final logp is just the sum of the last scan state
-    joint_logp = pt.logsumexp(log_alphas[-1], axis=0)
+    # Final logp sums the last message over all n_lags remaining (leading) state axes.
+    joint_logp = pt.logsumexp(log_alphas[-1], axis=tuple(range(chain_op.n_lags)))
 
     # Align logp with non-collapsed batch dimensions of first RV
     remaining_dims_first_emission = list(op.dims_connections[0])
@@ -262,7 +298,12 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     inner_inputs = inner_graph.inputs
     chain = inner_graph.outputs[0]
     dependents = list(inner_graph.outputs[1 : 1 + op.n_dependent_rvs])
+    chain_op = chain.owner.op
 
+    if chain_op.n_lags > 1:
+        raise NotImplementedError(
+            "conditional()/recover() for DiscreteMarkovChain with n_lags > 1 is not yet supported."
+        )
     if chain.type.ndim > 1:
         raise NotImplementedError(
             "Recovering a batched DiscreteMarkovChain (more than one chain) is not yet supported."
@@ -273,12 +314,10 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     batch_logp_emissions, batch_chain_value, chain_shape = _hmm_emission_logp(
         op, chain, dependents, dep_dummies
     )
-    batch_logp_init_dist, log_P = _hmm_log_init_and_transition(
-        chain, chain_shape, batch_chain_value
-    )
-    time_varying = chain.owner.op.time_varying_P
+    log_init_joint, log_P = _hmm_log_init_and_transition(chain, chain_shape, batch_chain_value)
+    time_varying = chain_op.time_varying_P
     log_alphas = _hmm_forward_log_alphas(
-        batch_logp_emissions, batch_logp_init_dist, log_P, time_varying
+        batch_logp_emissions, log_init_joint, log_P, chain_op.n_lags, time_varying
     )  # (T, k)
     log_betas = _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying)  # (T, k)
 
@@ -314,24 +353,6 @@ def discrete_markov_chain_marginal(fgraph, node):
     marginalized_rv_op = marginalized_rv.owner.op
     if not isinstance(marginalized_rv_op, DiscreteMarkovChain):
         return None
-
-    if marginalized_rv_op.n_lags > 1:
-        raise NotImplementedError(
-            "Marginalization for DiscreteMarkovChain with n_lags > 1 is not supported"
-        )
-    P_ndim = marginalized_rv.owner.inputs[0].type.ndim
-    # A time-varying chain has an extra (time, k, k) core axis, so ndim == 3 is expected
-    # there; the flag disambiguates it from a genuine batch dimension.
-    if marginalized_rv_op.time_varying_P:
-        if P_ndim > 3:
-            raise NotImplementedError(
-                "Marginalization for batched time-varying DiscreteMarkovChain is not supported"
-            )
-    elif P_ndim > 2:
-        raise NotImplementedError(
-            "Marginalization for DiscreteMarkovChain with non-matrix transition probability "
-            "is not supported"
-        )
 
     return build_enumerable_marginal_rv(node, inputs, outputs, MarginalDiscreteMarkovChainRV)
 

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -9,7 +9,8 @@ from pytensor.graph.replace import clone_replace, graph_replace
 from pytensor.scan import scan
 from pytensor.tensor.special import log_softmax, softmax
 
-from pymc_extras.distributions import DiscreteMarkovChain
+from pymc_extras.distributions import DiscreteMarkovChain, JointCategorical
+from pymc_extras.distributions.multivariate.joint_categorical import _unravel_states
 from pymc_extras.model.marginal.distributions.core import (
     inline_ofg_outputs,
     marginalized_conditional,
@@ -91,25 +92,44 @@ def _hmm_log_init_and_transition(chain, chain_shape, batch_chain_value):
     op = chain.owner.op
     n_lags = op.n_lags
     time_varying = op.time_varying_P
+    batch_shape = tuple(chain_shape[:-1])
+    batch_ndim = len(batch_shape)
 
     init_dist_value = init_dist_.type()
     logp_init_dist = logp(init_dist_, init_dist_value)
-    # The n_lags initial states are independent (IID scalar init). Evaluate the domain at every
-    # lag position and outer-sum the per-position terms, one leading state axis per lag.
-    logp_init_per_position = vectorize_graph(
-        logp_init_dist, {init_dist_value: batch_chain_value[..., :n_lags]}
-    )  # (n_states, *batch, n_lags)
-    log_init_joint = 0
-    for j in range(n_lags):
-        g_j = logp_init_per_position[..., j]  # (n_states, *batch) over state j
-        insert = tuple(i for i in range(n_lags) if i != j)
-        log_init_joint = log_init_joint + (pt.expand_dims(g_j, insert) if insert else g_j)
+    if init_dist_.owner.op.ndim_supp == 0:
+        # Scalar init_dist: the n_lags initial states are independent. Evaluate the domain at
+        # every lag position and outer-sum the per-position terms, one leading state axis per lag.
+        logp_init_per_position = vectorize_graph(
+            logp_init_dist, {init_dist_value: batch_chain_value[..., :n_lags]}
+        )  # (n_states, *batch, n_lags)
+        log_init_joint = 0
+        for j in range(n_lags):
+            g_j = logp_init_per_position[..., j]  # (n_states, *batch) over state j
+            insert = tuple(i for i in range(n_lags) if i != j)
+            log_init_joint = log_init_joint + (pt.expand_dims(g_j, insert) if insert else g_j)
+    else:
+        # Vector init_dist (e.g. the JointCategorical of a recovered chain): an arbitrary joint
+        # over the n_lags initial states. Evaluate its logp on all n_states ** n_lags
+        # configurations and unflatten the leading axis into one state axis per lag.
+        n_states = P.shape[-1]
+        combos = pt.stack(
+            _unravel_states(pt.arange(n_states**n_lags), n_states, n_lags), axis=-1
+        )  # (n_states ** n_lags, n_lags)
+        if batch_ndim:
+            combos = pt.broadcast_to(
+                combos[(slice(None), *(None,) * batch_ndim)],
+                (n_states**n_lags, *batch_shape, n_lags),
+            )
+        logp_init_flat = vectorize_graph(
+            logp_init_dist, {init_dist_value: combos}
+        )  # (n_states ** n_lags, *batch)
+        log_init_joint = logp_init_flat.reshape((*(n_states,) * n_lags, *batch_shape))
 
     # Bring P's n_lags + 1 state axes (and the time axis, when time-varying) to the front so the
     # message pass indexes them directly; batch dims trail. Homogeneous P becomes
     # (n_states,) * (n_lags + 1) + batch; time-varying becomes (time, (n_states,) * (n_lags + 1),
     # batch), iterated as a scan sequence downstream.
-    batch_ndim = len(chain_shape) - 1
     core_ndim = op.P_core_ndim
     P = pt.atleast_Nd(P, n=core_ndim + batch_ndim)
     state_axes = list(range(-(n_lags + 1), 0))
@@ -199,29 +219,36 @@ def _hmm_forward_log_alphas(
     )
 
 
-def _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying=False):
-    """Backward messages ``log β_t(i) = log p(y_{t+1:} | s_t=i)``, shape ``(n_steps, n_states)``.
+def _hmm_backward_log_betas(batch_logp_emissions, log_P, n_lags, time_varying=False):
+    """Backward messages over the last ``n_lags`` states, batch trailing.
 
-    ``β_{T-1} = 1`` (0 in logs); ``log β_t(i) = logsumexp_j[log A_{t+1}(i,j) + log b_{t+1}(j) +
-    log β_{t+1}(j)]``. ``log_P`` is ``(n_states, n_states)`` for a homogeneous chain, or one
-    matrix per transition ``(n_transitions, n_states, n_states)`` when ``time_varying`` (the
-    transition into step ``t+1`` uses ``A_{t+1} = log_P[t]``). Unbatched chain.
+    ``β_t(s_{t-n_lags+1}, ..., s_t) = log p(y_{t+1:} | those states)``; ``β_{T-1} = 0``. Each step
+    sums out the newest future state ``s_{t+1}``, weighting by the transition into it and its
+    emission and ``β_{t+1}``. Returns the trace ``β_{n_lags-1}, ..., β_{T-1}`` (chronological).
+    For ``n_lags == 1`` this is the standard backward filter over a single state.
     """
-    n_states = batch_logp_emissions.shape[0]
-    log_beta_last = pt.zeros((n_states,))
-    # Emissions for the t+1 step, iterated backwards: b_{T-1}, ..., b_1
-    rev_next_emissions = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)[::-1]
+    emissions_shape = tuple(batch_logp_emissions.shape)
+    n_states, batch_shape = emissions_shape[0], emissions_shape[1:-1]
+    log_beta_last = pt.zeros((*(n_states,) * n_lags, *batch_shape))
+    # Emissions for the t+1 step, iterated backwards: b_{T-1}, ..., b_{n_lags}
+    rev_next_emissions = pt.moveaxis(batch_logp_emissions[..., n_lags:], -1, 0)[::-1]
 
-    def step_beta(logp_emission_next, log_P_t, log_beta_next):
-        v = logp_emission_next + log_beta_next  # (n_states,) over j
-        return pt.logsumexp(log_P_t + v[None, :], axis=1)  # (n_states,) over i
+    def step_beta(logp_emission_next, log_A_next, log_beta_next):
+        # log_A_next: (k,) * (n_lags + 1) over (s_{t-n_lags+1}, ..., s_t, s_{t+1}); log_beta_next is
+        # over its last n_lags axes; emission over its last axis. Sum out the newest state s_{t+1}.
+        v = (
+            log_A_next
+            + pt.expand_dims(log_beta_next, 0)
+            + pt.expand_dims(logp_emission_next, tuple(range(n_lags)))
+        )
+        return pt.logsumexp(v, axis=n_lags)
 
-    # Full backward trace in scan (reverse) order: β_{T-1}, β_{T-2}, ..., β_0
+    # Inputs are fed in reverse (latest step first), so the scan output is the backward trace in
+    # reverse order too; it is flipped back to chronological order before being returned.
     log_beta_seq = _scan_messages(
         step_beta,
         init=log_beta_last,
         emissions_seq=rev_next_emissions,
-        # A_{t+1} in the same backwards order as the emissions: A_{T-1}, ..., A_1
         log_P=log_P[::-1] if time_varying else log_P,
         time_varying=time_varying,
     )
@@ -280,13 +307,23 @@ def marginal_discrete_markov_chain_logp(op, values, *inputs, **kwargs):
 def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     """Conditional ``p(chain | emissions, inputs)`` of a marginalized DiscreteMarkovChain.
 
-    The posterior over the latent path is itself a (time-inhomogeneous) Markov
-    chain, so we return a :class:`DiscreteMarkovChain` with a time-varying
-    transition matrix — which already has both an exact logp and a sampler, so
-    we get a loggable *and* sampleable conditional without a bespoke Op.
-    Forward-backward yields the smoothed initial distribution ``γ₀ ∝ α₀·β₀`` and
-    the forward-smoothed transitions
-    ``p(s_t | s_{t-1}, y) ∝ P(s_{t-1}, s_t)·b_t(s_t)·β_t(s_t)``.
+    The posterior over the latent path is itself a Markov chain of the same order, but
+    time-inhomogeneous: conditioning on the emissions makes each transition depend on the step. So
+    we return a :class:`DiscreteMarkovChain` with ``time_varying_P=True``, which already has both an
+    exact logp and a sampler, giving a loggable *and* sampleable conditional without a bespoke Op.
+
+    Its two parameters come from a forward-backward pass (the same ``alpha`` filter used by the
+    marginal logp, plus the backward ``beta`` messages):
+
+    - ``init_dist``, the smoothed distribution over the first ``n_lags`` states,
+      ``gamma ∝ alpha_{n_lags-1} · beta_{n_lags-1}``. For a single lag this is a
+      :class:`~pymc.Categorical`; for ``n_lags > 1`` those states are correlated a posteriori, so
+      it is a :class:`~pymc_extras.distributions.JointCategorical` over all ``n_states ** n_lags``
+      configurations of them.
+    - ``P``, the forward-smoothed transitions for each step ``t = n_lags .. T-1``,
+      ``p(s_t | s_{t-n_lags}, ..., s_{t-1}, y) ∝ P(...) · b_t(s_t) · beta_t(...)``, normalized over
+      ``s_t``. As in the logp, ``n_lags > 1`` keeps one axis per lag rather than reducing the chain
+      to a first-order one over compound states.
 
     Mirrors :func:`finite_discrete_marginalized_conditional`: built on the inner
     (nominal) graph with value dummies for the dependents, then the real
@@ -299,15 +336,7 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     chain = inner_graph.outputs[0]
     dependents = list(inner_graph.outputs[1 : 1 + op.n_dependent_rvs])
     chain_op = chain.owner.op
-
-    if chain_op.n_lags > 1:
-        raise NotImplementedError(
-            "conditional()/recover() for DiscreteMarkovChain with n_lags > 1 is not yet supported."
-        )
-    if chain.type.ndim > 1:
-        raise NotImplementedError(
-            "Recovering a batched DiscreteMarkovChain (more than one chain) is not yet supported."
-        )
+    n_lags = chain_op.n_lags
 
     dep_dummies = [dep.type() for dep in dependents]
 
@@ -317,27 +346,52 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     log_init_joint, log_P = _hmm_log_init_and_transition(chain, chain_shape, batch_chain_value)
     time_varying = chain_op.time_varying_P
     log_alphas = _hmm_forward_log_alphas(
-        batch_logp_emissions, log_init_joint, log_P, chain_op.n_lags, time_varying
-    )  # (T, k)
-    log_betas = _hmm_backward_log_betas(batch_logp_emissions, log_P, time_varying)  # (T, k)
+        batch_logp_emissions, log_init_joint, log_P, n_lags, time_varying
+    )  # trace (n_lags,) * n_lags leading state axes
+    log_betas = _hmm_backward_log_betas(batch_logp_emissions, log_P, n_lags, time_varying)
 
-    # Smoothed initial distribution γ₀ ∝ α₀·β₀
-    log_gamma_0 = log_softmax(log_alphas[0] + log_betas[0], axis=-1)  # (k,)
-    init_dist = Categorical.dist(logit_p=log_gamma_0)
+    # Smoothed distribution over the first n_lags states, proportional to
+    # alpha_{n_lags-1} * beta_{n_lags-1}. The message pass keeps state axes leading and batch
+    # trailing; DiscreteMarkovChain expects the opposite, so move the states last. For a single
+    # lag it is a plain Categorical (with an explicit length-1 lag axis so batch dims are read
+    # correctly); for higher order it is the (correlated) joint over the n_lags states, which
+    # JointCategorical takes with one axis per lag, exactly as the message pass produces it.
+    log_gamma_init = log_alphas[0] + log_betas[0]  # ((k,) * n_lags, *batch)
+    log_gamma_init = pt.moveaxis(
+        log_gamma_init, tuple(range(n_lags)), tuple(range(-n_lags, 0))
+    )  # (*batch, (k,) * n_lags)
+    if n_lags == 1:
+        init_dist = Categorical.dist(logit_p=log_softmax(log_gamma_init, axis=-1)[..., None, :])
+    else:
+        state_axes = tuple(range(-n_lags, 0))
+        init_dist = JointCategorical.dist(
+            # Normalize over the joint, i.e. all state axes at once.
+            logit_p=log_gamma_init - pt.logsumexp(log_gamma_init, axis=state_axes, keepdims=True),
+            n_lags=n_lags,
+        )
 
-    # Forward-smoothed time-varying transitions for steps t = 1 .. T-1:
-    #   p(s_t=j | s_{t-1}=i, y) ∝ A_t(i,j) · b_t(j) · β_t(j)   (normalized over j)
-    emissions_jt = pt.moveaxis(batch_logp_emissions[..., 1:], -1, 0)  # (T-1, k) over (t, j)
-    log_terms = emissions_jt + log_betas[1:]  # (T-1, k): b_t(j) + β_t(j)
-    # log_A_t: a single matrix broadcast over steps (homogeneous), or the per-step prior
-    # transition (already (T-1, k, k), where log_P[t] is the transition into state t+1).
-    log_A_t = log_P[None, :, :] if not time_varying else log_P
-    log_P_t = log_A_t + log_terms[:, None, :]  # (T-1, k, k) over (t, i, j)
-    P_t = softmax(log_P_t, axis=-1)  # row-stochastic transition matrix per step
+    # Forward-smoothed time-varying order-n_lags transitions for steps t = n_lags .. T-1:
+    #   p(s_t | s_{t-n_lags}..s_{t-1}, y) ∝ A_t(...) · b_t(s_t) · β_t(s_{t-n_lags+1}..s_t)
+    # normalized over s_t. Everything below carries a leading time axis of length T - n_lags
+    # and trailing batch axes.
+    b_jt = pt.moveaxis(batch_logp_emissions[..., n_lags:], -1, 0)  # (T-L, k, *batch) over (t, s_t)
+    beta_t = log_betas[1:]  # (T-L, (k,) * n_lags, *batch) over (t, s_{t-n_lags+1}..s_t)
+    # log_A_t: single transition tensor broadcast over steps (homogeneous), or the per-step prior
+    # (already (T-L, (k,) * (n_lags + 1), *batch), log_P[t] transitions into state t + n_lags).
+    log_A_t = log_P[None] if not time_varying else log_P
+    log_P_t = (
+        log_A_t
+        + pt.expand_dims(beta_t, 1)  # broadcast β_t over the oldest "from" state s_{t-n_lags}
+        + pt.expand_dims(b_jt, tuple(range(1, n_lags + 1)))  # emission over the "to" state s_t
+    )
+    # DiscreteMarkovChain expects P as (*batch, time, states...), so move the leading
+    # (time, states...) block behind the batch axes before normalizing over s_t.
+    log_P_t = pt.moveaxis(log_P_t, tuple(range(n_lags + 2)), tuple(range(-(n_lags + 2), 0)))
+    P_t = softmax(log_P_t, axis=-1)  # row-stochastic over s_t per step
 
-    steps = chain_shape[0] - 1
+    steps = chain_shape[-1] - n_lags
     cond_chain = DiscreteMarkovChain.dist(
-        P=P_t, init_dist=init_dist, steps=steps, time_varying_P=True
+        P=P_t, init_dist=init_dist, steps=steps, n_lags=n_lags, time_varying_P=True
     )
 
     replacements = dict(zip(inner_inputs, inputs))

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -8,7 +8,7 @@ import pytensor.tensor as pt
 from pymc.distributions import Bernoulli, Categorical, DiscreteUniform
 from pymc.logprob.abstract import _logprob
 from pymc.logprob.basic import conditional_logp
-from pymc.pytensorf import constant_fold
+from pymc.pytensorf import constant_fold, resolve_shapes
 from pytensor.compile.mode import Mode
 from pytensor.graph import Op, node_rewriter, vectorize_graph
 from pytensor.graph.replace import graph_replace
@@ -100,7 +100,8 @@ def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> tuple[int, ...]:
         return tuple(np.arange(lower, upper + 1))
     elif isinstance(op, DiscreteMarkovChain):
         P, *_ = dist_params
-        return tuple(range(pt.get_vector_length(P[-1])))
+        [n_states] = constant_fold(resolve_shapes([P.shape[-1]]))
+        return tuple(range(n_states))
 
     raise NotImplementedError(f"Cannot compute domain for op {op}")
 

--- a/tests/distributions/test_discrete_markov_chain.py
+++ b/tests/distributions/test_discrete_markov_chain.py
@@ -154,11 +154,48 @@ class TestDiscreteMarkovRV:
         from_0 = draws[:, 0] == 0
         np.testing.assert_allclose((draws[from_0, 1] == 0).mean(), 0.9, atol=0.02)
 
-    def test_time_varying_P_requires_single_lag(self):
-        P_t = np.zeros((3, 2, 2, 2))
-        x0 = pm.Categorical.dist(p=[0.5, 0.5])
-        with pytest.raises(NotImplementedError, match="time_varying_P is only supported"):
-            DiscreteMarkovChain.dist(P=P_t, init_dist=x0, steps=3, time_varying_P=True, n_lags=2)
+    @pytest.mark.parametrize("batched", [False, True], ids=lambda b: f"batched={b}")
+    @pytest.mark.parametrize("time_varying", [False, True], ids=lambda t: f"time_varying={t}")
+    def test_higher_order_P(self, batched, time_varying):
+        """A second-order (n_lags=2) chain, optionally batched (a leading batch dim on P yields
+        independent chains) and/or time-varying (a per-step transition tensor). Draws have the
+        expected per-chain shape and logp matches the hand-rolled init * transition product."""
+        rng = np.random.default_rng(4)
+        B, k, n_lags, steps = 3, 2, 2, 4
+        pi0 = np.array([0.4, 0.6])
+        # Transition tensor core is (k,) * (n_lags + 1) == P[s_{t-2}, s_{t-1}, s_t]; prepend a time
+        # axis when time-varying and a batch axis when batched. dirichlet's ``size`` is everything
+        # left of the final (normalized) axis.
+        size = ((B,) if batched else ()) + ((steps,) if time_varying else ()) + (k, k)
+        P = rng.dirichlet(np.ones(k), size=size)
+        x0 = pm.Categorical.dist(p=pi0)
+        chain = DiscreteMarkovChain.dist(
+            P=pt.as_tensor_variable(P),
+            init_dist=x0,
+            n_lags=n_lags,
+            time_varying_P=time_varying,
+            # steps inferred from P's time axis when time-varying
+            steps=None if time_varying else steps,
+        )
+
+        draw = pm.draw(chain, random_seed=1)
+        assert draw.shape == ((B, n_lags + steps) if batched else (n_lags + steps,))
+
+        value = rng.integers(0, k, size=draw.shape)
+        logp = pm.logp(chain, value).eval()
+
+        def path_logp(P_row, v):
+            lp = np.log(pi0[v[0]]) + np.log(pi0[v[1]])
+            for t in range(steps):
+                P_t = P_row[t] if time_varying else P_row
+                lp += np.log(P_t[v[t], v[t + 1], v[t + 2]])
+            return lp
+
+        if batched:
+            expected = np.array([path_logp(P[b], value[b]) for b in range(B)])
+        else:
+            expected = path_logp(P, value)
+        np.testing.assert_allclose(logp, expected)
 
     def test_time_varying_P_steps_conflict(self):
         """An explicit steps inconsistent with P's time axis is rejected."""

--- a/tests/distributions/test_discrete_markov_chain.py
+++ b/tests/distributions/test_discrete_markov_chain.py
@@ -10,6 +10,7 @@ from pymc.distributions.shape_utils import change_dist_size
 from pymc.logprob.utils import ParameterValueError
 from pymc.sampling.mcmc import assign_step_methods
 
+from pymc_extras.distributions.multivariate import JointCategorical
 from pymc_extras.distributions.timeseries import (
     DiscreteMarkovChain,
     DiscreteMarkovChainGibbsMetropolis,
@@ -195,6 +196,41 @@ class TestDiscreteMarkovRV:
             expected = np.array([path_logp(P[b], value[b]) for b in range(B)])
         else:
             expected = path_logp(P, value)
+        np.testing.assert_allclose(logp, expected)
+
+    def test_joint_categorical(self):
+        """JointCategorical draws and scores an arbitrary joint over n_lags categorical states."""
+        rng = np.random.default_rng(0)
+        k, n_lags = 2, 3
+        gamma = rng.random((k,) * n_lags)
+        gamma /= gamma.sum()
+        jc = JointCategorical.dist(p=gamma, n_lags=n_lags)
+
+        draws = pm.draw(jc, 40_000, random_seed=1)
+        assert draws.shape == (40_000, n_lags)
+        flat = draws[:, 0] * k * k + draws[:, 1] * k + draws[:, 2]
+        emp = np.bincount(flat, minlength=k**n_lags) / len(flat)
+        np.testing.assert_allclose(emp, gamma.ravel(), atol=0.01)
+
+        value = np.array([1, 0, 1])
+        logp = pm.logp(jc, value).eval()
+        np.testing.assert_allclose(logp, np.log(gamma[tuple(value)]))
+
+    def test_multivariate_init_dist(self):
+        """A DMC accepts a multivariate (joint) init_dist, scoring the initial states jointly."""
+        rng = np.random.default_rng(1)
+        k, n_lags = 2, 2
+        gamma = rng.random((k,) * n_lags)
+        gamma /= gamma.sum()
+        P = rng.dirichlet(np.ones(k), size=(k, k))  # (k, k, k)
+        init = JointCategorical.dist(p=gamma, n_lags=n_lags)
+        chain = DiscreteMarkovChain.dist(P=P, init_dist=init, steps=2, n_lags=n_lags)
+
+        draws = pm.draw(chain, random_seed=2)
+        assert draws.shape == (n_lags + 2,)
+        value = np.array([1, 0, 1, 1])
+        logp = pm.logp(chain, value).eval()
+        expected = np.log(gamma[1, 0]) + np.log(P[1, 0, 1]) + np.log(P[0, 1, 1])
         np.testing.assert_allclose(logp, expected)
 
     def test_time_varying_P_steps_conflict(self):

--- a/tests/model/marginal/test_discrete_markov_chain.py
+++ b/tests/model/marginal/test_discrete_markov_chain.py
@@ -223,6 +223,97 @@ def test_marginalized_discrete_markov_chain_time_varying_P():
     np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
 
 
+def test_marginalized_discrete_markov_chain_batched_time_varying_P():
+    """Batched chains sharing one time-varying P. The batch axes of the chain must not collide
+    with P's core (time, from, to) axes in the forward filter."""
+    pi0 = np.array([0.6, 0.4])
+    sigma = 0.8
+    obs = np.array([[0.1, 1.2, 0.8, -0.2], [0.9, -0.1, 0.2, 1.1], [0.5, 0.7, 1.0, 0.3]])
+    n_chains, T, k = *obs.shape, 2
+    A_t = np.array(
+        [
+            [[0.9, 0.1], [0.2, 0.8]],
+            [[0.4, 0.6], [0.3, 0.7]],
+            [[0.1, 0.9], [0.5, 0.5]],
+        ]
+    )  # (T - 1, k, k), no batch axis: every chain shares the same per-step kernels
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0, shape=(n_chains,))
+        states = DiscreteMarkovChain(
+            "states", P=A_t, init_dist=init, time_varying_P=True, shape=(n_chains, T)
+        )
+        pm.Normal("emission", mu=states, sigma=sigma, observed=obs)
+
+    marginal_m = marginalize(m, [states])
+
+    # The chains are independent, so brute force each one over its k**T paths and sum.
+    expected = 0.0
+    for b in range(n_chains):
+        log_joint = []
+        for s in itertools.product(range(k), repeat=T):
+            lp = np.log(pi0[s[0]]) + sum(np.log(A_t[t - 1, s[t - 1], s[t]]) for t in range(1, T))
+            lp += norm.logpdf(obs[b], loc=np.array(s), scale=sigma).sum()
+            log_joint.append(lp)
+        expected += logsumexp(log_joint)
+
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
+def test_marginalized_discrete_markov_chain_higher_order():
+    """Marginalizing a second-order (n_lags=2) chain matches brute force over all k**T paths."""
+    rng = np.random.default_rng(4)
+    pi0 = np.array([0.4, 0.6])
+    sigma = 0.7
+    obs = np.array([0.2, 1.1, -0.3, 0.9, 0.5])
+    T, k, n_lags = len(obs), 2, 2
+    P = rng.dirichlet(np.ones(k), size=(k, k))  # (k, k, k): P[s_{t-2}, s_{t-1}, s_t]
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0)
+        chain = DiscreteMarkovChain("chain", P=P, init_dist=init, steps=T - n_lags, n_lags=n_lags)
+        pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
+    marginal_m = marginalize(m, [chain])
+
+    log_joint = []
+    for s in itertools.product(range(k), repeat=T):
+        lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+        lp += sum(np.log(P[s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
+        lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
+        log_joint.append(lp)
+    expected = logsumexp(log_joint)
+
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
+def test_marginalized_discrete_markov_chain_higher_order_time_varying():
+    """Second-order (n_lags=2) chain with a per-step transition tensor, vs brute force."""
+    rng = np.random.default_rng(5)
+    pi0 = np.array([0.4, 0.6])
+    sigma = 0.7
+    obs = np.array([0.2, 1.1, -0.3, 0.9, 0.5])
+    T, k, n_lags = len(obs), 2, 2
+    P_t = rng.dirichlet(np.ones(k), size=(T - n_lags, k, k))  # (steps, k, k, k)
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0)
+        chain = DiscreteMarkovChain(
+            "chain", P=P_t, init_dist=init, n_lags=n_lags, time_varying_P=True
+        )
+        pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
+    marginal_m = marginalize(m, [chain])
+
+    log_joint = []
+    for s in itertools.product(range(k), repeat=T):
+        lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+        lp += sum(np.log(P_t[t - n_lags, s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
+        lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
+        log_joint.append(lp)
+    expected = logsumexp(log_joint)
+
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
 def test_conditional_discrete_markov_chain_time_varying_P():
     """conditional()/recover() for a non-homogeneous (time-varying P) HMM."""
     pi0 = np.array([0.6, 0.4])

--- a/tests/model/marginal/test_discrete_markov_chain.py
+++ b/tests/model/marginal/test_discrete_markov_chain.py
@@ -10,7 +10,7 @@ from arviz_base import from_dict
 from scipy.special import logsumexp
 from scipy.stats import norm
 
-from pymc_extras.distributions import DiscreteMarkovChain
+from pymc_extras.distributions import DiscreteMarkovChain, JointCategorical
 from pymc_extras.marginal import conditional, marginalize, recover
 
 
@@ -189,124 +189,220 @@ def test_conditional_discrete_markov_chain():
     np.testing.assert_allclose(recovered, brute_marginal, atol=0.02)
 
 
-def test_marginalized_discrete_markov_chain_time_varying_P():
-    """Marginalizing a non-homogeneous (time-varying P) chain matches brute force."""
+@pytest.mark.parametrize("batched", [False, True], ids=lambda b: f"batched={b}")
+def test_marginalized_discrete_markov_chain_time_varying_P(batched):
+    """Marginalizing a non-homogeneous (time-varying P) chain matches brute force. When batched,
+    independent chains share one per-step transition sequence, so the chain's batch axes must not
+    collide with P's core (time, from, to) axes in the forward filter."""
+    rng = np.random.default_rng(8)
     pi0 = np.array([0.6, 0.4])
     sigma = 0.8
-    obs = np.array([0.1, 1.2, 0.8, -0.2, 0.9])
-    T, k = len(obs), 2
-    A_t = np.array(
-        [
-            [[0.9, 0.1], [0.2, 0.8]],
-            [[0.4, 0.6], [0.3, 0.7]],
-            [[0.1, 0.9], [0.5, 0.5]],
-            [[0.7, 0.3], [0.6, 0.4]],
-        ]
-    )
+    T, k = 5, 2
+    A_t = rng.dirichlet(np.ones(k), size=(T - 1, k))  # (T - 1, k, k): one matrix per transition
+    if batched:
+        n_chains = 3
+        obs = rng.normal(size=(n_chains, T))
+    else:
+        obs = rng.normal(size=T)
 
     with pm.Model() as m:
-        init = pm.Categorical.dist(p=pi0)
+        init = pm.Categorical.dist(p=pi0, shape=(n_chains,) if batched else None)
         # steps inferred from A_t's time axis
-        states = DiscreteMarkovChain("states", P=A_t, init_dist=init, time_varying_P=True)
-        pm.Normal("emission", mu=states, sigma=sigma, observed=obs)
-
-    marginal_m = marginalize(m, [states])
-
-    # Brute-force marginal likelihood log p(y) over all k^T paths.
-    log_joint = []
-    for s in itertools.product(range(k), repeat=T):
-        lp = np.log(pi0[s[0]]) + sum(np.log(A_t[t - 1, s[t - 1], s[t]]) for t in range(1, T))
-        lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
-        log_joint.append(lp)
-    expected = logsumexp(log_joint)
-
-    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
-
-
-def test_marginalized_discrete_markov_chain_batched_time_varying_P():
-    """Batched chains sharing one time-varying P. The batch axes of the chain must not collide
-    with P's core (time, from, to) axes in the forward filter."""
-    pi0 = np.array([0.6, 0.4])
-    sigma = 0.8
-    obs = np.array([[0.1, 1.2, 0.8, -0.2], [0.9, -0.1, 0.2, 1.1], [0.5, 0.7, 1.0, 0.3]])
-    n_chains, T, k = *obs.shape, 2
-    A_t = np.array(
-        [
-            [[0.9, 0.1], [0.2, 0.8]],
-            [[0.4, 0.6], [0.3, 0.7]],
-            [[0.1, 0.9], [0.5, 0.5]],
-        ]
-    )  # (T - 1, k, k), no batch axis: every chain shares the same per-step kernels
-
-    with pm.Model() as m:
-        init = pm.Categorical.dist(p=pi0, shape=(n_chains,))
         states = DiscreteMarkovChain(
-            "states", P=A_t, init_dist=init, time_varying_P=True, shape=(n_chains, T)
+            "states",
+            P=A_t,
+            init_dist=init,
+            time_varying_P=True,
+            shape=(n_chains, T) if batched else None,
         )
         pm.Normal("emission", mu=states, sigma=sigma, observed=obs)
 
     marginal_m = marginalize(m, [states])
 
-    # The chains are independent, so brute force each one over its k**T paths and sum.
-    expected = 0.0
-    for b in range(n_chains):
+    def brute(obs_row):
+        # Marginal likelihood log p(y) over all k**T paths of a single chain.
         log_joint = []
         for s in itertools.product(range(k), repeat=T):
             lp = np.log(pi0[s[0]]) + sum(np.log(A_t[t - 1, s[t - 1], s[t]]) for t in range(1, T))
-            lp += norm.logpdf(obs[b], loc=np.array(s), scale=sigma).sum()
+            lp += norm.logpdf(obs_row, loc=np.array(s), scale=sigma).sum()
             log_joint.append(lp)
-        expected += logsumexp(log_joint)
+        return logsumexp(log_joint)
 
+    expected = sum(brute(o) for o in obs) if batched else brute(obs)
     np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
 
 
-def test_marginalized_discrete_markov_chain_higher_order():
-    """Marginalizing a second-order (n_lags=2) chain matches brute force over all k**T paths."""
+@pytest.mark.parametrize("batched", [False, True], ids=lambda b: f"batched={b}")
+def test_marginalized_discrete_markov_chain_higher_order(batched):
+    """Marginalizing a second-order (n_lags=2) chain matches brute force over all k**T paths. When
+    batched, a leading batch dim on P gives independent chains each with their own transition
+    tensor, exercising P's batch axis in the forward filter."""
     rng = np.random.default_rng(4)
     pi0 = np.array([0.4, 0.6])
     sigma = 0.7
-    obs = np.array([0.2, 1.1, -0.3, 0.9, 0.5])
-    T, k, n_lags = len(obs), 2, 2
-    P = rng.dirichlet(np.ones(k), size=(k, k))  # (k, k, k): P[s_{t-2}, s_{t-1}, s_t]
+    T, k, n_lags = 5, 2, 2
+    n_chains = 3
+    # (k, k, k) == P[s_{t-2}, s_{t-1}, s_t]; a leading batch axis when batched.
+    P = rng.dirichlet(np.ones(k), size=((n_chains, k, k) if batched else (k, k)))
+    obs = rng.normal(size=(n_chains, T)) if batched else rng.normal(size=T)
 
     with pm.Model() as m:
         init = pm.Categorical.dist(p=pi0)
+        chain = DiscreteMarkovChain(
+            "chain",
+            P=P,
+            init_dist=init,
+            steps=T - n_lags,
+            n_lags=n_lags,
+            shape=obs.shape if batched else None,
+        )
+        pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
+    marginal_m = marginalize(m, [chain])
+
+    def brute(P_row, obs_row):
+        log_joint = []
+        for s in itertools.product(range(k), repeat=T):
+            lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+            lp += sum(np.log(P_row[s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
+            lp += norm.logpdf(obs_row, loc=np.array(s), scale=sigma).sum()
+            log_joint.append(lp)
+        return logsumexp(log_joint)
+
+    expected = sum(brute(P[b], obs[b]) for b in range(n_chains)) if batched else brute(P, obs)
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
+@pytest.mark.parametrize("batched", [False, True], ids=lambda b: f"batched={b}")
+def test_marginalized_discrete_markov_chain_higher_order_time_varying(batched):
+    """Second-order (n_lags=2) chain with a per-step transition tensor, vs brute force. When
+    batched, independent chains share one per-step transition tensor."""
+    rng = np.random.default_rng(5)
+    pi0 = np.array([0.4, 0.6])
+    sigma = 0.7
+    T, k, n_lags = 5, 2, 2
+    P_t = rng.dirichlet(np.ones(k), size=(T - n_lags, k, k))  # (steps, k, k, k)
+    obs = rng.normal(size=(3, T)) if batched else rng.normal(size=T)
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0)
+        chain = DiscreteMarkovChain(
+            "chain",
+            P=P_t,
+            init_dist=init,
+            n_lags=n_lags,
+            time_varying_P=True,
+            shape=obs.shape if batched else None,
+        )
+        pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
+    marginal_m = marginalize(m, [chain])
+
+    def brute(obs_row):
+        log_joint = []
+        for s in itertools.product(range(k), repeat=T):
+            lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+            lp += sum(np.log(P_t[t - n_lags, s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
+            lp += norm.logpdf(obs_row, loc=np.array(s), scale=sigma).sum()
+            log_joint.append(lp)
+        return logsumexp(log_joint)
+
+    expected = sum(brute(o) for o in obs) if batched else brute(obs)
+    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
+
+
+@pytest.mark.parametrize("batched", [False, True], ids=lambda b: f"batched={b}")
+def test_conditional_discrete_markov_chain_higher_order(batched):
+    """conditional() logp and recover() marginals for a second-order (n_lags=2) HMM, vs brute force.
+
+    The posterior over the first two states is correlated, so the recovered chain carries a joint
+    (JointCategorical) init; when batched, a leading batch dim on P gives independent chains each
+    with their own transition tensor, and that init and the smoothed time-varying transitions are
+    themselves batched."""
+    rng = np.random.default_rng(7 if batched else 3)
+    k, n_lags = 2, 2
+    pi0 = np.array([0.5, 0.5])
+    sigma = 0.8
+    obs = np.array([[0.2, 1.1, -0.3, 0.9], [-0.7, 0.5, 1.3, 0.1]])
+    if not batched:
+        obs = obs[:1]
+    n_chains, T = obs.shape
+    # (k, k, k) == P[s_{t-2}, s_{t-1}, s_t]; a leading batch axis when batched (each chain its own).
+    P = rng.dirichlet(np.ones(k), size=((n_chains, k, k) if batched else (k, k)))
+
+    with pm.Model() as m:
+        init = pm.Categorical.dist(p=pi0)
+        states = DiscreteMarkovChain(
+            "states",
+            P=P,
+            init_dist=init,
+            steps=T - n_lags,
+            n_lags=n_lags,
+            shape=obs.shape if batched else None,
+        )
+        pm.Normal("emission", mu=states, sigma=sigma, observed=obs if batched else obs[0])
+    marginal_m = marginalize(m, [states])
+    cond_m = conditional(marginal_m)
+
+    # Per-row brute force over all k**T paths -> normalizer -> marginals.
+    log_joint = [{} for _ in range(n_chains)]
+    for b in range(n_chains):
+        P_row = P[b] if batched else P
+        for s in itertools.product(range(k), repeat=T):
+            lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+            lp += sum(np.log(P_row[s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
+            lp += norm.logpdf(obs[b], loc=np.array(s), scale=sigma).sum()
+            log_joint[b][s] = lp
+    log_z = [logsumexp(list(d.values())) for d in log_joint]
+    brute_marginal = np.array(
+        [
+            [sum(np.exp(d[s] - z) for s in d if s[t] == 1) for t in range(T)]
+            for d, z in zip(log_joint, log_z)
+        ]
+    )
+
+    # Exact conditional logp p(s | y) (summed over the batch rows when batched).
+    logp_fn = cond_m.compile_logp(vars=[cond_m["states"]])
+    if batched:
+        paths = np.array([[0, 0, 1, 0], [1, 1, 0, 1]])
+        expected_logp = sum(log_joint[b][tuple(paths[b])] - log_z[b] for b in range(n_chains))
+        np.testing.assert_allclose(logp_fn({"states": paths}), expected_logp, atol=1e-5)
+    else:
+        for path in [(0, 0, 1, 0), (1, 1, 0, 1), (0, 1, 1, 0)]:
+            np.testing.assert_allclose(
+                logp_fn({"states": np.array(path)}), log_joint[0][path] - log_z[0], atol=1e-5
+            )
+
+    # Recovered marginals match each row's brute force.
+    idata = from_dict({"posterior": {"sigma": np.full((2, 4000), sigma)}})
+    recovered = (
+        recover(idata, model=marginal_m, random_seed=0).posterior["states"].mean(("chain", "draw"))
+    )
+    expected_marginal = brute_marginal if batched else brute_marginal[0]
+    np.testing.assert_allclose(recovered, expected_marginal, atol=0.02)
+
+
+def test_marginalized_discrete_markov_chain_joint_init_dist():
+    """Marginalizing a second-order chain whose initial states have a correlated joint
+    (JointCategorical) init_dist matches brute force. This closes the loop over recovery: the
+    init of a recovered higher-order chain is a JointCategorical, so its model can itself be
+    marginalized again."""
+    rng = np.random.default_rng(6)
+    k, n_lags = 2, 2
+    P = rng.dirichlet(np.ones(k), size=(k, k))  # (k, k, k): P[s_{t-2}, s_{t-1}, s_t]
+    pi0_joint = np.array([[0.1, 0.4], [0.3, 0.2]])  # pi0_joint[s_0, s_1]
+    sigma = 0.7
+    obs = np.array([0.2, 1.1, -0.3, 0.9])
+    T = len(obs)
+
+    with pm.Model() as m:
+        init = JointCategorical.dist(p=pi0_joint, n_lags=n_lags)
         chain = DiscreteMarkovChain("chain", P=P, init_dist=init, steps=T - n_lags, n_lags=n_lags)
         pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
     marginal_m = marginalize(m, [chain])
 
     log_joint = []
     for s in itertools.product(range(k), repeat=T):
-        lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
+        lp = np.log(pi0_joint[s[0], s[1]])
         lp += sum(np.log(P[s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
-        lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
-        log_joint.append(lp)
-    expected = logsumexp(log_joint)
-
-    np.testing.assert_allclose(marginal_m.compile_logp()({}), expected)
-
-
-def test_marginalized_discrete_markov_chain_higher_order_time_varying():
-    """Second-order (n_lags=2) chain with a per-step transition tensor, vs brute force."""
-    rng = np.random.default_rng(5)
-    pi0 = np.array([0.4, 0.6])
-    sigma = 0.7
-    obs = np.array([0.2, 1.1, -0.3, 0.9, 0.5])
-    T, k, n_lags = len(obs), 2, 2
-    P_t = rng.dirichlet(np.ones(k), size=(T - n_lags, k, k))  # (steps, k, k, k)
-
-    with pm.Model() as m:
-        init = pm.Categorical.dist(p=pi0)
-        chain = DiscreteMarkovChain(
-            "chain", P=P_t, init_dist=init, n_lags=n_lags, time_varying_P=True
-        )
-        pm.Normal("emission", mu=chain, sigma=sigma, observed=obs)
-    marginal_m = marginalize(m, [chain])
-
-    log_joint = []
-    for s in itertools.product(range(k), repeat=T):
-        lp = np.log(pi0[s[0]]) + np.log(pi0[s[1]])
-        lp += sum(np.log(P_t[t - n_lags, s[t - 2], s[t - 1], s[t]]) for t in range(n_lags, T))
         lp += norm.logpdf(obs, loc=np.array(s), scale=sigma).sum()
         log_joint.append(lp)
     expected = logsumexp(log_joint)


### PR DESCRIPTION
- **Compatibility with pytensor 3.1 and new pymc model fgraph API**
- **Support batched and time-varying DiscreteMarkovChain with n_lags > 1**
- **Marginalize DiscreteMarkovChain with n_lags > 1**
- **Recover DiscreteMarkovChain with n_lags > 1**

Closes #550