### PR TITLE
marginalize dims

### DIFF
--- a/pymc_extras/model/marginal/conditional.py
+++ b/pymc_extras/model/marginal/conditional.py
@@ -14,6 +14,12 @@ from pymc.sampling.forward import sample_posterior_predictive
 from pymc.util import RandomState
 from pytensor.graph import FunctionGraph, Variable
 from pytensor.graph.replace import graph_replace
+from pytensor.xtensor.basic import (
+    XTensorFromTensor,
+    tensor_from_xtensor,
+    xtensor_from_tensor,
+)
+from pytensor.xtensor.type import XTensorType
 from xarray import DataTree
 
 from pymc_extras.model.marginal.distributions.core import (
@@ -37,15 +43,31 @@ def _find_marg_rv(fg, var_name):
 
 
 def _model_var_of(fg, rv_output):
-    """The fg model variable wrapping ``rv_output`` (or its data, if observed)."""
-    mv_client = next(
-        (c for c, _ in fg.clients[rv_output] if isinstance(c.op, ModelValuedVar)), None
-    )
-    if mv_client is None:
-        raise ValueError(f"No model variable found wrapping dependent output {rv_output}")
-    if isinstance(mv_client.op, ModelObservedRV):
-        return mv_client.inputs[1]
-    return mv_client.outputs[0]
+    """The fg model variable wrapping ``rv_output`` (or its data, if observed).
+
+    In a ``pymc.dims`` model the MarginalRV was built over a lowered tensor subgraph, so its
+    outputs reach their model variable through an XTensorFromTensor that restores the dims.
+    """
+    candidates = [rv_output]
+    candidates += [
+        c.outputs[0]
+        for c, _ in fg.clients[rv_output]
+        if c != "output" and isinstance(c.op, XTensorFromTensor)
+    ]
+    for candidate in candidates:
+        mv_client = next(
+            (
+                c
+                for c, _ in fg.clients[candidate]
+                if c != "output" and isinstance(c.op, ModelValuedVar)
+            ),
+            None,
+        )
+        if mv_client is not None:
+            if isinstance(mv_client.op, ModelObservedRV):
+                return mv_client.inputs[1]
+            return mv_client.outputs[0]
+    raise ValueError(f"No model variable found wrapping dependent output {rv_output}")
 
 
 def conditional_fgraph(
@@ -126,7 +148,16 @@ def conditional_fgraph(
             replaced = graph_replace([*inputs, *dep_rvs], replace=remap, strict=False)
             inputs, dep_rvs = replaced[: len(inputs)], replaced[len(inputs) :]
 
+        # For a dims model the op's inner graph is lowered tensors, so the dependents it
+        # conditions on are handed over as tensors and the conditional comes back as one.
+        dep_rvs = [
+            tensor_from_xtensor(dep_rv) if isinstance(dep_rv.type, XTensorType) else dep_rv
+            for dep_rv in dep_rvs
+        ]
         sample_graph = marginalized_conditional(op, inputs, dep_rvs)
+        marginalized_dims = None if op.output_dims is None else op.output_dims[0]
+        if marginalized_dims is not None:
+            sample_graph = xtensor_from_tensor(sample_graph, dims=marginalized_dims)
 
         # Add the conditional as a new free RV. import_missing imports its value
         # variable and any new shared RNGs (e.g. from Categorical.dist) as inputs.

--- a/pymc_extras/model/marginal/dims.py
+++ b/pymc_extras/model/marginal/dims.py
@@ -1,0 +1,71 @@
+"""Support for marginalizing ``pymc.dims`` models.
+
+A ``pymc.dims`` model is built out of ``XTensorVariable``s, whose dims are names rather than
+positions. Rather than teach every marginalization strategy to reason about named dims, the
+marginal subgraph is lowered to plain tensors before it is recognized, so the existing
+strategies, their dim-connection analysis and their logps all apply unchanged. The resulting
+``MarginalRV`` outputs are then cast back, so the model's variables keep their dims.
+"""
+
+from pytensor.compile import optdb
+from pytensor.graph import FunctionGraph
+from pytensor.graph.replace import graph_replace
+from pytensor.tensor import tensor
+from pytensor.xtensor.basic import tensor_from_xtensor, xtensor_from_tensor
+from pytensor.xtensor.type import XTensorType
+
+
+def lower_marginal_subgraph(inputs, outputs):
+    """Rewrite an xtensor subgraph into the equivalent tensor one.
+
+    Returns ``(inner_inputs, outer_inputs, outputs)``. ``inner_inputs`` are fresh placeholders
+    that cut the subgraph at its boundary, so the lowering stops there instead of descending
+    into the rest of the model; they are what the MarginalRV's inner graph is written over.
+    ``outer_inputs`` are the matching expressions in the model's own graph, which the resulting
+    op is applied to. Variables that were already tensors are passed through untouched, so a
+    subgraph that mixes dims and non-dims variables is fine.
+    """
+    inner_inputs = []
+    outer_inputs = []
+    replacements = {}
+    for inp in inputs:
+        if isinstance(inp.type, XTensorType):
+            placeholder = tensor(dtype=inp.type.dtype, shape=inp.type.shape)
+            replacements[inp] = xtensor_from_tensor(placeholder, dims=inp.type.dims)
+            inner_inputs.append(placeholder)
+            outer_inputs.append(tensor_from_xtensor(inp))
+        else:
+            inner_inputs.append(inp)
+            outer_inputs.append(inp)
+
+    # Casting the outputs to tensors leaves round-trips that the lowering rewrites cancel,
+    # so what comes out is a graph of plain tensor Ops.
+    cast_outputs = [
+        tensor_from_xtensor(out) if isinstance(out.type, XTensorType) else out for out in outputs
+    ]
+    if replacements:
+        cast_outputs = graph_replace(cast_outputs, replacements, strict=False)
+
+    # Let the FunctionGraph collect its own inputs: the subgraph also reaches shared variables
+    # (the RNGs the RVs draw from) that aren't part of the boundary we were handed.
+    fgraph = FunctionGraph(outputs=cast_outputs, clone=False)
+    optdb.query("+lower_xtensor").rewrite(fgraph)
+    return inner_inputs, outer_inputs, list(fgraph.outputs)
+
+
+def output_dims_of(node):
+    """The dims of each output of a MarginalSubgraph node, or None for a plain tensor model.
+
+    The marker's outputs are ``[marginalized_rv, *dependents]`` and carry the types of the model
+    variables they stand for, so their dims are readable straight off them. An individual entry
+    is None when that variable is a plain tensor, which happens in a model that mixes dims and
+    non-dims variables.
+
+    This is not the same as ``marginalized_dims``, which is the pymc model's dims metadata and
+    exists for plain tensor models too. These are the dims the variables actually carry.
+    """
+    if not any(isinstance(out.type, XTensorType) for out in node.outputs):
+        return None
+    return tuple(
+        out.type.dims if isinstance(out.type, XTensorType) else None for out in node.outputs
+    )

--- a/pymc_extras/model/marginal/distributions/core.py
+++ b/pymc_extras/model/marginal/distributions/core.py
@@ -28,6 +28,13 @@ class MarginalRV(OpFromGraph, MeasurableOp):
     number of dependent RVs, are stored explicitly (``marginalized_name``,
     ``marginalized_dims``, ``n_dependent_rvs``) because pytensor makes no
     guarantee that variable names/metadata survive cloning and rewrites.
+
+    ``output_dims`` holds the dims each output carries -- the marginalized variable first, then
+    the dependents -- or None for an output that is a plain tensor. It is only set when
+    marginalizing a ``pymc.dims`` model, whose subgraph is lowered to tensors inside the op, and
+    is what lets the dims be restored on the way out (see ``core_dims``, and
+    ``local_unmarginalize``). Distinct from ``marginalized_dims``, which is the model's dims
+    metadata and exists for plain tensor models too.
     """
 
     def __init__(
@@ -36,12 +43,34 @@ class MarginalRV(OpFromGraph, MeasurableOp):
         marginalized_name: str,
         marginalized_dims,
         n_dependent_rvs: int,
+        output_dims: tuple[tuple[str, ...] | None, ...] | None = None,
         **kwargs,
     ) -> None:
         self.marginalized_name = marginalized_name
         self.marginalized_dims = marginalized_dims
         self.n_dependent_rvs = n_dependent_rvs
+        self.output_dims = output_dims
         super().__init__(*args, **kwargs)
+
+    @property
+    def core_dims(self) -> tuple[tuple[str, ...] | None, ...] | None:
+        """For each dependent's value, the dims this op's logp reduces.
+
+        This is the op's io dims signature: ``pymc.dims`` reads it to keep the joint logp on a
+        single node and to label the resulting terms, rather than assuming (wrongly, for us)
+        that the reduced dims are the rightmost ones. None when marginalizing a plain tensor
+        model, where there are no dims to declare.
+        """
+        if self.output_dims is None:
+            return None
+        # `support_axes` is the same information positionally, and the subclasses already derive
+        # it from their dims_connections. Output 0 is the marginalized variable, which has no
+        # value and so no core dims to declare.
+        support_axes = getattr(self, "support_axes", ((),) * self.n_dependent_rvs)
+        return tuple(
+            None if dims is None else tuple(dims[axis] for axis in axes)
+            for dims, axes in zip(self.output_dims[1:], support_axes, strict=True)
+        )
 
 
 @_support_point.register(MarginalRV)

--- a/pymc_extras/model/marginal/distributions/core.py
+++ b/pymc_extras/model/marginal/distributions/core.py
@@ -28,6 +28,13 @@ class MarginalRV(OpFromGraph, MeasurableOp):
     number of dependent RVs, are stored explicitly (``marginalized_name``,
     ``marginalized_dims``, ``n_dependent_rvs``) because pytensor makes no
     guarantee that variable names/metadata survive cloning and rewrites.
+
+    ``output_dims`` holds the dims each output carries -- the marginalized variable first, then
+    the dependents -- or None for an output that is a plain tensor. It is only set when
+    marginalizing a ``pymc.dims`` model, whose subgraph is lowered to tensors inside the op, and
+    is what lets the dims be restored on the way out (see ``local_unmarginalize``). Distinct
+    from ``marginalized_dims``, which is the model's dims metadata and exists for plain tensor
+    models too.
     """
 
     def __init__(
@@ -36,12 +43,28 @@ class MarginalRV(OpFromGraph, MeasurableOp):
         marginalized_name: str,
         marginalized_dims,
         n_dependent_rvs: int,
+        output_dims: tuple[tuple[str, ...] | None, ...] | None = None,
         **kwargs,
     ) -> None:
         self.marginalized_name = marginalized_name
         self.marginalized_dims = marginalized_dims
         self.n_dependent_rvs = n_dependent_rvs
+        self.output_dims = output_dims
         super().__init__(*args, **kwargs)
+
+    @property
+    def supp_axes(self) -> tuple[tuple[int, ...], ...] | None:
+        """For each output, which of its axes this op's density is over.
+
+        `pymc` reads this to give a deferred density term its shape, and to label it when the
+        variable carries dims. It is the `support_axes` the strategies already derive from their
+        dims_connections, with an entry prepended for the marginalized variable, which has no
+        value. None when a strategy did not derive them, which reads as "not declared".
+        """
+        support_axes = getattr(self, "support_axes", None)
+        if support_axes is None:
+            return None
+        return ((), *(tuple(axes) for axes in support_axes))
 
 
 @_support_point.register(MarginalRV)

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -308,7 +308,7 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
 
 @node_rewriter(tracks=[MarginalSubgraph])
 def discrete_markov_chain_marginal(fgraph, node):
-    inputs, outputs = extract_marginal_subgraph(node)
+    inputs, outer_inputs, outputs = extract_marginal_subgraph(node)
     marginalized_rv = outputs[0]
     marginalized_rv_op = marginalized_rv.owner.op
     if not isinstance(marginalized_rv_op, DiscreteMarkovChain):
@@ -332,7 +332,9 @@ def discrete_markov_chain_marginal(fgraph, node):
             "is not supported"
         )
 
-    return build_enumerable_marginal_rv(node, inputs, outputs, MarginalDiscreteMarkovChainRV)
+    return build_enumerable_marginal_rv(
+        node, inputs, outer_inputs, outputs, MarginalDiscreteMarkovChainRV
+    )
 
 
 marginal_rewrites_db.register(

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -15,10 +15,10 @@ from pymc_extras.model.marginal.distributions.core import (
     marginalized_conditional,
 )
 from pymc_extras.model.marginal.distributions.enumerable import (
-    DUMMY_ZERO,
     EnumerableMarginalRV,
     align_logp_dims,
     build_enumerable_marginal_rv,
+    dummy_logps,
     reduce_batch_dependent_logps,
     warn_non_separable_logp,
 )
@@ -236,8 +236,7 @@ def marginal_discrete_markov_chain_logp(op, values, *inputs, **kwargs):
     # If there are multiple emission streams, we have to add dummy logps for the remaining value variables. The first
     # return is the joint probability of everything together, but PyMC still expects one logp for each emission stream.
     warn_non_separable_logp(values)
-    dummy_logps = (DUMMY_ZERO,) * (len(values) - 1)
-    return joint_logp, *dummy_logps
+    return joint_logp, *dummy_logps(op, values)
 
 
 @marginalized_conditional.register(MarginalDiscreteMarkovChainRV)

--- a/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
+++ b/pymc_extras/model/marginal/distributions/discrete_markov_chain.py
@@ -57,7 +57,7 @@ def _hmm_emission_logp(op, chain, dependent_rvs, values):
 
     chain_value = chain.clone()
     dependent_rvs = clone_replace(dependent_rvs, {chain: chain_value})
-    logp_emissions_dict = conditional_logp(dict(zip(dependent_rvs, values)))
+    logp_emissions_dict = conditional_logp(dict(zip(dependent_rvs, values, strict=True)))
 
     # Reduce and add the batch dims beyond the chain dimension
     reduced_logp_emissions = reduce_batch_dependent_logps(
@@ -300,8 +300,8 @@ def discrete_markov_chain_marginalized_conditional(op, inputs, dep_rvs):
         P=P_t, init_dist=init_dist, steps=steps, time_varying_P=True
     )
 
-    replacements = dict(zip(inner_inputs, inputs))
-    replacements.update(zip(dep_dummies, dep_rvs))
+    replacements = dict(zip(inner_inputs, inputs, strict=True))
+    replacements.update(zip(dep_dummies, dep_rvs, strict=True))
     [cond_chain] = graph_replace([cond_chain], replace=replacements, strict=False)
     return cond_chain
 

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -16,6 +16,7 @@ from pytensor.scan import map as scan_map
 from pytensor.tensor import TensorVariable
 
 from pymc_extras.distributions import DiscreteMarkovChain
+from pymc_extras.model.marginal.dims import output_dims_of
 from pymc_extras.model.marginal.distributions.core import (
     MarginalRV,
     inline_ofg_outputs,
@@ -28,6 +29,7 @@ from pymc_extras.model.marginal.graph_analysis import (
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
+    finalize_marginal_rv,
     marginal_rewrites_db,
 )
 
@@ -82,7 +84,8 @@ def dummy_logps(op, values) -> tuple[TensorVariable, ...]:
     The joint logp of a MarginalRV cannot be split across its dependents, so it is all assigned
     to the first value and the rest get a placeholder. Each carries the shape a real term would
     have -- the value's shape minus the axes its logp reduces -- rather than a bare scalar, so
-    that callers can reason about the term's shape without special-casing the placeholder.
+    that callers can reason about the term's shape (and, for dims models, label its dims)
+    without special-casing the placeholder.
     """
     if len(values) < 2:
         return ()
@@ -305,7 +308,7 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
     return sample_graph
 
 
-def build_enumerable_marginal_rv(node, inputs, outputs, constructor):
+def build_enumerable_marginal_rv(node, inputs, outer_inputs, outputs, constructor):
     """Build an :class:`EnumerableMarginalRV` of type ``constructor`` from a marginal subgraph.
 
     Shared by the per-distribution rewriters (e.g. finite discrete and DiscreteMarkovChain).
@@ -334,21 +337,20 @@ def build_enumerable_marginal_rv(node, inputs, outputs, constructor):
         marginalized_name=op.marginalized_name,
         marginalized_dims=op.marginalized_dims,
         n_dependent_rvs=n_dep,
+        output_dims=output_dims_of(node),
     )
-
-    new_outputs = typed_op(*inputs)
-    if not isinstance(new_outputs, list):
-        new_outputs = list(new_outputs)
-    return new_outputs[: len(node.outputs)]
+    return finalize_marginal_rv(node, typed_op, outer_inputs)
 
 
 @node_rewriter(tracks=[MarginalSubgraph])
 def finite_discrete_marginal(fgraph, node):
-    inputs, outputs = extract_marginal_subgraph(node)
+    inputs, outer_inputs, outputs = extract_marginal_subgraph(node)
     marginalized_rv_op = outputs[0].owner.op
     if not isinstance(marginalized_rv_op, Bernoulli | Categorical | DiscreteUniform):
         return None
-    return build_enumerable_marginal_rv(node, inputs, outputs, MarginalFiniteDiscreteRV)
+    return build_enumerable_marginal_rv(
+        node, inputs, outer_inputs, outputs, MarginalFiniteDiscreteRV
+    )
 
 
 marginal_rewrites_db.register("finite_discrete_marginal", finite_discrete_marginal, "basic")

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -136,9 +136,12 @@ def reduce_batch_dependent_logps(
             # Some may have already been reduced by the logp expression of the dependent RV (e.g., multivariate RVs)
             dep_supp_axes = get_support_axes(dependent_op)[0]
 
-            # Dependent RV support axes are already collapsed in the logp, so we ignore them
+            # Dependent RV support axes are already collapsed in the logp, so we ignore them.
+            # The axes that remain must also be renumbered: they are counted against the
+            # dependent RV, but the logp no longer has the collapsed ones, so each support axis
+            # to the right of an axis shifts it one step towards zero.
             supp_axes = [
-                -i
+                -(i - sum(1 for supp_axis in dep_supp_axes if supp_axis > -i))
                 for i, dim in enumerate(reversed(dependent_dims_connection), start=1)
                 if (dim is None and -i not in dep_supp_axes)
             ]

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -21,7 +21,10 @@ from pymc_extras.model.marginal.distributions.core import (
     inline_ofg_outputs,
     marginalized_conditional,
 )
-from pymc_extras.model.marginal.graph_analysis import subgraph_batch_dim_connection
+from pymc_extras.model.marginal.graph_analysis import (
+    get_support_axes,
+    subgraph_batch_dim_connection,
+)
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
@@ -73,7 +76,23 @@ def warn_non_separable_logp(values):
         )
 
 
-DUMMY_ZERO = pt.constant(0, name="dummy_zero")
+def dummy_logps(op, values) -> tuple[TensorVariable, ...]:
+    """Zero placeholders for the values whose density was folded into the first logp term.
+
+    The joint logp of a MarginalRV cannot be split across its dependents, so it is all assigned
+    to the first value and the rest get a placeholder. Each carries the shape a real term would
+    have -- the value's shape minus the axes its logp reduces -- rather than a bare scalar, so
+    that callers can reason about the term's shape without special-casing the placeholder.
+    """
+    if len(values) < 2:
+        return ()
+
+    placeholders = []
+    for value, supp_axes in zip(values[1:], get_support_axes(op)[1:]):
+        ndim = value.type.ndim
+        kept = [i for i in range(ndim) if (i - ndim) not in supp_axes]
+        placeholders.append(pt.zeros([value.shape[i] for i in kept], dtype=value.type.dtype))
+    return tuple(placeholders)
 
 
 def align_logp_dims(dims: tuple[int | None, ...], logp: TensorVariable) -> TensorVariable:
@@ -125,8 +144,6 @@ def reduce_batch_dependent_logps(
        as well as transpose the remaining axis of dep1 logp before adding the two element-wise.
 
     """
-    from pymc_extras.model.marginal.graph_analysis import get_support_axes
-
     reduced_logps = []
     for dependent_op, dependent_logp, dependent_dims_connection in zip(
         dependent_ops, dependent_logps, dependent_dims_connections
@@ -220,8 +237,7 @@ def finite_discrete_marginal_rv_logp(op: MarginalFiniteDiscreteRV, values, *inpu
 
     warn_non_separable_logp(values)
     # We have to add dummy logps for the remaining value variables, otherwise PyMC will raise
-    dummy_logps = (DUMMY_ZERO,) * (len(values) - 1)
-    return joint_logp, *dummy_logps
+    return joint_logp, *dummy_logps(op, values)
 
 
 @marginalized_conditional.register(MarginalFiniteDiscreteRV)

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -182,7 +182,9 @@ def finite_discrete_marginal_rv_logp(op: MarginalFiniteDiscreteRV, values, *inpu
     inner_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
 
     # Obtain the joint_logp graph of the inner RV graph
-    inner_rv_values = dict(zip(inner_rvs, values))
+    # strict: a caller that provides fewer values than there are dependents would
+    # otherwise silently get the joint density of a subset of them
+    inner_rv_values = dict(zip(inner_rvs, values, strict=True))
     marginalized_vv = marginalized_rv.clone()
     rv_values = inner_rv_values | {marginalized_rv: marginalized_vv}
     logps_dict = conditional_logp(rv_values=rv_values, **kwargs)
@@ -260,7 +262,7 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
     marginalized_value = marginalized.clone()
     dep_dummies = [dep.type() for dep in dependents]
     rvs_to_values = {marginalized: marginalized_value}
-    rvs_to_values.update(zip(dependents, dep_dummies))
+    rvs_to_values.update(zip(dependents, dep_dummies, strict=True))
 
     logps_dict = conditional_logp(rvs_to_values)
     marginalized_logp = logps_dict[marginalized_value]
@@ -297,8 +299,8 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
         # matching the marginalized dtype so the conditional stays loggable.
         sample_graph += rv_domain[0].astype(marginalized.dtype)
 
-    replacements = dict(zip(inner_inputs, inputs))
-    replacements.update(zip(dep_dummies, dep_rvs))
+    replacements = dict(zip(inner_inputs, inputs, strict=True))
+    replacements.update(zip(dep_dummies, dep_rvs, strict=True))
     [sample_graph] = graph_replace([sample_graph], replace=replacements, strict=False)
     return sample_graph
 

--- a/pymc_extras/model/marginal/distributions/laplace.py
+++ b/pymc_extras/model/marginal/distributions/laplace.py
@@ -184,7 +184,7 @@ def laplace_marginal(fgraph, node):
 
     # Q was appended as the last boundary input and is kept as a dummy input
     # of the OpFromGraph (popped again by the logp implementation)
-    inputs, outputs = extract_marginal_subgraph(node)
+    inputs, outer_inputs, outputs = extract_marginal_subgraph(node)
 
     typed_op = MarginalLaplaceRV(
         inputs=inputs,
@@ -195,7 +195,7 @@ def laplace_marginal(fgraph, node):
         minimizer_kwargs=op.minimizer_kwargs,
     )
 
-    new_outputs = typed_op(*inputs)
+    new_outputs = typed_op(*outer_inputs)
     if not isinstance(new_outputs, list):
         new_outputs = list(new_outputs)
     return new_outputs[: len(node.outputs)]

--- a/pymc_extras/model/marginal/distributions/laplace.py
+++ b/pymc_extras/model/marginal/distributions/laplace.py
@@ -142,7 +142,7 @@ def laplace_marginal_rv_logp(op: MarginalLaplaceRV, values, *inputs_and_Q, **kwa
     inner_rvs = list(all_outputs[1 : 1 + op.n_dependent_rvs])
 
     # Obtain the joint_logp graph of the inner RV graph
-    inner_rv_values = dict(zip(inner_rvs, values))
+    inner_rv_values = dict(zip(inner_rvs, values, strict=True))
 
     marginalized_vv = x.clone()
     rv_values = inner_rv_values | {x: marginalized_vv}

--- a/pymc_extras/model/marginal/distributions/normal.py
+++ b/pymc_extras/model/marginal/distributions/normal.py
@@ -7,6 +7,7 @@ from pytensor.graph.replace import graph_replace
 from pytensor.graph.traversal import ancestors
 from pytensor.tensor import broadcast_to, constant, sqrt
 
+from pymc_extras.model.marginal.dims import output_dims_of
 from pymc_extras.model.marginal.distributions.core import (
     MarginalRV,
     inline_ofg_outputs,
@@ -15,6 +16,7 @@ from pymc_extras.model.marginal.distributions.core import (
 from pymc_extras.model.marginal.rewrites import (
     MarginalSubgraph,
     extract_marginal_subgraph,
+    finalize_marginal_rv,
     marginal_rewrites_db,
 )
 
@@ -79,7 +81,7 @@ def normal_normal_marginal_rewrite(fgraph, node):
     if op.n_dependent_rvs != 1:
         return None
 
-    inputs, outputs = extract_marginal_subgraph(node)
+    inputs, outer_inputs, outputs = extract_marginal_subgraph(node)
     marginalized_rv = outputs[0]
     dependent_rv = outputs[1]
 
@@ -112,12 +114,9 @@ def normal_normal_marginal_rewrite(fgraph, node):
         outputs=outputs,
         marginalized_name=op.marginalized_name,
         marginalized_dims=op.marginalized_dims,
+        output_dims=output_dims_of(node),
     )
-
-    new_outputs = typed_op(*inputs)
-    if not isinstance(new_outputs, list):
-        new_outputs = list(new_outputs)
-    return new_outputs[: len(node.outputs)]
+    return finalize_marginal_rv(node, typed_op, outer_inputs)
 
 
 marginal_rewrites_db.register("normal_normal_marginal", normal_normal_marginal_rewrite, "basic")

--- a/pymc_extras/model/marginal/graph_analysis.py
+++ b/pymc_extras/model/marginal/graph_analysis.py
@@ -328,6 +328,12 @@ def _subgraph_batch_dim_connection(var_dims: VAR_DIMS, input_vars, output_vars) 
         elif isinstance(node.op, MinibatchRandomVariable):
             var_dims[node.outputs[0]] = inputs_dims[0]
 
+        elif isinstance(node.op, Shape):
+            # A shape carries lengths, not values, so it connects no batch dims of the
+            # marginalized variable to the output. Leaving it out of var_dims marks it
+            # unrelated, which is what it is.
+            pass
+
         else:
             raise NotImplementedError(f"Marginalization through operation {node} not supported.")
 

--- a/pymc_extras/model/marginal/rewrites.py
+++ b/pymc_extras/model/marginal/rewrites.py
@@ -5,7 +5,10 @@ from pytensor.graph import Apply, Op, node_rewriter
 from pytensor.graph.replace import graph_replace
 from pytensor.graph.rewriting.db import EquilibriumDB
 from pytensor.graph.traversal import graph_inputs
+from pytensor.xtensor.basic import tensor_from_xtensor, xtensor_from_tensor
+from pytensor.xtensor.type import XTensorType
 
+from pymc_extras.model.marginal.dims import lower_marginal_subgraph
 from pymc_extras.model.marginal.distributions.core import MarginalRV, inline_ofg_outputs
 
 
@@ -138,9 +141,22 @@ def extract_marginal_subgraph(node):
     _unwrap_subgraph_model_vars during replace_marginal_subgraph. RNG
     updates are discovered here. The OpFromGraph constructor handles cloning.
 
-    Returns (inputs, outputs) where outputs = [marginalized_rv, *deps, *rng_updates].
+    A subgraph of a ``pymc.dims`` model is lowered to tensors first, so that the strategies
+    that recognize it, their dim-connection analysis and their logps all see the plain RVs they
+    were written for. ``finalize_marginal_rv`` casts the outputs back.
+
+    Returns (inner_inputs, outer_inputs, outputs), where outputs =
+    [marginalized_rv, *deps, *rng_updates]. The two input lists differ only for a lowered dims
+    subgraph: build the op over ``inner_inputs`` and apply it to ``outer_inputs``.
     """
     subgraph_outputs, boundary = node.op.split_node_inputs(node)
+
+    if any(isinstance(out.type, XTensorType) for out in subgraph_outputs):
+        boundary, outer_boundary, subgraph_outputs = lower_marginal_subgraph(
+            boundary, subgraph_outputs
+        )
+    else:
+        outer_boundary = boundary
 
     n_rvs = 1 + node.op.n_dependent_rvs
     rng_updates = collect_default_updates(
@@ -148,7 +164,26 @@ def extract_marginal_subgraph(node):
     )
 
     outputs = subgraph_outputs + list(rng_updates.values())
-    return boundary, outputs
+    return boundary, outer_boundary, outputs
+
+
+def finalize_marginal_rv(node, typed_op, inputs):
+    """Apply a resolved MarginalRV and return outputs matching the marker node's.
+
+    The marker's outputs carry the dims of the model variables they stand for. When those are
+    dims variables the MarginalRV was built over a lowered tensor subgraph, so its outputs are
+    cast back here -- the model keeps its dims on both the RVs and their values.
+    """
+    new_outputs = typed_op(*inputs)
+    if not isinstance(new_outputs, list):
+        new_outputs = list(new_outputs)
+
+    return [
+        xtensor_from_tensor(new_out, dims=old_out.type.dims)
+        if isinstance(old_out.type, XTensorType)
+        else new_out
+        for old_out, new_out in zip(node.outputs, new_outputs[: len(node.outputs)])
+    ]
 
 
 @node_rewriter(tracks=[MarginalRV])
@@ -159,13 +194,22 @@ def local_unmarginalize(fgraph, node):
     dependent_rvs = list(all_outputs[1 : 1 + n_dep])
     rngs = list(all_outputs[1 + n_dep :])
 
+    # For a dims model the inner graph was lowered to tensors, so the recovered variable comes
+    # out as one. Cast it back, or the model would silently get its variable back without dims.
+    marginalized_dims = None if node.op.output_dims is None else node.op.output_dims[0]
+    model_var = (
+        unmarginalized_rv
+        if marginalized_dims is None
+        else xtensor_from_tensor(unmarginalized_rv, dims=marginalized_dims)
+    )
+
     # Variable names are not preserved reliably through cloning/rewrites;
     # restore the model variable name from the op metadata.
-    unmarginalized_rv.name = node.op.marginalized_name
-    value = unmarginalized_rv.clone()
+    model_var.name = node.op.marginalized_name
+    value = model_var.clone()
     transform = None
     unmarginalized_free_rv = model_free_rv(
-        unmarginalized_rv, value, transform, node.op.marginalized_name, *node.op.marginalized_dims
+        model_var, value, transform, node.op.marginalized_name, *node.op.marginalized_dims
     )
 
     # Restore the model-variable output that was dropped when the variable was
@@ -173,9 +217,19 @@ def local_unmarginalize(fgraph, node):
     # import_missing imports the new value variable as an input.
     fgraph.add_output(unmarginalized_free_rv, reason="unmarginalize", import_missing=True)
 
-    dependent_rvs = graph_replace(dependent_rvs, {unmarginalized_rv: unmarginalized_free_rv})
+    # The dependents must be rewired onto the recovered *valued* variable, or they would keep
+    # drawing their own copy of it. For a dims model they are lowered tensors, so they take its
+    # tensor view -- replacing them with the xtensor model variable would match nothing.
+    recovered = (
+        unmarginalized_free_rv
+        if marginalized_dims is None
+        else tensor_from_xtensor(unmarginalized_free_rv)
+    )
+    dependent_rvs = graph_replace(dependent_rvs, {unmarginalized_rv: recovered})
 
-    return [unmarginalized_free_rv, *dependent_rvs, *rngs]
+    # The marginalized output has no clients (it was dropped when the variable was
+    # marginalized), but the replacement still has to match the node's output type.
+    return [recovered, *dependent_rvs, *rngs]
 
 
 marginal_rewrites_db = EquilibriumDB()

--- a/tests/model/marginal/test_dims.py
+++ b/tests/model/marginal/test_dims.py
@@ -1,0 +1,146 @@
+"""Marginalization of ``pymc.dims`` models.
+
+The reference for a dims model is always the equivalent plain tensor model: marginalizing it
+should produce the same computation, and leave the dims on the model's variables.
+"""
+
+import numpy as np
+import pymc as pm
+import pymc.dims as pmd
+import pytest
+import scipy.special
+
+from pymc.testing import equal_computations_up_to_root
+from pytensor.graph import rewrite_graph
+from pytensor.graph.replace import graph_replace
+from pytensor.printing import debugprint
+from pytensor.xtensor import as_xtensor
+
+from pymc_extras.marginal import conditional, marginalize, unmarginalize
+
+
+def assert_equivalent_logp_graph(model, reference_model):
+    """Assert a dims model's logp graph matches that of an equivalent tensor model.
+
+    Mirrors ``tests/dims/utils.py`` in pymc, which is not importable from here.
+    """
+    replacements = {
+        var: as_xtensor(var.values.clone(name=var.name), dims=var.dims) for var in model.value_vars
+    }
+    lowered = rewrite_graph(
+        [graph_replace(model.logp(), replacements)],
+        include=("lower_xtensor", "canonicalize", "local_remove_all_assert"),
+    )
+    reference_lowered = rewrite_graph(
+        [reference_model.logp()],
+        include=("canonicalize", "local_remove_all_assert"),
+    )
+    assert equal_computations_up_to_root(lowered, reference_lowered, ignore_rng_values=False), (
+        debugprint(lowered + reference_lowered, print_type=True)
+    )
+
+
+COORDS = {"trial": range(3), "obs": range(5), "cat": range(2)}
+P = np.array([0.3, 0.7])
+
+
+def test_marginalize_finite_discrete():
+    with pm.Model(coords=COORDS) as m:
+        idx = pmd.Categorical(
+            "idx", p=pmd.as_xtensor(P, dims=("cat",)), core_dims="cat", dims=("trial",)
+        )
+        pmd.Normal("y", mu=idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+
+    with pm.Model(coords=COORDS) as ref:
+        ref_idx = pm.Categorical("idx", p=P, dims=("trial",))
+        pm.Normal("y", mu=ref_idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+
+    marginal_m = marginalize(m, ["idx"])
+    assert_equivalent_logp_graph(marginal_m, marginalize(ref, ["idx"]))
+
+    # The model keeps its dims, on the RVs and on their values
+    [y] = marginal_m.free_RVs
+    assert y.type.dims == ("obs", "trial")
+    assert marginal_m.value_vars[0].type.dims == ("obs", "trial")
+
+
+def test_marginalize_multiple_dependents():
+    """The joint logp of several dependents cannot be split across them.
+
+    Deriving it per dependent silently computes the density of a subset, which is why this
+    asserts the joint against a reference rather than only that a logp comes out.
+    """
+    with pm.Model(coords=COORDS) as m:
+        idx = pmd.Categorical(
+            "idx", p=pmd.as_xtensor(P, dims=("cat",)), core_dims="cat", dims=("trial",)
+        )
+        pmd.Normal("y1", mu=idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+        pmd.Normal("y2", mu=idx * 3.0, sigma=1.0, dims=("trial",))
+
+    with pm.Model(coords=COORDS) as ref:
+        ref_idx = pm.Categorical("idx", p=P, dims=("trial",))
+        pm.Normal("y1", mu=ref_idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+        pm.Normal("y2", mu=ref_idx * 3.0, sigma=1.0, dims=("trial",))
+
+    point = {"y1": np.zeros((5, 3)), "y2": np.zeros(3)}
+    with pytest.warns(UserWarning, match="There are multiple dependent variables"):
+        got = marginalize(m, ["idx"]).compile_logp()(point)
+        expected = marginalize(ref, ["idx"]).compile_logp()(point)
+    np.testing.assert_allclose(got, expected)
+
+
+def test_marginalize_normal_normal():
+    with pm.Model(coords=COORDS) as m:
+        x = pmd.Normal("x", mu=0.0, sigma=1.0, dims=("trial",))
+        pmd.Normal("y", mu=x + 1.0, sigma=2.0, dims=("trial",))
+
+    with pm.Model(coords=COORDS) as ref:
+        ref_x = pm.Normal("x", mu=0.0, sigma=1.0, dims=("trial",))
+        pm.Normal("y", mu=ref_x + 1.0, sigma=2.0, dims=("trial",))
+
+    assert_equivalent_logp_graph(marginalize(m, ["x"]), marginalize(ref, ["x"]))
+
+
+def test_unmarginalize_roundtrip():
+    def build():
+        with pm.Model(coords=COORDS) as m:
+            idx = pmd.Categorical(
+                "idx", p=pmd.as_xtensor(P, dims=("cat",)), core_dims="cat", dims=("trial",)
+            )
+            pmd.Normal("y", mu=idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+        return m
+
+    recovered = unmarginalize(marginalize(build(), ["idx"]))
+
+    # The recovered variable comes back with its dims, not as a bare tensor
+    assert recovered["idx"].type.dims == ("trial",)
+
+    # ...and the model is the one we started with: the dependents must be rewired onto the
+    # recovered variable, not left drawing their own copy of it
+    point = {"idx": np.array([0, 1, 0]), "y": np.zeros((5, 3))}
+    np.testing.assert_allclose(recovered.compile_logp()(point), build().compile_logp()(point))
+
+
+def test_conditional():
+    with pm.Model(coords=COORDS) as m:
+        idx = pmd.Categorical(
+            "idx", p=pmd.as_xtensor(P, dims=("cat",)), core_dims="cat", dims=("trial",)
+        )
+        pmd.Normal("y", mu=idx * 2.0, sigma=1.0, dims=("obs", "trial"))
+
+    cond_m = conditional(marginalize(m, ["idx"]))
+    assert cond_m["idx"].type.dims == ("trial",)
+
+    # p(idx | y) per trial, against the same enumeration done by hand
+    y_val = np.tile(np.array([0.0, 2.0, 1.0]), (5, 1))
+    logp_idx = cond_m.compile_logp(vars=[cond_m["idx"]], sum=False)
+    for k in (0, 1):
+        [got] = logp_idx({"idx": np.full(3, k), "y": y_val})
+        unnormalized = np.array(
+            [
+                np.log(w) - 0.5 * ((y_val - 2.0 * j) ** 2).sum(0) - 5 * 0.5 * np.log(2 * np.pi)
+                for j, w in enumerate(P)
+            ]
+        )
+        expected = unnormalized[k] - scipy.special.logsumexp(unnormalized, axis=0)
+        np.testing.assert_allclose(np.asarray(got).ravel(), expected, atol=1e-8)

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -1,10 +1,13 @@
 import numpy as np
 import pymc as pm
+import scipy.special
+import scipy.stats
 
 from pymc.logprob.abstract import _logprob
 from pymc.pytensorf import collect_default_updates
 from pytensor import tensor as pt
 
+from pymc_extras.marginal import marginalize
 from pymc_extras.model.marginal.distributions import MarginalFiniteDiscreteRV
 
 
@@ -39,3 +42,28 @@ def test_marginalized_bernoulli_logp():
         logp.eval({mu: [-1, 1], y_vv: 2}),
         ref_logp.eval({mu: [-1, 1], y_vv: 2}),
     )
+
+
+def test_multivariate_dependent_with_extra_batch_dim():
+    """A dependent whose own logp collapses its core dims, plus a dim to marginalize over.
+
+    ``dims_connections`` is indexed against the dependent RV, but MvNormal's logp has already
+    dropped ``c``, so the axes left to reduce have to be renumbered against the logp.
+    """
+    with pm.Model() as m:
+        idx = pm.Categorical("idx", p=[0.3, 0.7], shape=(3,))
+        mu = np.zeros((5, 3, 4)) + idx[None, :, None] * 2.0
+        pm.MvNormal("y", mu=mu, chol=np.eye(4), shape=(5, 3, 4))
+
+    logp = marginalize(m, ["idx"]).compile_logp()({"y": np.zeros((5, 3, 4))})
+
+    # idx is shared across the 5 obs, so each trial marginalizes over one idx draw
+    expected = 3 * scipy.special.logsumexp(
+        [
+            np.log(w)
+            + 5
+            * scipy.stats.multivariate_normal.logpdf(np.zeros(4), np.full(4, 2.0 * k), np.eye(4))
+            for k, w in [(0, 0.3), (1, 0.7)]
+        ]
+    )
+    np.testing.assert_allclose(logp, expected)

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pymc as pm
+import pytest
 import scipy.special
 import scipy.stats
 
@@ -67,3 +68,37 @@ def test_multivariate_dependent_with_extra_batch_dim():
         ]
     )
     np.testing.assert_allclose(logp, expected)
+
+
+def test_multiple_dependents_logp_term_shapes():
+    """The joint logp goes to the first value; the rest get zeros of the right shape.
+
+    A bare scalar placeholder would still sum to the correct total, but leaves
+    ``compile_logp(sum=False)`` returning a term that doesn't match its variable's shape.
+    """
+    with pm.Model() as m:
+        idx = pm.Categorical("idx", p=[0.3, 0.7], shape=(3,))
+        pm.Normal("y1", mu=idx * 2.0, sigma=1.0, shape=(5, 3))
+        pm.Normal("y2", mu=idx * 3.0, sigma=1.0, shape=(3,))
+
+    marginal_m = marginalize(m, ["idx"])
+    point = {"y1": np.zeros((5, 3)), "y2": np.zeros(3)}
+    with pytest.warns(UserWarning, match="There are multiple dependent variables"):
+        logp_fn = marginal_m.compile_logp(sum=False)
+    y1_term, y2_term = logp_fn(point)
+
+    # Each term keeps its variable's batch shape, placeholder included
+    assert y1_term.shape == (3,)
+    assert y2_term.shape == (3,)
+    np.testing.assert_allclose(y2_term, 0.0)
+
+    # The whole joint sits on the first term, so the total is still exact
+    expected = 3 * scipy.special.logsumexp(
+        [
+            np.log(w)
+            + scipy.stats.norm.logpdf(np.zeros(5), 2.0 * k, 1).sum()
+            + scipy.stats.norm.logpdf(0.0, 3.0 * k, 1)
+            for k, w in [(0, 0.3), (1, 0.7)]
+        ]
+    )
+    np.testing.assert_allclose(y1_term.sum() + y2_term.sum(), expected)


### PR DESCRIPTION
- **Fix marginal logp of multivariate dependents with extra batch dims**
- **Give marginal logp placeholders the shape of a real term**
- **Raise instead of truncating when a marginal logp is given too few values**
- **Don't trace dim connections through Shape**
- **Support marginalizing pymc.dims models**
