### PR TITLE
Use known static shapes in pathfinder 

### DIFF
--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -4,17 +4,17 @@ channels:
 - nodefaults
 dependencies:
   - scikit-learn
-  - better-optimize>=0.4.2
+  - better-optimize>=0.4.2,<1.0
   - dask<2025.1.1
   - xhistogram
   - statsmodels
   - numba
   - pytest
   - pytest-cov
-  - pydantic>=2.0.0
+  - pydantic>=2.0.0,<3.0
   - h5netcdf
-  - pymc>=6.1.0,<6.2
-  - pytensor>=3.1.3,<3.2
+  - pymc>=6.2.0,<6.3
+  - pytensor>=3.2.2,<3.3
   - preliz>=0.26,<0.27
   # arviz-plots 1.1.0 imports matplotlib.style.core, removed in matplotlib 3.11
   - matplotlib<3.11
@@ -22,5 +22,3 @@ dependencies:
   - pip:
       - jax
       - blackjax
-      - pytensor>=3.0.4
-      - preliz>=0.25

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -15,9 +15,8 @@ dependencies:
   - h5netcdf
   - pymc>=6.2.0,<6.3
   - pytensor>=3.2.2,<3.3
+  - arviz>=1.2,<2.0
   - preliz>=0.26,<0.27
-  # arviz-plots 1.1.0 imports matplotlib.style.core, removed in matplotlib 3.11
-  - matplotlib<3.11
   - pip
   - pip:
       - jax

--- a/conda-envs/environment-test.yml
+++ b/conda-envs/environment-test.yml
@@ -16,7 +16,7 @@ dependencies:
   - pymc>=6.2.0,<6.3
   - pytensor>=3.2.2,<3.3
   - arviz>=1.2,<2.0
-  - preliz>=0.26,<0.27
+  - preliz>=0.27,<0.28
   - pip
   - pip:
       - jax

--- a/pymc_extras/inference/pathfinder/bfgs_sample.py
+++ b/pymc_extras/inference/pathfinder/bfgs_sample.py
@@ -167,11 +167,11 @@ def make_pathfinder_sample_fn(
         model.value_vars,
     )
 
-    x_sym = pt.vector("x", dtype="float64")
-    g_sym = pt.vector("g", dtype="float64")
-    alpha_sym = pt.vector("alpha", dtype="float64")
-    s_win_sym = pt.matrix("s_win", dtype="float64")  # (N, J)
-    z_win_sym = pt.matrix("z_win", dtype="float64")  # (N, J)
+    x_sym = pt.tensor("x", shape=(N,), dtype="float64")
+    g_sym = pt.tensor("g", shape=(N,), dtype="float64")
+    alpha_sym = pt.tensor("alpha", shape=(N,), dtype="float64")
+    s_win_sym = pt.tensor("s_win", shape=(N, J), dtype="float64")
+    z_win_sym = pt.tensor("z_win", shape=(N, J), dtype="float64")
     u_sym = pt.matrix("u", dtype="float64")  # (M, N) — M is dynamic
 
     phi_sym, logQ_sym, inv_hessian_diag_sym = _bfgs_sample_pt(

--- a/pymc_extras/inference/pathfinder/bfgs_sample.py
+++ b/pymc_extras/inference/pathfinder/bfgs_sample.py
@@ -123,7 +123,10 @@ def _bfgs_sample_pt(
         ql = Q @ Lchol
         inv_hessian_diag = alpha * (1.0 + pt.sum(ql * ql, axis=1) - pt.sum(Q * Q, axis=1))
 
-    logQ = -0.5 * (logdet + pt.sum(u * u, axis=-1) + N * np.log(2.0 * np.pi))
+    # Keep the log-normalizer at the input dtype so the whole graph stays floatX; an np.float64
+    # constant here would upcast logQ and put a float64 op on-device (rejected by MLX/Metal).
+    log_2pi = pt.constant(np.log(2.0 * np.pi), dtype=x.dtype)
+    logQ = -0.5 * (logdet + pt.sum(u * u, axis=-1) + N * log_2pi)
     return phi, logQ, inv_hessian_diag
 
 
@@ -167,12 +170,15 @@ def make_pathfinder_sample_fn(
         model.value_vars,
     )
 
-    x_sym = pt.tensor("x", shape=(N,), dtype="float64")
-    g_sym = pt.tensor("g", shape=(N,), dtype="float64")
-    alpha_sym = pt.tensor("alpha", shape=(N,), dtype="float64")
-    s_win_sym = pt.tensor("s_win", shape=(N, J), dtype="float64")
-    z_win_sym = pt.tensor("z_win", shape=(N, J), dtype="float64")
-    u_sym = pt.matrix("u", dtype="float64")  # (M, N) — M is dynamic
+    # Match the model's precision (float32 for MLX/float32 models) so callers feed the
+    # compiled function inputs of the right dtype; single_input carries the model's floatX.
+    floatX = single_input.type.dtype
+    x_sym = pt.tensor("x", shape=(N,), dtype=floatX)
+    g_sym = pt.tensor("g", shape=(N,), dtype=floatX)
+    alpha_sym = pt.tensor("alpha", shape=(N,), dtype=floatX)
+    s_win_sym = pt.tensor("s_win", shape=(N, J), dtype=floatX)
+    z_win_sym = pt.tensor("z_win", shape=(N, J), dtype=floatX)
+    u_sym = pt.matrix("u", dtype=floatX)  # (M, N) — M is dynamic
 
     phi_sym, logQ_sym, inv_hessian_diag_sym = _bfgs_sample_pt(
         x_sym, g_sym, alpha_sym, s_win_sym, z_win_sym, u_sym, J, N

--- a/pymc_extras/inference/pathfinder/idata.py
+++ b/pymc_extras/inference/pathfinder/idata.py
@@ -211,11 +211,13 @@ def add_pathfinder_to_inference_data(
 
 
 def _transform_draws_vectorized(model, vars_to_sample, trace, compile_kwargs: dict) -> list:
-    # Add a (chain, draw) batch dim across the Deterministic subgraph in one shot.
-    new_shapes = [v.ndim * (None,) for v in trace.values()]
+    # Add a (chain, draw) batch dim across the Deterministic subgraph in one shot. The trace is
+    # already materialized, so give the batch dims their concrete sizes rather than None: the JAX
+    # backend rejects reshapes with traced target shapes, and static sizes let the batched
+    # reshapes fold to constant targets instead.
     replace = {
-        var: pt.tensor(dtype="float64", shape=new_shapes[i])
-        for i, var in enumerate(model.value_vars)
+        var: pt.tensor(name=var.name, dtype="float64", shape=trace[var.name].shape)
+        for var in model.value_vars
     }
     outputs = vectorize_graph(vars_to_sample, replace=replace)
     # The transform graph is compiled once and run once, so skip the rewrite phase (FAST_COMPILE)
@@ -227,7 +229,7 @@ def _transform_draws_vectorized(model, vars_to_sample, trace, compile_kwargs: di
         **{"mode": FAST_COMPILE, "on_unused_input": "ignore", **compile_kwargs},
     )
     fn.trust_input = True
-    result = fn(*list(trace.values()))
+    result = fn(*[trace[var.name] for var in model.value_vars])
     return result if isinstance(result, list) else [result]
 
 

--- a/pymc_extras/inference/pathfinder/lbfgs.py
+++ b/pymc_extras/inference/pathfinder/lbfgs.py
@@ -90,6 +90,22 @@ class LBFGSInitFailed(LBFGSException):
         super().__init__(message or self.DEFAULT_MESSAGE, status)
 
 
+def _as_numpy_value_grad(value_grad_fn: Callable) -> Callable:
+    """Wrap a fused ``(value, grad)`` objective so its outputs are numpy arrays.
+
+    scipy's L-BFGS-B needs numpy for the value and gradient. Array backends that return
+    their own type (e.g. MLX returns ``mx.array``) otherwise flow through unconverted and
+    the optimizer degenerates to zero steps. The computation's own dtype is preserved
+    (float32 backends stay float32); JAX already returns numpy, so this is a no-op there.
+    """
+
+    def wrapped(x):
+        value, grad = value_grad_fn(x)
+        return np.asarray(value), np.asarray(grad)
+
+    return wrapped
+
+
 class LBFGS:
     """L-BFGS optimizer wrapping ``scipy.optimize.minimize(method="L-BFGS-B")``.
 
@@ -109,6 +125,9 @@ class LBFGS:
         Maximum line-search steps per iteration. Default 1000.
     epsilon : float, optional
         Curvature-condition threshold for accepting a step. Default 1e-12.
+    dtype : str or numpy.dtype, optional
+        Working precision of the L-BFGS objective, matching the compiled model (e.g. float32
+        for MLX/float32 models). Default ``"float64"``.
     """
 
     def __init__(
@@ -120,14 +139,16 @@ class LBFGS:
         gtol: float = 1e-8,
         maxls: int = 1000,
         epsilon: float = 1e-12,
+        dtype: str | np.dtype = "float64",
     ) -> None:
-        self.value_grad_fn = value_grad_fn
+        self.value_grad_fn = _as_numpy_value_grad(value_grad_fn)
         self.maxcor = maxcor
         self.maxiter = maxiter
         self.ftol = ftol
         self.gtol = gtol
         self.maxls = maxls
         self.epsilon = epsilon
+        self.dtype = np.dtype(dtype)
 
     def _classify_status(self, result, update_count: int) -> LBFGSStatus:
         """Classify the LBFGS termination status.
@@ -175,7 +196,10 @@ class LBFGS:
         lbfgs_status : LBFGSStatus
             The classified termination status.
         """
-        x0 = np.array(x0, dtype=np.float64)
+        # scipy calls the objective at x0's dtype, so this sets the working precision of the
+        # L-BFGS objective (float32 for MLX/float32 models); scipy still runs its own state in
+        # double regardless.
+        x0 = np.asarray(x0, dtype=self.dtype)
         # better_optimize detects the fused (value, grad) objective and promotes maxcor/maxiter/...
         # to scipy's options dict itself, so they pass straight through as keyword arguments.
         result = minimize(
@@ -221,6 +245,10 @@ class LBFGSStreamingCallback:
         Called with a progress dict after each step. Default None.
     on_step_callback : callable, optional
         Called after each accepted step with ``(x, g, alpha, s_win, z_win, elbo)``. Default None.
+    dtype : str or numpy.dtype, optional
+        Working precision for the initial point, smoothing buffers, and ELBO draws passed to
+        ``sample_logp_fn``, matching the compiled model. scipy's float64 step positions are cast
+        down to it. Default ``"float64"``.
     """
 
     def __init__(
@@ -234,7 +262,9 @@ class LBFGSStreamingCallback:
         epsilon: float,
         progress_callback: Callable | None = None,
         on_step_callback: Callable | None = None,
+        dtype: str | np.dtype = "float64",
     ) -> None:
+        value_grad_fn = _as_numpy_value_grad(value_grad_fn)
         self.value_grad_fn = value_grad_fn
         self.sample_logp_fn = sample_logp_fn
         self.num_elbo_draws = num_elbo_draws
@@ -243,19 +273,24 @@ class LBFGSStreamingCallback:
         self.epsilon = epsilon
         self.progress_callback = progress_callback
         self.on_step_callback = on_step_callback
+        # Working precision for everything fed to the (model-dtype) sample_logp_fn: the initial
+        # point, the smoothing buffers, and the ELBO draws. scipy hands back float64 positions,
+        # which __call__ casts down to this.
+        self.dtype = np.dtype(dtype)
 
         N = x0.shape[0]
         self._N = N
+        x0 = np.asarray(x0, dtype=self.dtype)
         _, g0 = value_grad_fn(x0)
 
         self.x_prev: NDArray = x0.copy()
-        self.g_prev: NDArray = np.array(g0, dtype=np.float64)
-        self.alpha_prev: NDArray = np.ones(N, dtype=np.float64)
+        self.g_prev: NDArray = np.asarray(g0, dtype=self.dtype)
+        self.alpha_prev: NDArray = np.ones(N, dtype=self.dtype)
 
         # Ring buffer: numpy arrays passed as inputs to sample_logp_fn each call.
         # Thread-safe: no shared mutable state across concurrent invocations.
-        self.s_win: NDArray = np.zeros((N, J), dtype=np.float64)
-        self.z_win: NDArray = np.zeros((N, J), dtype=np.float64)
+        self.s_win: NDArray = np.zeros((N, J), dtype=self.dtype)
+        self.z_win: NDArray = np.zeros((N, J), dtype=self.dtype)
         self.win_idx: int = -1
         self.best_elbo: float = -np.inf
         self.best_state: dict = {}
@@ -270,13 +305,16 @@ class LBFGSStreamingCallback:
         ``intermediate`` is a scipy/better_optimize ``OptimizeResult`` (carrying ``.x``, ``.fun``,
         and ``.jac``) or, for a classic scipy callback, the raw position array.
         """
+        # scipy iterates in float64, but sample_logp_fn is compiled at self.dtype with
+        # trust_input=True. Positions and gradients must be cast down to self.dtype here; widening
+        # back to float64 would reintroduce a float64 op into the (possibly Metal) sample graph.
         if hasattr(intermediate, "x"):
-            x = np.asarray(intermediate.x, dtype=np.float64)
+            x = np.asarray(intermediate.x, dtype=self.dtype)
             value = float(intermediate.fun)
             g = getattr(intermediate, "jac", None)
-            g = self.value_grad_fn(x)[1] if g is None else np.asarray(g, dtype=np.float64)
+            g = self.value_grad_fn(x)[1] if g is None else np.asarray(g, dtype=self.dtype)
         else:
-            x = np.asarray(intermediate, dtype=np.float64)
+            x = np.asarray(intermediate, dtype=self.dtype)
             value, g = self.value_grad_fn(x)
 
         s = x - self.x_prev
@@ -295,7 +333,7 @@ class LBFGSStreamingCallback:
         self.z_win[:, self.win_idx] = z
 
         # Sample + logP in a single compiled call. Pass s_win/z_win as inputs.
-        u = self._rng.standard_normal((self.num_elbo_draws, self._N))
+        u = self._rng.standard_normal((self.num_elbo_draws, self._N)).astype(self.dtype)
         sample_out = self.sample_logp_fn(x, g, alpha, self.s_win, self.z_win, u)
         _, logQ, logP, _ = sample_out
         logP = np.asarray(logP)

--- a/pymc_extras/inference/pathfinder/lbfgs.py
+++ b/pymc_extras/inference/pathfinder/lbfgs.py
@@ -109,10 +109,11 @@ def _as_numpy_value_grad(value_grad_fn: Callable) -> Callable:
 class LBFGS:
     """L-BFGS optimizer wrapping ``scipy.optimize.minimize(method="L-BFGS-B")``.
 
+    The objective and the curvature-condition threshold live on the
+    :class:`LBFGSStreamingCallback` that :meth:`minimize_streaming` drives, not here.
+
     Parameters
     ----------
-    value_grad_fn : callable
-        Returns ``(value, gradient)`` for a position.
     maxcor : int
         Number of variable-metric corrections.
     maxiter : int, optional
@@ -123,8 +124,6 @@ class LBFGS:
         Gradient-norm tolerance for convergence. Default 1e-8.
     maxls : int, optional
         Maximum line-search steps per iteration. Default 1000.
-    epsilon : float, optional
-        Curvature-condition threshold for accepting a step. Default 1e-12.
     dtype : str or numpy.dtype, optional
         Working precision of the L-BFGS objective, matching the compiled model (e.g. float32
         for MLX/float32 models). Default ``"float64"``.
@@ -132,25 +131,22 @@ class LBFGS:
 
     def __init__(
         self,
-        value_grad_fn,
         maxcor: int,
         maxiter: int = 1000,
         ftol: float = 1e-5,
         gtol: float = 1e-8,
         maxls: int = 1000,
-        epsilon: float = 1e-12,
         dtype: str | np.dtype = "float64",
     ) -> None:
-        self.value_grad_fn = _as_numpy_value_grad(value_grad_fn)
         self.maxcor = maxcor
         self.maxiter = maxiter
         self.ftol = ftol
         self.gtol = gtol
         self.maxls = maxls
-        self.epsilon = epsilon
         self.dtype = np.dtype(dtype)
 
-    def _classify_status(self, result, update_count: int) -> LBFGSStatus:
+    @staticmethod
+    def _classify_status(result, update_count: int) -> LBFGSStatus:
         """Classify the LBFGS termination status.
 
         Parameters

--- a/pymc_extras/inference/pathfinder/single_path.py
+++ b/pymc_extras/inference/pathfinder/single_path.py
@@ -160,9 +160,7 @@ def make_single_pathfinder_fn(
         if progress_callback is not None:
             progress_callback({"status": "running"})
 
-        local_lbfgs = LBFGS(
-            neg_logp_dlogp_func, maxcor, maxiter, ftol, gtol, maxls, epsilon, dtype=floatX
-        )
+        local_lbfgs = LBFGS(maxcor, maxiter, ftol, gtol, maxls, dtype=floatX)
         lbfgs_status = LBFGSStatus.LBFGS_FAILED  # default before LBFGS runs
 
         try:

--- a/pymc_extras/inference/pathfinder/single_path.py
+++ b/pymc_extras/inference/pathfinder/single_path.py
@@ -111,6 +111,7 @@ def make_single_pathfinder_fn(
     ip = Point(ipfn(None), model=model)
     x_base = DictToArrayBijection.map(ip).data
     N = x_base.shape[0]
+    floatX = x_base.dtype  # model precision; pathfinder's numpy buffers/draws follow it
 
     sample_logp_func = make_pathfinder_sample_fn(
         model=model,
@@ -120,6 +121,17 @@ def make_single_pathfinder_fn(
         compile_kwargs=compile_kwargs,
         vectorize=vectorize_logp,
     )
+
+    # LBFGS and its callback feed numpy buffers straight into sample_logp_func, which is compiled
+    # at the model's floatX with trust_input=True (no dtype coercion at call time). A dtype
+    # mismatch would be silently miscomputed rather than raised, so pin the buffer dtype to the
+    # function's declared input dtype.
+    sample_input_dtype = sample_logp_func.maker.fgraph.inputs[0].type.dtype
+    if floatX != sample_input_dtype:
+        raise ValueError(
+            f"Pathfinder buffer dtype {floatX} does not match the compiled sample-function input "
+            f"dtype {sample_input_dtype}."
+        )
 
     def _check_lbfgs_status(status):
         if status in {LBFGSStatus.INIT_FAILED, LBFGSStatus.INIT_FAILED_LOW_UPDATE_PCT}:
@@ -148,7 +160,9 @@ def make_single_pathfinder_fn(
         if progress_callback is not None:
             progress_callback({"status": "running"})
 
-        local_lbfgs = LBFGS(neg_logp_dlogp_func, maxcor, maxiter, ftol, gtol, maxls, epsilon)
+        local_lbfgs = LBFGS(
+            neg_logp_dlogp_func, maxcor, maxiter, ftol, gtol, maxls, epsilon, dtype=floatX
+        )
         lbfgs_status = LBFGSStatus.LBFGS_FAILED  # default before LBFGS runs
 
         try:
@@ -176,6 +190,7 @@ def make_single_pathfinder_fn(
                         J=maxcor,
                         epsilon=epsilon,
                         progress_callback=progress_callback,
+                        dtype=floatX,
                     )
 
                     lbfgs_niter, lbfgs_status = local_lbfgs.minimize_streaming(streaming_cb, x0)
@@ -191,7 +206,7 @@ def make_single_pathfinder_fn(
                     best_state = streaming_cb.best_state
 
                     final_rng = np.random.default_rng(final_seed)
-                    u_final = final_rng.standard_normal((num_draws, N))
+                    u_final = final_rng.standard_normal((num_draws, N)).astype(floatX)
                     if progress_callback is not None:
                         progress_callback({"status": "sampling"})
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
   "arviz>=1.2,<2.0",
   "better-optimize>=0.4.2,<1.0",
   "pydantic>=2.0.0,<3.0",
-  "preliz>=0.26.0,<0.27.0",
+  "preliz>=0.27.0,<0.28.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,13 +36,10 @@ dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
   "pymc>=6.2.0,<6.3",
   "pytensor>=3.2.2,<3.3",
-  "arviz>=1.1,<2.0",
+  "arviz>=1.2,<2.0",
   "better-optimize>=0.4.2,<1.0",
   "pydantic>=2.0.0,<3.0",
   "preliz>=0.26.0,<0.27.0",
-  # arviz-plots 1.1.0 imports matplotlib.style.core, which was removed in matplotlib 3.11.
-  # Remove once a fixed arviz-plots is released.
-  "matplotlib<3.11",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,11 +34,11 @@ keywords = [
 license = {file = "LICENSE"}
 dynamic = ["version"]  # specify the version in the __init__.py file
 dependencies = [
-  "pymc>=6.1.0,<6.2",
-  "pytensor>=3.1.3,<3.2",
-  "arviz>=1.1",
+  "pymc>=6.2.0,<6.3",
+  "pytensor>=3.2.2,<3.3",
+  "arviz>=1.1,<2.0",
   "better-optimize>=0.4.2,<1.0",
-  "pydantic>=2.0.0",
+  "pydantic>=2.0.0,<3.0",
   "preliz>=0.26.0,<0.27.0",
   # arviz-plots 1.1.0 imports matplotlib.style.core, which was removed in matplotlib 3.11.
   # Remove once a fixed arviz-plots is released.
@@ -51,15 +51,15 @@ complete = [
   "xhistogram",
 ]
 dev = [
-  "pytest>=6.0",
+  "pytest>=6.0,<10.0",
   "dask[all]<2025.1.1",
-  "blackjax>=0.12",
+  "blackjax>=0.12,<2.0",
   "statsmodels",
 ]
 docs = [
-  "nbsphinx>=0.4.2",
-  "sphinx>=4.0",
-  "pymc-sphinx-theme>=0.16",
+  "nbsphinx>=0.4.2,<1.0",
+  "sphinx>=4.0,<10.0",
+  "pymc-sphinx-theme>=0.16,<1.0",
 ]
 dask_histogram = [
   "dask[complete]<2025.1.1",

--- a/tests/inference/pathfinder/generate_fixtures.py
+++ b/tests/inference/pathfinder/generate_fixtures.py
@@ -78,7 +78,7 @@ def generate_fixture(name: str, model_fn, **compile_kwargs) -> None:
     )
     cached_fn = LRUCache1(neg_logp_dlogp_func, copy_x=True)
     rng_elbo = np.random.default_rng(ELBO_SEED)
-    lbfgs = LBFGS(cached_fn, MAXCOR, MAXITER)
+    lbfgs = LBFGS(MAXCOR, MAXITER)
     cb = LBFGSStreamingCallback(
         value_grad_fn=cached_fn,
         x0=x0,

--- a/tests/inference/pathfinder/test_bfgs_sample.py
+++ b/tests/inference/pathfinder/test_bfgs_sample.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pymc as pm
+import pytensor
 import pytest
 
 from pymc_extras.inference.pathfinder.bfgs_sample import (
@@ -117,6 +118,21 @@ def test_make_pathfinder_sample_fn_runs(N, J):
     assert logQ.shape == (M,)
     assert logP.shape == (M,)
     assert inv_hessian_diag.shape == (N,)
+
+
+@pytest.mark.parametrize("N, J", [_DENSE, _SPARSE], ids=["dense", "sparse"])
+def test_make_pathfinder_sample_fn_preserves_float32(N, J):
+    """A float32 model keeps every sample-fn output in float32, on both the dense and sparse
+    branches. A stray float64 constant (e.g. the log-normalizer in logQ) would upcast the graph
+    and put a float64 op on-device, which MLX/Metal rejects."""
+    M = 7
+    with pytensor.config.change_flags(floatX="float32"):
+        fn = _pathfinder_sample_fn(N, J, mode="FAST_RUN")
+        inputs = tuple(np.asarray(a, dtype="float32") for a in _pathfinder_sample_inputs(N, J, M))
+        outputs = fn(*inputs)
+
+    for output in outputs:
+        assert np.asarray(output).dtype == np.float32
 
 
 @pytest.mark.parametrize("N, J", [_DENSE, _SPARSE], ids=["dense", "sparse"])

--- a/tests/inference/pathfinder/test_bfgs_sample.py
+++ b/tests/inference/pathfinder/test_bfgs_sample.py
@@ -6,6 +6,7 @@ from pymc_extras.inference.pathfinder.bfgs_sample import (
     alpha_step_numpy,
     get_logp_dlogp_of_ravel_inputs,
     get_neg_logp_dlogp_of_ravel_inputs,
+    make_pathfinder_sample_fn,
 )
 
 
@@ -74,3 +75,63 @@ def test_neg_logp_dlogp_negates(scalar_model):
 
     np.testing.assert_allclose(neg_logp, -_standard_normal_logp(np.array(2.0)))
     np.testing.assert_allclose(neg_dlogp, [2.0])
+
+
+def _pathfinder_sample_fn(N, J, mode):
+    with pm.Model() as model:
+        pm.Normal("x", 0, 1, shape=N)
+    return make_pathfinder_sample_fn(
+        model=model,
+        N=N,
+        J=J,
+        jacobian=True,
+        compile_kwargs={"mode": mode},
+    )
+
+
+def _pathfinder_sample_inputs(N, J, M):
+    rng = np.random.default_rng(0)
+    return (
+        rng.standard_normal(N),
+        rng.standard_normal(N),
+        np.abs(rng.standard_normal(N)) + 0.1,
+        rng.standard_normal((N, J)),
+        rng.standard_normal((N, J)),
+        rng.standard_normal((M, N)),
+    )
+
+
+# (N, J) chosen to exercise both branches of _bfgs_sample_pt: 2J >= N takes the dense
+# path, 2J < N takes the sparse QR path.
+_DENSE = (3, 5)
+_SPARSE = (8, 2)
+
+
+@pytest.mark.parametrize("N, J", [_DENSE, _SPARSE], ids=["dense", "sparse"])
+def test_make_pathfinder_sample_fn_runs(N, J):
+    M = 7
+    fn = _pathfinder_sample_fn(N, J, mode="FAST_RUN")
+    phi, logQ, logP, inv_hessian_diag = fn(*_pathfinder_sample_inputs(N, J, M))
+
+    assert phi.shape == (M, N)
+    assert logQ.shape == (M,)
+    assert logP.shape == (M,)
+    assert inv_hessian_diag.shape == (N,)
+
+
+@pytest.mark.parametrize("N, J", [_DENSE, _SPARSE], ids=["dense", "sparse"])
+def test_make_pathfinder_sample_fn_jax_matches_c_backend(N, J):
+    """JAX must compile and agree numerically with the C backend.
+
+    Dynamic-shape s_win/z_win made ``pt.triu(S.T @ Z)`` build a symbolic-bound arange that
+    JAX's dispatch rejects; static (N, J) shapes fold it to a constant so the graph lowers.
+    """
+    pytest.importorskip("jax")
+
+    M = 7
+    inputs = _pathfinder_sample_inputs(N, J, M)
+    c_outputs = _pathfinder_sample_fn(N, J, mode="FAST_RUN")(*inputs)
+    jax_outputs = _pathfinder_sample_fn(N, J, mode="JAX")(*inputs)
+
+    for c_out, jax_out in zip(c_outputs, jax_outputs):
+        np.testing.assert_allclose(np.asarray(jax_out), c_out, rtol=1e-6, atol=1e-6)

--- a/tests/inference/pathfinder/test_idata.py
+++ b/tests/inference/pathfinder/test_idata.py
@@ -4,6 +4,7 @@ from collections import Counter
 
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
 import xarray as xr
 
@@ -247,11 +248,6 @@ def test_mock_result_is_subset_of_real_schema():
     )
 
 
-# ---------------------------------------------------------------------------
-# pathfinder_report
-# ---------------------------------------------------------------------------
-
-
 def test_pathfinder_report_smoke():
     """pathfinder_report prints without raising on a fully populated idata."""
     posterior = xr.Dataset({"x": (["chain", "draw"], np.random.normal(0, 1, (1, 100)))})
@@ -268,10 +264,6 @@ def test_pathfinder_report_missing_group():
     with pytest.raises(ValueError, match="missing the 'pathfinder' group"):
         pathfinder_report(idata)
 
-
-# ---------------------------------------------------------------------------
-# convert_flat_trace_to_idata
-# ---------------------------------------------------------------------------
 
 _POSTPROC_N = 3  # a (scalar) + b (shape 2)
 
@@ -310,3 +302,40 @@ def test_convert_flat_trace_keeps_paths(postproc_model, vectorize):
 
     assert idata.posterior["a"].shape == (num_paths, num_pdraws)
     assert idata.posterior["b"].shape == (num_paths, num_pdraws, 2)
+
+
+@pytest.mark.parametrize("vectorize", [False, True])
+def test_convert_flat_trace_jax_postprocessing_with_dynamic_shape(vectorize):
+    """Postprocessing whose Deterministic has a data-dependent shape must lower under JAX.
+
+    ``repeat`` gives the batched Deterministic an output dimension JAX cannot size until runtime.
+    When the batch dims of the postprocessing graph are left symbolic, that dimension reaches
+    JAX's reshape as a tracer and compilation fails; concrete batch sizes let it fold. This must
+    hold for both postprocessing paths, and the result must match the default backend.
+    """
+    pytest.importorskip("jax")
+
+    rows, cols, num_draws, repeats = 4, 3, 7, 2
+    with pm.Model() as model:
+        weight = pm.Normal("weight", 0, 1, shape=(rows, cols))
+        pm.Deterministic("weight_repeated", pt.repeat(weight, repeats, axis=0))
+
+    samples = np.random.default_rng(0).normal(size=(num_draws, rows * cols))
+
+    default_idata = convert_flat_trace_to_idata(
+        samples, model=model, importance_sampling="psis", vectorize=vectorize
+    )
+    jax_idata = convert_flat_trace_to_idata(
+        samples,
+        model=model,
+        importance_sampling="psis",
+        vectorize=vectorize,
+        compile_kwargs={"mode": "JAX"},
+    )
+
+    assert jax_idata.posterior["weight_repeated"].shape == (1, num_draws, rows * repeats, cols)
+    np.testing.assert_allclose(
+        jax_idata.posterior["weight_repeated"].values,
+        default_idata.posterior["weight_repeated"].values,
+        rtol=1e-6,
+    )

--- a/tests/inference/pathfinder/test_lbfgs.py
+++ b/tests/inference/pathfinder/test_lbfgs.py
@@ -16,6 +16,7 @@ from pymc_extras.inference.pathfinder.lbfgs import (
     LBFGSConfig,
     LBFGSStatus,
     LBFGSStreamingCallback,
+    _as_numpy_value_grad,
     _check_lbfgs_curvature_condition,
 )
 from tests.inference.pathfinder.conftest import (
@@ -40,6 +41,27 @@ from tests.inference.pathfinder.equivalence_models import make_ard_regression
 )
 def test_check_lbfgs_curvature_condition(s, z, epsilon, expected):
     assert _check_lbfgs_curvature_condition(s, z, epsilon) is expected
+
+
+def test_as_numpy_value_grad_converts_and_preserves_dtype():
+    """Foreign array outputs (e.g. MLX) become numpy without upcasting the computation's dtype."""
+
+    class FakeArray:
+        def __init__(self, data):
+            self._data = np.asarray(data, dtype=np.float32)
+
+        def __array__(self, dtype=None, copy=None):
+            return self._data if dtype is None else self._data.astype(dtype)
+
+    wrapped = _as_numpy_value_grad(lambda x: (FakeArray(1.5), FakeArray([0.1, 0.2])))
+    value, grad = wrapped(np.zeros(2))
+
+    assert isinstance(value, np.ndarray)
+    assert isinstance(grad, np.ndarray)
+    assert value.dtype == np.float32
+    assert grad.dtype == np.float32
+    np.testing.assert_allclose(value, 1.5)
+    np.testing.assert_allclose(grad, [0.1, 0.2])
 
 
 def test_set_default_maxcor_keeps_explicit_value():

--- a/tests/inference/pathfinder/test_lbfgs.py
+++ b/tests/inference/pathfinder/test_lbfgs.py
@@ -94,9 +94,8 @@ def test_set_default_maxcor_heuristic(N, expected):
     ids=["init_failed", "init_low_pct", "max_iter", "non_finite", "low_update_pct", "converged"],
 )
 def test_classify_status(nit, status, update_count, expected):
-    lbfgs = LBFGS(value_grad_fn=lambda x: (0.0, x), maxcor=5)
     result = OptimizeResult(nit=nit, status=status)
-    assert lbfgs._classify_status(result, update_count) is expected
+    assert LBFGS._classify_status(result, update_count) is expected
 
 
 @pytest.mark.parametrize("vectorize", [False, True])

--- a/tests/inference/pathfinder/test_single_path.py
+++ b/tests/inference/pathfinder/test_single_path.py
@@ -1,6 +1,8 @@
 from unittest.mock import patch
 
 import numpy as np
+import pymc as pm
+import pytensor
 import pytest
 
 from pymc.blocking import DictToArrayBijection
@@ -181,6 +183,23 @@ def test_shared_single_fn_is_leak_free():
         np.testing.assert_array_equal(r.inv_hessian_diag, ref.inv_hessian_diag)
         compared += 1
     assert compared >= 2, "need >=2 successful paths to meaningfully exercise fn reuse"
+
+
+def test_float32_model_dtype_propagation():
+    """A float32 model keeps pathfinder's numpy buffers, ELBO draws, and outputs in float32, so no
+    float64 op leaks into the compiled (potentially device) graph."""
+    with pytensor.config.change_flags(floatX="float32"):
+        with pm.Model() as model:
+            mu = pm.Normal("mu", 0.0, 1.0, shape=3)
+            pm.Normal("y", mu=mu, sigma=1.0, observed=np.array([0.3, -0.7, 1.2], dtype="float32"))
+        result = make_single_fn(model)(0)
+
+    assert result.path_status not in FAILED_PATH_STATUS
+    assert result.samples is not None
+    assert result.samples.dtype == np.float32
+    assert result.logP.dtype == np.float32
+    assert result.logQ.dtype == np.float32
+    assert result.inv_hessian_diag.dtype == np.float32
 
 
 @pytest.mark.parametrize("model_name", ["ard_regression", "bpca_small"])


### PR DESCRIPTION
Matrices built inside the pathfinder graph use fully dynamic shapes, even though their shapes are known at build time. This causes issues for jax/mlx. Fix is to simply pass along known shape info.  