### PR TITLE
Compatibility with PyTensor v3.1 and PyMC v6.1

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -13,7 +13,8 @@ dependencies:
   - pytest-cov
   - pydantic>=2.0.0
   - h5netcdf
-  - pymc>=6.0.1,<7.0
+  - pymc>=6.1.0,<6.2
+  - pytensor>=3.1.3,<3.2
   - preliz>=0.26,<0.27
   # arviz-plots 1.1.0 imports matplotlib.style.core, removed in matplotlib 3.11
   - matplotlib<3.11

--- a/pymc_extras/model/marginal/conditional.py
+++ b/pymc_extras/model/marginal/conditional.py
@@ -132,7 +132,9 @@ def conditional_fgraph(
         # variable and any new shared RNGs (e.g. from Categorical.dist) as inputs.
         sample_graph.name = var_name
         value = sample_graph.clone()
-        conditional_free_rv = model_free_rv(sample_graph, value, None, *op.marginalized_dims)
+        conditional_free_rv = model_free_rv(
+            sample_graph, value, None, var_name, *op.marginalized_dims
+        )
         fg.add_output(conditional_free_rv, reason="conditionalize", import_missing=True)
         recovered[var_name] = conditional_free_rv
 

--- a/pymc_extras/model/marginal/distributions/core.py
+++ b/pymc_extras/model/marginal/distributions/core.py
@@ -15,7 +15,7 @@ def inline_ofg_outputs(op: OpFromGraph, inputs: Sequence[Variable]) -> list[Vari
     Whereas `OpFromGraph` "wraps" a graph inside a single Op, this function "unwraps"
     the inner graph.
     """
-    outputs = op._frozen_fgraph.bind(list(inputs))
+    outputs = op.fgraph.bind(list(inputs))
     for inner_out, out in zip(op.inner_outputs, outputs):
         out.name = inner_out.name
     return outputs

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -256,8 +256,12 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
     (nominal) graph with value dummies for the dependents, then the real
     ``inputs`` / ``dep_rvs`` are substituted once at the end.
     """
-    chain = op.inner_outputs[0]
-    dependents = list(op.inner_outputs[1 : 1 + op.n_dependent_rvs])
+    # inner_inputs/inner_outputs are frozen (immutable) views; the logp and
+    # graph_replace below need mutable nodes, so work on an unfrozen copy.
+    inner_graph = op.fgraph.unfreeze()
+    inner_inputs = inner_graph.inputs
+    chain = inner_graph.outputs[0]
+    dependents = list(inner_graph.outputs[1 : 1 + op.n_dependent_rvs])
 
     if chain.type.ndim > 1:
         raise NotImplementedError(
@@ -297,7 +301,7 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
         P=P_t, init_dist=init_dist, steps=steps, time_varying_P=True
     )
 
-    replacements = dict(zip(op.inner_inputs, inputs))
+    replacements = dict(zip(inner_inputs, inputs))
     replacements.update(zip(dep_dummies, dep_rvs))
     [cond_chain] = graph_replace([cond_chain], replace=replacements, strict=False)
     return cond_chain

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -231,8 +231,12 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
     # perform internally (warn_rvs cannot be forwarded there). Work on the
     # inner (nominal) graph with value dummies and substitute the real
     # variables once at the end.
-    marginalized = op.inner_outputs[0]
-    dependents = list(op.inner_outputs[1 : 1 + op.n_dependent_rvs])
+    # inner_inputs/inner_outputs are frozen (immutable) views; conditional_logp
+    # and graph_replace below need mutable nodes, so work on an unfrozen copy.
+    inner_graph = op.fgraph.unfreeze()
+    inner_inputs = inner_graph.inputs
+    marginalized = inner_graph.outputs[0]
+    dependents = list(inner_graph.outputs[1 : 1 + op.n_dependent_rvs])
 
     marginalized_value = marginalized.clone()
     dep_dummies = [dep.type() for dep in dependents]
@@ -274,7 +278,7 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
         # matching the marginalized dtype so the conditional stays loggable.
         sample_graph += rv_domain[0].astype(marginalized.dtype)
 
-    replacements = dict(zip(op.inner_inputs, inputs))
+    replacements = dict(zip(inner_inputs, inputs))
     replacements.update(zip(dep_dummies, dep_rvs))
     [sample_graph] = graph_replace([sample_graph], replace=replacements, strict=False)
     return sample_graph

--- a/pymc_extras/model/marginal/marginalize.py
+++ b/pymc_extras/model/marginal/marginalize.py
@@ -11,7 +11,6 @@ from pymc.model.fgraph import (
     ModelDeterministic,
     ModelPotential,
     ModelValuedVar,
-    extract_dims,
     fgraph_from_model,
     model_from_fgraph,
 )
@@ -128,7 +127,7 @@ def _replace_marginal_subgraph(
             if client_node in subgraph_nodes:
                 fgraph.change_node_input(client_node, client_idx, raw_rv, import_missing=True)
 
-    marginalized_dims = extract_dims(rv_to_marginalize)
+    marginalized_dims = rv_to_marginalize.owner.op.dims
     n_dep = len(dependent_rvs)
 
     has_nested = any(

--- a/pymc_extras/model/marginal/rewrites.py
+++ b/pymc_extras/model/marginal/rewrites.py
@@ -165,7 +165,7 @@ def local_unmarginalize(fgraph, node):
     value = unmarginalized_rv.clone()
     transform = None
     unmarginalized_free_rv = model_free_rv(
-        unmarginalized_rv, value, transform, *node.op.marginalized_dims
+        unmarginalized_rv, value, transform, node.op.marginalized_name, *node.op.marginalized_dims
     )
 
     # Restore the model-variable output that was dropped when the variable was

--- a/pymc_extras/model/transforms/autoreparam.py
+++ b/pymc_extras/model/transforms/autoreparam.py
@@ -192,7 +192,7 @@ def vip_reparam_node(
         shape=rv_shape,
         name=lam_name,
     )
-    logit_lam = model_named(logit_lam_, *dims)
+    logit_lam = model_named(logit_lam_, lam_name, *dims)
     lam = pt.sigmoid(logit_lam)
     return (
         _vip_reparam_node(
@@ -243,6 +243,7 @@ def _(
         vip_rv_,
         vip_rv_.clone(),
         None,
+        vip_rv_.name,
         *dims,
     )
 
@@ -250,7 +251,7 @@ def _(
 
     vip_rep_.name = name
 
-    vip_rep = model_deterministic(vip_rep_, *dims)
+    vip_rep = model_deterministic(vip_rep_, vip_rep_.name, *dims)
     return vip_rep
 
 
@@ -281,6 +282,7 @@ def _(
         vip_rv_,
         vip_rv_value_,
         transform,
+        vip_rv_.name,
         *dims,
     )
 
@@ -288,7 +290,7 @@ def _(
 
     vip_rep_.name = name
 
-    vip_rep = model_deterministic(vip_rep_, *dims)
+    vip_rep = model_deterministic(vip_rep_, vip_rep_.name, *dims)
     return vip_rep
 
 

--- a/pymc_extras/utils/spline.py
+++ b/pymc_extras/utils/spline.py
@@ -61,7 +61,7 @@ class BSplineBasis(Op):
             Bx = scipy.sparse.csr_matrix(Bx, dtype=eval_points.dtype)
         output_storage[0][0] = Bx
 
-    def infer_shape(self, fgraph, node, ins_shapes):
+    def infer_shape(self, node, ins_shapes):
         return [(node.inputs[0].shape[0], node.inputs[1])]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,8 +34,8 @@ keywords = [
 license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
-  "pymc>=6.0.1,<7.0",
-  "pytensor>=3.0.4",
+  "pymc>=6.1.0,<6.2",
+  "pytensor>=3.1.3,<3.2",
   "arviz>=1.1",
   "better-optimize>=0.4.2,<1.0",
   "pydantic>=2.0.0",

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -2,6 +2,7 @@ import numpy as np
 import pymc as pm
 
 from pymc.logprob.abstract import _logprob
+from pymc.pytensorf import collect_default_updates
 from pytensor import tensor as pt
 
 from pymc_extras.model.marginal.distributions import MarginalFiniteDiscreteRV
@@ -13,14 +14,18 @@ def test_marginalized_bernoulli_logp():
 
     idx = pm.Bernoulli.dist(0.7, name="idx")
     y = pm.Normal.dist(mu=mu[idx], sigma=1.0, name="y")
+    # The inner RVs draw from shared RNGs, which the OpFromGraph requires as
+    # explicit inputs (with their updates as extra outputs).
+    updates = collect_default_updates([idx, y])
+    rngs, rng_updates = list(updates.keys()), list(updates.values())
     marginal_rv_node = MarginalFiniteDiscreteRV(
-        [mu],
-        [idx, y],
+        [mu, *rngs],
+        [idx, y, *rng_updates],
         n_dependent_rvs=1,
         dims_connections=(((),),),
         marginalized_name="idx",
         marginalized_dims=(),
-    )(mu)[0].owner
+    )(mu, *rngs)[0].owner
 
     y_vv = y.clone()
     (logp,) = _logprob(

--- a/tests/model/marginal/test_marginalize.py
+++ b/tests/model/marginal/test_marginalize.py
@@ -712,7 +712,7 @@ def test_forward_after_sampling():
 
     # Check that model.initial_point() does not modify the inner graph of the marginalization Op
     marginal_rv = marginalized_mod["y_hat"]
-    inner_outputs_before = marginal_rv.owner.op.fgraph.clone().outputs
+    inner_outputs_before = marginal_rv.owner.op.fgraph.unfreeze().outputs
     marginalized_mod.initial_point()
     inner_outputs_after = marginal_rv.owner.op.fgraph.outputs
     assert equal_computations_up_to_root(inner_outputs_before, inner_outputs_after)

--- a/tests/statespace/models/test_ETS.py
+++ b/tests/statespace/models/test_ETS.py
@@ -87,7 +87,7 @@ order_params = (
 
 
 @pytest.mark.parametrize(
-    "order, expected_flags", zip(orders, order_expected_flags), ids=order_names
+    "order, expected_flags", list(zip(orders, order_expected_flags)), ids=order_names
 )
 def test_order_flags(order, expected_flags):
     mod = BayesianETS(order=order, endog_names=["y"], seasonal_periods=4)
@@ -101,7 +101,7 @@ def test_mode_argument():
     assert mod.mode == "FAST_RUN"
 
 
-@pytest.mark.parametrize("order, expected_params", zip(orders, order_params), ids=order_names)
+@pytest.mark.parametrize("order, expected_params", list(zip(orders, order_params)), ids=order_names)
 def test_param_info(order: tuple[str, str, str], expected_params):
     mod = BayesianETS(order=order, endog_names=["y"], seasonal_periods=4)
 
@@ -115,7 +115,7 @@ def test_param_info(order: tuple[str, str, str], expected_params):
     )
 
 
-@pytest.mark.parametrize("order, expected_params", zip(orders, order_params), ids=order_names)
+@pytest.mark.parametrize("order, expected_params", list(zip(orders, order_params)), ids=order_names)
 @pytest.mark.parametrize("use_transformed", [True, False], ids=["transformed", "untransformed"])
 def test_statespace_matrices(
     rng, order: tuple[str, str, str], expected_params: list[str], use_transformed: bool
@@ -212,7 +212,7 @@ def test_statespace_matrices(
     assert_allclose(Z, Z_val)
 
 
-@pytest.mark.parametrize("order, params", zip(orders, order_params), ids=order_names)
+@pytest.mark.parametrize("order, params", list(zip(orders, order_params)), ids=order_names)
 def test_statespace_matches_statsmodels(rng, order: tuple[str, str, str], params):
     seasonal_periods = rng.integers(3, 12)
     data = rng.normal(size=(100,))
@@ -274,7 +274,7 @@ def test_statespace_matches_statsmodels(rng, order: tuple[str, str, str], params
         assert_allclose(matrix, sm_matrix, err_msg=f"{name} does not match")
 
 
-@pytest.mark.parametrize("order, params", zip(orders, order_params), ids=order_names)
+@pytest.mark.parametrize("order, params", list(zip(orders, order_params)), ids=order_names)
 @pytest.mark.parametrize("dense_cov", [True, False], ids=["dense", "diagonal"])
 def test_ETS_with_multiple_endog(rng, order, params, dense_cov):
     seasonal_periods = 4


### PR DESCRIPTION
- extract_dims -> op.dims; model_free_rv takes explicit name
- OpFromGraph inner graph is frozen: op._frozen_fgraph.bind ->
op.fgraph.bind,
  and unfreeze() before rebuilding graphs in the finite-discrete/HMM
conditionals
- drop deprecated fgraph param from BSplineBasis.infer_shape
- update tests for the immutable inner graph and explicit RNG inputs
