### PR TITLE
Post release notes to discourse

### DIFF
--- a/.github/workflows/publish-release-notes-to-discourse.yml
+++ b/.github/workflows/publish-release-notes-to-discourse.yml
@@ -1,0 +1,62 @@
+name: Publish Release Notes to Discourse
+
+permissions: {}
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag of an existing release to publish (e.g. v0.4.0)"
+        required: true
+        type: string
+
+jobs:
+  publish-to-discourse:
+    environment: discourse
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install requests
+
+      # Fetch the release from the API in both trigger modes, so a manual
+      # dispatch produces exactly the same payload as a published release
+      - name: Get release info
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          {
+            echo "tag=$TAG"
+            echo "url=$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json url --jq .url)"
+            echo "body<<RELEASE_BODY_EOF"
+            gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body
+            echo "RELEASE_BODY_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Publish release to Discourse
+        env:
+          DISCOURSE_API_KEY: ${{ secrets.DISCOURSE_API_KEY }}
+          DISCOURSE_USERNAME: "pymc-bot"
+          DISCOURSE_URL: "https://discourse.pymc.io"
+          DISCOURSE_CATEGORY: "News"
+          RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          RELEASE_BODY: ${{ steps.release.outputs.body }}
+          RELEASE_URL: ${{ steps.release.outputs.url }}
+          REPO_NAME: ${{ github.repository }}
+        run: python ./scripts/publish_release_notes_to_discourse.py

--- a/scripts/publish_release_notes_to_discourse.py
+++ b/scripts/publish_release_notes_to_discourse.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import os
+import re
+
+import requests
+
+
+def load_config() -> dict[str, str]:
+    env_config = {
+        "DISCOURSE_URL": os.getenv("DISCOURSE_URL"),
+        "DISCOURSE_API_KEY": os.getenv("DISCOURSE_API_KEY"),
+        "DISCOURSE_USERNAME": os.getenv("DISCOURSE_USERNAME"),
+        "DISCOURSE_CATEGORY": os.getenv("DISCOURSE_CATEGORY"),
+        # Release information from GitHub
+        "RELEASE_TAG": os.getenv("RELEASE_TAG"),
+        "RELEASE_BODY": os.getenv("RELEASE_BODY"),
+        "RELEASE_URL": os.getenv("RELEASE_URL"),
+        "REPO_NAME": os.getenv("REPO_NAME"),
+    }
+
+    missing_env_values = {key: value for key, value in env_config.items() if value is None}
+    if missing_env_values:
+        raise RuntimeError(
+            f"Missing required environment variables: {', '.join(missing_env_values.keys())}"
+        )
+    return env_config
+
+
+def find_category_id(config: dict[str, str]) -> int:
+    headers = {
+        "Api-Key": config["DISCOURSE_API_KEY"],
+        "Api-Username": config["DISCOURSE_USERNAME"],
+        "Content-Type": "application/json",
+    }
+
+    category_to_find = config["DISCOURSE_CATEGORY"].lower()
+    url = f"{config['DISCOURSE_URL']}/categories.json"
+    try:
+        response = requests.get(url, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+    except Exception:
+        print("Error fetching categories")
+        raise
+
+    if data.get("category_list") and data["category_list"].get("categories"):
+        categories = data["category_list"]["categories"]
+
+        for category in categories:
+            cat_id = category.get("id")
+            cat_name = category.get("name")
+            if cat_name.lower() == category_to_find:
+                return int(cat_id)
+
+    raise ValueError(f"Category '{category_to_find}' not found")
+
+
+def format_release_content(config: dict[str, str]) -> tuple[str, str]:
+    repo_name = config["REPO_NAME"].split("/")[1]
+    # Include the repo name in the title since multiple projects post to the same forum
+    title = f"🚀 Release {repo_name} {config['RELEASE_TAG']}"
+
+    # Format PR links in the release body
+    # Replace https://github.com/<repo>/pull/123 with [#123](https://github.com/<repo>/pull/123)
+    # This avoids redundant link rendering in Discourse
+    # Use negative lookbehind to avoid formatting already-formatted links
+    repo_pattern = re.escape(config["REPO_NAME"])
+    release_body = re.sub(
+        rf"(?<!\()\bhttps://github\.com/{repo_pattern}/pull/(\d+)\b",
+        r"[#\1](\g<0>)",
+        config["RELEASE_BODY"],
+    )
+
+    # Convert user mentions to GitHub profile links to avoid Discourse API limit of 10 mentions per post
+    # Replace @username with [@username](https://github.com/username)
+    release_body = re.sub(r"@([\w-]+)", r"[@\1](https://github.com/\1)", release_body)
+
+    content = f"""A new release of **{repo_name}** is now available!
+
+## 📦 Release Information
+
+- **Version:** `{config["RELEASE_TAG"]}`
+- **Repository:** [{config["REPO_NAME"]}](https://github.com/{config["REPO_NAME"]})
+- **Release Page:** {config["RELEASE_URL"]}
+- Note: It may take some time for the release to appear on PyPI and conda-forge.
+
+## 📋 Release Notes
+
+{release_body}
+
+---
+
+*This post was automatically generated from the GitHub release.*
+"""
+
+    return title, content
+
+
+def publish_release_to_discourse(config: dict[str, str]) -> bool:
+    print("🎯 GitHub Release to Discourse Publisher")
+    print(f"Release: {config['RELEASE_TAG']}")
+    print(f"Repository: {config['REPO_NAME']}")
+    print(f"Target Forum: {config['DISCOURSE_URL']}")
+    print(f"Target Category: {config['DISCOURSE_CATEGORY']}")
+    print("-" * 50)
+
+    category_id = find_category_id(config)
+    print(f"Publishing to category: {config['DISCOURSE_CATEGORY']} (ID: {category_id})")
+
+    # Format the release content
+    title, content = format_release_content(config)
+
+    # Create the topic data
+    topic_data = {"title": title, "raw": content, "category": category_id}
+
+    # Post to Discourse
+    headers = {
+        "Api-Key": config["DISCOURSE_API_KEY"],
+        "Api-Username": config["DISCOURSE_USERNAME"],
+        "Content-Type": "application/json",
+    }
+    url = f"{config['DISCOURSE_URL']}/posts.json"
+
+    try:
+        response = requests.post(url, headers=headers, json=topic_data)
+        response.raise_for_status()
+
+        data = response.json()
+        topic_id = data.get("topic_id")
+        post_id = data.get("id")
+
+        print("✅ Release published successfully!")
+        print(f"Topic ID: {topic_id}")
+        print(f"Post ID: {post_id}")
+        print(f"URL: {config['DISCOURSE_URL']}/t/{topic_id}")
+        return True
+
+    except requests.exceptions.RequestException as e:
+        print(f"❌ Error publishing release: {e}")
+        if hasattr(e, "response") and e.response is not None:
+            print(f"Response status: {e.response.status_code}")
+            try:
+                error_data = e.response.json()
+                print(f"Error details: {error_data}")
+            except Exception:
+                print(f"Response content: {e.response.text}")
+        raise
+
+
+if __name__ == "__main__":
+    config = load_config()
+    publish_release_to_discourse(config)

--- a/scripts/test_publish_release_notes.py
+++ b/scripts/test_publish_release_notes.py
@@ -1,0 +1,150 @@
+#   Copyright 2025 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+import re
+
+from publish_release_notes_to_discourse import format_release_content
+
+
+class TestFormatReleaseContent:
+    def test_pr_links_are_formatted(self):
+        """Test that PR links are formatted correctly in the release body."""
+        release_body = """<!-- Release notes generated using configuration in .github/release.yml at main -->
+
+## What's Changed
+### New Features 🎉
+* Add time-varying transition matrices to DiscreteMarkovChain by @ricardoV94 in https://github.com/pymc-devs/pymc-extras/pull/700
+* Build autoguide in unconstrained space by @theorashid in https://github.com/pymc-devs/pymc-extras/pull/701
+### Bugfixes 🪲
+* Fix conditional for marginalized DiscreteMarkovChain by @ricardoV94 in https://github.com/pymc-devs/pymc-extras/pull/702
+
+## New Contributors
+* @theorashid made their first contribution in https://github.com/pymc-devs/pymc-extras/pull/701
+
+**Full Changelog**: https://github.com/pymc-devs/pymc-extras/compare/v0.3.0...v0.4.0"""
+
+        config = {
+            "RELEASE_TAG": "v0.4.0",
+            "REPO_NAME": "pymc-devs/pymc-extras",
+            "RELEASE_BODY": release_body,
+            "RELEASE_URL": "https://github.com/pymc-devs/pymc-extras/releases/tag/v0.4.0",
+        }
+
+        title, content = format_release_content(config)
+
+        assert title == "🚀 Release pymc-extras v0.4.0"
+
+        assert "[#700](https://github.com/pymc-devs/pymc-extras/pull/700)" in content
+        assert "[#701](https://github.com/pymc-devs/pymc-extras/pull/701)" in content
+        assert "[#702](https://github.com/pymc-devs/pymc-extras/pull/702)" in content
+
+        # No raw PR links should remain outside markdown link syntax
+        raw_pr_links = re.findall(
+            r"(?<!\()\bhttps://github\.com/pymc-devs/pymc-extras/pull/\d+(?!\))", content
+        )
+        assert len(raw_pr_links) == 0, f"Found raw PR links: {raw_pr_links}"
+
+        # Other links remain unchanged (e.g., the Full Changelog link)
+        assert (
+            "**Full Changelog**: https://github.com/pymc-devs/pymc-extras/compare/v0.3.0...v0.4.0"
+            in content
+        )
+
+    def test_non_repo_links_unchanged(self):
+        """Test that PR links from other repositories are not affected."""
+        release_body = """Some changes:
+* Feature from external repo in https://github.com/other-org/other-repo/pull/123
+* Our feature in https://github.com/pymc-devs/pymc-extras/pull/456
+"""
+
+        config = {
+            "RELEASE_TAG": "v1.0.0",
+            "REPO_NAME": "pymc-devs/pymc-extras",
+            "RELEASE_BODY": release_body,
+            "RELEASE_URL": "https://github.com/pymc-devs/pymc-extras/releases/tag/v1.0.0",
+        }
+
+        _title, content = format_release_content(config)
+
+        assert "[#456](https://github.com/pymc-devs/pymc-extras/pull/456)" in content
+
+        assert "https://github.com/other-org/other-repo/pull/123" in content
+        assert "[#123](https://github.com/other-org/other-repo/pull/123)" not in content
+
+    def test_release_structure(self):
+        """Test that the overall release structure is correct."""
+        config = {
+            "RELEASE_TAG": "v1.2.3",
+            "REPO_NAME": "pymc-devs/pymc-extras",
+            "RELEASE_BODY": "Test body with PR https://github.com/pymc-devs/pymc-extras/pull/999",
+            "RELEASE_URL": "https://github.com/pymc-devs/pymc-extras/releases/tag/v1.2.3",
+        }
+
+        title, content = format_release_content(config)
+
+        assert title == "🚀 Release pymc-extras v1.2.3"
+        assert "A new release of **pymc-extras** is now available!" in content
+        assert "**Version:** `v1.2.3`" in content
+        assert (
+            "**Repository:** [pymc-devs/pymc-extras](https://github.com/pymc-devs/pymc-extras)"
+            in content
+        )
+        assert (
+            "**Release Page:** https://github.com/pymc-devs/pymc-extras/releases/tag/v1.2.3"
+            in content
+        )
+        assert "[#999](https://github.com/pymc-devs/pymc-extras/pull/999)" in content
+
+    def test_already_formatted_links_not_double_formatted(self):
+        """Test that already-formatted PR links are not double-formatted."""
+        release_body = """Some changes:
+* Already formatted: [#123](https://github.com/pymc-devs/pymc-extras/pull/123)
+* Raw link: https://github.com/pymc-devs/pymc-extras/pull/456
+"""
+
+        config = {
+            "RELEASE_TAG": "v1.0.0",
+            "REPO_NAME": "pymc-devs/pymc-extras",
+            "RELEASE_BODY": release_body,
+            "RELEASE_URL": "https://github.com/pymc-devs/pymc-extras/releases/tag/v1.0.0",
+        }
+
+        _title, content = format_release_content(config)
+
+        assert "[#123](https://github.com/pymc-devs/pymc-extras/pull/123)" in content
+        assert "[#123]([#123](https://github.com/pymc-devs/pymc-extras/pull/123))" not in content
+
+        assert "[#456](https://github.com/pymc-devs/pymc-extras/pull/456)" in content
+
+    def test_user_mentions_converted_to_links(self):
+        """Test that user mentions are converted to GitHub profile links."""
+        release_body = """## New Contributors
+* @ricardoV94 in https://github.com/pymc-devs/pymc-extras/pull/700
+* @user-with-dashes contributed in https://github.com/pymc-devs/pymc-extras/pull/701
+* @another_user123 helped out in https://github.com/pymc-devs/pymc-extras/pull/702
+"""
+
+        config = {
+            "RELEASE_TAG": "v0.4.0",
+            "REPO_NAME": "pymc-devs/pymc-extras",
+            "RELEASE_BODY": release_body,
+            "RELEASE_URL": "https://github.com/pymc-devs/pymc-extras/releases/tag/v0.4.0",
+        }
+
+        _title, content = format_release_content(config)
+
+        assert "[@ricardoV94](https://github.com/ricardoV94)" in content
+        assert "[@user-with-dashes](https://github.com/user-with-dashes)" in content
+        assert "[@another_user123](https://github.com/another_user123)" in content
+
+        assert "[#700](https://github.com/pymc-devs/pymc-extras/pull/700)" in content


### PR DESCRIPTION
Same code as in PyMC repo, added a way to retroactively fire for previous releases.