### PR TITLE
Add serialization to Scaled distribution

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -1733,8 +1733,8 @@ class Scaled:
     def to_dict(self) -> dict[str, Any]:
         """Convert the scaled distribution to a dictionary.
 
-        The ``factor`` is encoded with :func:`_serialize_value`: a scalar is
-        stored as-is, a numpy array as a list, and an ``xarray.DataArray`` as a
+        The ``factor`` is encoded the same way as ``Prior`` parameters: a
+        scalar is stored as-is, a numpy array as a list, and an ``xarray.DataArray`` as a
         ``{"class": "DataArray", ...}`` mapping. A pytensor variable is
         evaluated first. Non-tensor factors (arbitrary Python objects) are left
         untouched, so a factor that is not JSON-serializable will fail at the

--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -101,6 +101,7 @@ from pydantic.dataclasses import dataclass
 from pymc.distributions.shape_utils import Dims
 from pytensor.graph import Variable
 from pytensor.tensor import TensorVariable
+from pytensor.xtensor.type import XTensorType
 from xarray import DataArray, Dataset
 
 from pymc_extras.deserialize import deserialize, register_deserialization
@@ -522,6 +523,34 @@ def _param_value_with_dims(param: str, value, dims: Dims | None):
                 value = as_xtensor(value, dims=parameter_dims)
             else:
                 value = DataArray(value, dims=parameter_dims)
+
+    return value
+
+
+def _serialize_value(value):
+    """Encode a value for the dictionary form of a distribution.
+
+    Scalars pass through unchanged, numpy arrays become lists, and an
+    ``xarray.DataArray`` becomes a ``{"class": "DataArray", ...}`` mapping. A
+    pytensor variable is evaluated first, then handled as above.
+    """
+    if isinstance(value, Variable):
+        if isinstance(value.type, pt.TensorType):
+            value = value.eval()
+        elif isinstance(value.type, XTensorType):
+            value = DataArray(value.eval(), dims=value.type.dims)
+        else:
+            raise ValueError(f"Cannot serialize pytensor variable of type {value.type}")
+
+    if isinstance(value, np.ndarray):
+        return value.tolist()
+
+    if isinstance(value, DataArray):
+        return {
+            "class": "DataArray",
+            "data": value.data.tolist(),
+            "dims": list(value.dims),
+        }
 
     return value
 
@@ -1045,28 +1074,7 @@ class Prior:
                 if isinstance(value, Prior):
                     return value.to_dict()
 
-                if isinstance(value, Variable):
-                    if isinstance(value.type, pt.TensorType):
-                        value = value.eval()
-
-                    # Avoid XTensor import warnings, remove this when the warnings are gone
-                    elif value.type.__class__.__name__.startswith("XTensor"):
-                        value = DataArray(value.eval(), dims=value.type.dims)
-
-                    else:
-                        raise ValueError(
-                            f"Prior does not know how to serialize pytensor variable of type {value.type}"
-                        )
-
-                if isinstance(value, np.ndarray):
-                    return value.tolist()
-
-                if isinstance(value, DataArray):
-                    return {
-                        "class": "DataArray",
-                        "data": value.data.tolist(),
-                        "dims": list(value.dims),
-                    }
+                value = _serialize_value(value)
 
                 if hasattr(value, "to_dict"):
                     return value.to_dict()
@@ -1725,49 +1733,23 @@ class Scaled:
     def to_dict(self) -> dict[str, Any]:
         """Convert the scaled distribution to a dictionary.
 
-        The ``factor`` is stored inline: a scalar is stored as-is, a numpy array
-        as a list, and an ``xarray.DataArray`` as a ``{"class": "DataArray", ...}``
-        mapping. A pytensor variable is evaluated first. Non-tensor factors
-        (arbitrary Python objects) are left untouched, so a factor that is not
-        JSON-serializable will fail at the serialization layer, not here.
+        The ``factor`` is encoded with :func:`_serialize_value`: a scalar is
+        stored as-is, a numpy array as a list, and an ``xarray.DataArray`` as a
+        ``{"class": "DataArray", ...}`` mapping. A pytensor variable is
+        evaluated first. Non-tensor factors (arbitrary Python objects) are left
+        untouched, so a factor that is not JSON-serializable will fail at the
+        serialization layer, not here.
 
         Returns
         -------
         dict[str, Any]
             The dictionary format of the scaled distribution.
         """
-
-        def handle_factor(value):
-            if isinstance(value, Variable):
-                if isinstance(value.type, pt.TensorType):
-                    value = value.eval()
-
-                # Avoid XTensor import warnings, remove this when the warnings are gone
-                elif value.type.__class__.__name__.startswith("XTensor"):
-                    value = DataArray(value.eval(), dims=value.type.dims)
-
-                else:
-                    raise ValueError(
-                        f"Scaled does not know how to serialize pytensor variable of type {value.type}"
-                    )
-
-            if isinstance(value, np.ndarray):
-                return value.tolist()
-
-            if isinstance(value, DataArray):
-                return {
-                    "class": "DataArray",
-                    "data": value.data.tolist(),
-                    "dims": list(value.dims),
-                }
-
-            return value
-
         return {
             "class": "Scaled",
             "data": {
                 "dist": self.dist.to_dict(),
-                "factor": handle_factor(self.factor),
+                "factor": _serialize_value(self.factor),
             },
         }
 

--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -1722,6 +1722,68 @@ class Scaled:
 
         return det_class(name, var * self.factor, dims=self.dims)
 
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the scaled distribution to a dictionary.
+
+        The ``factor`` is stored inline: a scalar is stored as-is, a numpy array
+        as a list, and an ``xarray.DataArray`` as a ``{"class": "DataArray", ...}``
+        mapping. A pytensor variable is evaluated first. Non-tensor factors
+        (arbitrary Python objects) are left untouched, so a factor that is not
+        JSON-serializable will fail at the serialization layer, not here.
+
+        Returns
+        -------
+        dict[str, Any]
+            The dictionary format of the scaled distribution.
+        """
+
+        def handle_factor(value):
+            if isinstance(value, Variable):
+                if isinstance(value.type, pt.TensorType):
+                    value = value.eval()
+
+                # Avoid XTensor import warnings, remove this when the warnings are gone
+                elif value.type.__class__.__name__.startswith("XTensor"):
+                    value = DataArray(value.eval(), dims=value.type.dims)
+
+                else:
+                    raise ValueError(
+                        f"Scaled does not know how to serialize pytensor variable of type {value.type}"
+                    )
+
+            if isinstance(value, np.ndarray):
+                return value.tolist()
+
+            if isinstance(value, DataArray):
+                return {
+                    "class": "DataArray",
+                    "data": value.data.tolist(),
+                    "dims": list(value.dims),
+                }
+
+            return value
+
+        return {
+            "class": "Scaled",
+            "data": {
+                "dist": self.dist.to_dict(),
+                "factor": handle_factor(self.factor),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Scaled:
+        """Create a Scaled distribution from a dictionary."""
+        data = data["data"]
+
+        factor = data["factor"]
+        if isinstance(factor, dict):
+            factor = deserialize(factor)
+        elif isinstance(factor, list):
+            factor = np.array(factor)
+
+        return cls(dist=deserialize(data["dist"]), factor=factor)
+
 
 def _is_prior_type(data: dict) -> bool:
     return "dist" in data
@@ -1731,12 +1793,17 @@ def _is_censored_type(data: dict) -> bool:
     return data.keys() == {"class", "data"} and data["class"] == "Censored"
 
 
+def _is_scaled_type(data: dict) -> bool:
+    return data.keys() == {"class", "data"} and data["class"] == "Scaled"
+
+
 def _is_data_array_type(data: dict) -> bool:
     return data.keys() == {"class", "data", "dims"} and data["class"] == "DataArray"
 
 
 register_deserialization(is_type=_is_prior_type, deserialize=Prior.from_dict)
 register_deserialization(is_type=_is_censored_type, deserialize=Censored.from_dict)
+register_deserialization(is_type=_is_scaled_type, deserialize=Scaled.from_dict)
 register_deserialization(is_type=_is_data_array_type, deserialize=DataArray.from_dict)
 
 

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1001,6 +1001,18 @@ class TestScaled:
         assert isinstance(again.factor, xr.DataArray)
         xr.testing.assert_equal(again.factor, factor)
 
+    def test_scaled_round_trip_pytensor_factor(self) -> None:
+        """Test round-trip with a pytensor tensor-variable factor."""
+        normal = Prior("Normal", mu=0, sigma=1)
+        scaled = Scaled(normal, factor=pt.as_tensor_variable(2.5))
+
+        data = scaled.to_dict()
+        assert data["data"]["factor"] == 2.5
+
+        again = deserialize(data)
+        assert isinstance(again, Scaled)
+        assert again.factor == 2.5
+
 
 class TestCensored:
     def test_censored_is_variable_factory(

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -940,6 +940,67 @@ class TestScaled:
         assert "scaled_var" in prior
         assert "scaled_var_unscaled" in prior
 
+    def test_scaled_to_dict(self) -> None:
+        """Test that a scalar-factor Scaled serializes as expected."""
+        normal = Prior("Normal", mu=0, sigma=1, dims="channel")
+        scaled = Scaled(normal, factor=2.0)
+
+        data = scaled.to_dict()
+        assert data == {
+            "class": "Scaled",
+            "data": {"dist": normal.to_dict(), "factor": 2.0},
+        }
+
+    def test_deserialize_scaled(self) -> None:
+        """Test that a Scaled dictionary reconstructs a Scaled instance."""
+        data = {
+            "class": "Scaled",
+            "data": {
+                "dist": {"dist": "Normal", "kwargs": {"mu": 0, "sigma": 1}},
+                "factor": 50_000,
+            },
+        }
+
+        instance = deserialize(data)
+        assert isinstance(instance, Scaled)
+        assert isinstance(instance.dist, Prior)
+        assert instance.dist == Prior("Normal", mu=0, sigma=1)
+        assert instance.factor == 50_000
+
+    def test_scaled_round_trip(self) -> None:
+        """Test that to_dict -> deserialize preserves dist and factor."""
+        normal = Prior("Normal", mu=0, sigma=1, dims="channel")
+        scaled = Scaled(normal, factor=2.5)
+
+        again = deserialize(scaled.to_dict())
+        assert isinstance(again, Scaled)
+        assert again.dist == scaled.dist
+        assert again.factor == scaled.factor
+
+    def test_scaled_round_trip_array_factor(self) -> None:
+        """Test round-trip with a numpy-array factor."""
+        normal = Prior("Normal", mu=0, sigma=1, dims="channel")
+        factor = np.array([1.0, 2.0, 3.0])
+        scaled = Scaled(normal, factor=factor)
+
+        data = scaled.to_dict()
+        assert data["data"]["factor"] == [1.0, 2.0, 3.0]
+
+        again = deserialize(data)
+        assert isinstance(again, Scaled)
+        np.testing.assert_array_equal(again.factor, factor)
+
+    def test_scaled_round_trip_dataarray_factor(self) -> None:
+        """Test round-trip with an xarray.DataArray factor."""
+        normal = Prior("Normal", mu=0, sigma=1, dims="channel")
+        factor = xr.DataArray([1.0, 2.0, 3.0], dims="channel")
+        scaled = Scaled(normal, factor=factor)
+
+        again = deserialize(scaled.to_dict())
+        assert isinstance(again, Scaled)
+        assert isinstance(again.factor, xr.DataArray)
+        xr.testing.assert_equal(again.factor, factor)
+
 
 class TestCensored:
     def test_censored_is_variable_factory(


### PR DESCRIPTION
## Add serialization to `Scaled`

`Scaled(dist, factor)` had `create_variable` and a `dims` property but no `to_dict`/`from_dict`, and was not registered with the deserializer. So it could not round-trip like `Prior` and `Censored`. This adds that.

### What changed
- `Scaled.to_dict()` returns `{"class": "Scaled", "data": {"dist": dist.to_dict(), "factor": <encoded>}}`.
- `Scaled.from_dict()` reconstructs a `Scaled`, deserializing the inner `dist` and decoding the factor.
- Registered `_is_scaled_type` / `Scaled.from_dict` with `register_deserialization`, so `deserialize(...)` rebuilds a `Scaled`.

I used the same `{"class", "data"}` wrapper as `Censored` on purpose. The `Prior` deserializer matches any dict that has a `"dist"` key, so a flat `{"dist": ..., "factor": ...}` would be picked up as a `Prior`. The wrapper avoids that collision.

### Factor encoding
`factor` is `XTensorLike`. The contract is the smallest that covers real use:
- scalar: stored as-is (the common case, e.g. `factor=50_000`)
- numpy array: stored as a list, decoded back with `np.array`
- `xarray.DataArray`: stored as `{"class": "DataArray", ...}`, decoded by the existing DataArray deserializer
- pytensor variable: evaluated first, then handled as above

Anything else is passed through untouched, so a non-serializable factor fails at the serialization layer, not silently.

### Tests
Added to `TestScaled` in `tests/test_prior.py`: `to_dict` shape, `deserialize` of a hand-written dict, and round-trips for scalar, numpy-array, and DataArray factors.

### Motivation
pymc-marketing's `BassModel` save/load needs `Scaled` priors to serialize. Today pymc-marketing carries a shim (`_serialize_scaled`/`_deserialize_scaled` in `special_priors.py`) that can be removed once this lands. Raised in pymc-labs/pymc-marketing#2724.
