### PR TITLE
Streaming Pathfinder: minibatch L-BFGS with same-batch curvature pairs

### DIFF
--- a/pymc_extras/inference/pathfinder/__init__.py
+++ b/pymc_extras/inference/pathfinder/__init__.py
@@ -1,4 +1,10 @@
 from pymc_extras.inference.pathfinder.idata import pathfinder_report
 from pymc_extras.inference.pathfinder.pathfinder import fit_blackjax_pathfinder, fit_pathfinder
+from pymc_extras.inference.pathfinder.streaming_pathfinder import fit_streaming_pathfinder
 
-__all__ = ["fit_blackjax_pathfinder", "fit_pathfinder", "pathfinder_report"]
+__all__ = [
+    "fit_blackjax_pathfinder",
+    "fit_pathfinder",
+    "fit_streaming_pathfinder",
+    "pathfinder_report",
+]

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -13,24 +13,17 @@ search remains valid, and forms each curvature pair from a **single minibatch**
 
     y_k = grad_{B_k}(x_{k+1}) - grad_{B_k}(x_k)
 
-Both gradients are evaluated on the same batch, so the same noise enters both and
-cancels in the difference. Differencing across two batches leaves it, and ``y`` then
-estimates nothing in particular: the secant condition ``y ~= H s`` needs both gradients
-to be of the *same* objective. Schraudolph et al. give that form as their eq. (13), the
-one that lets sampling noise into the update, and report divergence below batch 1000 on
-their quadratic model.
-
-The sign violation this produces, ``s . y < 0``, is not the common case at the step lengths
-this loop runs at: over logistic and Gaussian trajectories at batches 4 to 512, same-batch
-pairing produced no negative ``s . y`` on any cell, and cross-batch produced 0.3% to 12% of
-steps. It becomes the common case as the step shrinks, because the cross-batch noise term
-scales with ``||s||`` while the curvature term scales with ``||s||^2``; at a fixed point the
-cross-batch rate is about one in two once ``||s||`` is below 1e-2. Pairs still failing the
-curvature condition are skipped, not forced into the history.
-
-Each accepted step records the ``(x, g, alpha, s_win, z_win)`` that
-``make_pathfinder_sample_fn`` consumes, with the window ordered oldest-to-newest
-rather than in the physical ring order ``LBFGSStreamingCallback`` hands on.
+Both gradients are evaluated on the same batch, so the same noise enters both and cancels in
+the difference: the secant condition ``y ~= H s`` needs both gradients to be of the *same*
+objective. Differencing across two batches -- Schraudolph et al.'s eq. (13), for which they
+report divergence below batch 1000 on their quadratic model -- leaves the noise in. Measured
+over logistic and Gaussian trajectories at batches 4 to 512, same-batch pairing produced no
+negative ``s . y`` on any cell and cross-batch produced 0.3% to 12% of steps; the cross-batch
+rate rises to about one in two once ``||s||`` is below 1e-2, its noise term scaling with
+``||s||`` against the curvature term's ``||s||^2``. Pairs still failing the curvature condition
+are skipped, not forced into the history. Each accepted step records the
+``(x, g, alpha, s_win, z_win)`` that ``make_pathfinder_sample_fn`` consumes, with the window
+ordered oldest-to-newest rather than in physical ring order.
 """
 
 from dataclasses import dataclass, field
@@ -148,21 +141,13 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         Number of optimization steps.
     config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
-        Called after each step as ``(approx, losses, i)``, ``pm.fit``'s contract:
-        ``losses`` holds one minibatch objective per step so far and ``i`` counts from 1.
-        One raising ``StopIteration`` ends the run. There is no ``Approximation`` here, so
-        ``approx`` is ``None`` and a callback that inspects it, such as
-        ``pymc.variational.callbacks.CheckParametersConvergence``, cannot be used.
-
-        ``losses[i - 1]`` is the objective at the position step ``i`` reached, evaluated on
-        the batch installed *after* that step -- deliberately not the value that step's
-        Armijo test accepted. The accepted value is measured on the very batch the position
-        was chosen to minimize and so reads low against the full-data objective, while the
-        recorded one is measured on a batch the step never saw. The two differ by a level
-        shift on average only: over the 200 steps of the operating configuration in
-        ``fit_streaming_pathfinder`` the gap averaged +393 with an sd of 1661, so it is not
-        steady step to step and differencing the series does not cancel it.
-        ``test_recorded_loss_is_measured_after_the_batch_advance`` pins the convention.
+        Called after each step as ``(approx, losses, i)``, ``pm.fit``'s contract, with ``i``
+        counting from 1. One raising ``StopIteration`` ends the run. There is no
+        ``Approximation`` here, so ``approx`` is ``None`` and a callback that inspects it, such
+        as ``pymc.variational.callbacks.CheckParametersConvergence``, cannot be used.
+        ``losses[i - 1]`` is measured on the batch installed *after* step ``i``, not on the
+        value that step's Armijo test accepted: over the 200 steps of the operating
+        configuration the gap averaged +393 with an sd of 1661, so it is not a steady offset.
 
     Returns
     -------
@@ -201,9 +186,8 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         for _ in range(config.maxls):
             x_trial = x + t * d
             f_trial, g_trial = value_grad_fn(x_trial)
-            # A finite value is not enough: pymc's Bernoulli(logit_p) gradient divides by
-            # 1 - sigmoid(z), and sigmoid(37.0) == 1.0 in float64, so a saturated trial
-            # point passes Armijo and hands back a NaN gradient that stalls every step after.
+            # pymc's Bernoulli(logit_p) gradient divides by 1 - sigmoid(z), and
+            # sigmoid(37.0) == 1.0 in float64, so a finite f_trial can carry a NaN gradient.
             if (
                 np.isfinite(f_trial)
                 and np.all(np.isfinite(g_trial))
@@ -225,11 +209,8 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
             sy = s @ y
             if s2 < 1e-16:
                 traj.n_null += 1  # stopped moving, which is not a curvature failure
-            # Two floors, and which one binds depends on the step length: at the default
-            # epsilon=1e-8, epsilon * s2 falls below the absolute 1e-16 once ||s|| < 1e-4.
-            # So the absolute floor is what decides short steps and the relative curvature
-            # test is what decides ordinary ones. That absolute floor is the same value
-            # _two_loop_direction re-applies to its strided window views.
+            # Absolute 1e-16 decides short steps (epsilon * s2 drops below it once ||s|| < 1e-4),
+            # relative epsilon * s2 the rest; _two_loop_direction re-applies the same floor.
             elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
                 alpha = alpha_step_numpy(alpha, s, y)
                 win_idx = (win_idx + 1) % J

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -179,7 +179,14 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         for _ in range(config.maxls):
             x_trial = x + t * d
             f_trial, g_trial = value_grad_fn(x_trial)
-            if np.isfinite(f_trial) and f_trial <= f + config.armijo_c1 * t * gd:
+            # A finite value is not enough: pymc's Bernoulli(logit_p) gradient divides by
+            # 1 - sigmoid(z), and sigmoid(37.0) == 1.0 in float64, so a saturated trial
+            # point passes Armijo and hands back a NaN gradient that stalls every step after.
+            if (
+                np.isfinite(f_trial)
+                and np.all(np.isfinite(g_trial))
+                and f_trial <= f + config.armijo_c1 * t * gd
+            ):
                 x_new, g_new = x_trial, g_trial
                 break
             t *= config.backtrack

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -1,0 +1,229 @@
+"""A stochastic L-BFGS trajectory for streaming (minibatch) Pathfinder.
+
+Pathfinder builds a Gaussian approximation at every L-BFGS iterate from the recent
+``(s, y)`` curvature pairs, keeping the best by ELBO. The deterministic Pathfinder
+(``pymc_extras.inference.pathfinder.lbfgs``) delegates the optimization to SciPy's
+``L-BFGS-B``, whose Wolfe line search and convergence tests assume a deterministic
+objective and break under minibatch-noisy gradients.
+
+This module replaces just that optimizer with a stochastic quasi-Newton loop that
+keeps the objective deterministic *within* each step so a plain backtracking line
+search remains valid, and forms each curvature pair from a **single minibatch**
+(Schraudolph, Yu & Günter, 2007):
+
+    y_k = grad_{B_k}(x_{k+1}) - grad_{B_k}(x_k)
+
+Both gradients are evaluated on the same batch, so the minibatch noise cancels in
+the difference (unlike differencing across two batches, which leaves the noise and
+routinely produces ``s . y < 0``). Pairs still failing the curvature condition are
+skipped, not forced into the history.
+
+The trajectory records, at every accepted step, exactly the state the pathfinder
+sampler consumes — ``x, g, alpha, s_win, z_win`` — with the ``(N, J)`` ring-buffer
+layout of ``pymc_extras.inference.pathfinder.lbfgs.LBFGSStreamingCallback`` and the
+diagonal update ``alpha_step_numpy`` from ``bfgs_sample``, so ``streaming_pathfinder``
+can feed each iterate straight into ``make_pathfinder_sample_fn``.
+
+The optimizer loop is pure numpy and testable on analytic objectives; only the
+diagonal update is imported from ``bfgs_sample``.
+"""
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+from pymc_extras.inference.pathfinder.bfgs_sample import alpha_step_numpy
+
+__all__ = ["StochasticLBFGSConfig", "Trajectory", "run_stochastic_lbfgs"]
+
+
+@dataclass(frozen=True)
+class StochasticLBFGSConfig:
+    """Hyperparameters for :func:`run_stochastic_lbfgs`.
+
+    Parameters
+    ----------
+    maxcor : int
+        L-BFGS history size ``J`` (number of curvature pairs retained).
+    init_step : float
+        Initial trial step length for the backtracking line search.
+    backtrack : float
+        Line-search step-shrink factor ``rho`` in ``(0, 1)``.
+    armijo_c1 : float
+        Armijo sufficient-decrease constant.
+    maxls : int
+        Maximum backtracking iterations before the step is declared a failure.
+    epsilon : float
+        A pair is accepted iff ``s . y >= epsilon * (s . s)``.
+    """
+
+    maxcor: int = 6
+    init_step: float = 1.0
+    backtrack: float = 0.5
+    armijo_c1: float = 1e-4
+    maxls: int = 20
+    epsilon: float = 1e-8
+
+
+@dataclass
+class Trajectory:
+    """Recorded output of :func:`run_stochastic_lbfgs`.
+
+    ``iterates`` holds one dict ``{x, g, alpha, s_win, z_win}`` per accepted step —
+    the exact inputs (besides the noise draws ``u``) that
+    ``make_pathfinder_sample_fn`` expects. Counters summarize optimizer health.
+    """
+
+    iterates: list = field(default_factory=list)
+    n_steps: int = 0
+    n_accepted: int = 0
+    n_curvature_violations: int = 0
+    n_null: int = 0
+    n_ls_failures: int = 0
+
+    @property
+    def violation_rate(self):
+        """Curvature-rejection rate among steps that actually moved (target < 20%).
+
+        Null steps (the optimizer has effectively stopped, so ``s`` is below the
+        floor) are excluded — they signal convergence, not a curvature failure.
+        """
+        moved = self.n_accepted + self.n_curvature_violations
+        return self.n_curvature_violations / moved if moved else 0.0
+
+
+def _two_loop_direction(g, alpha, s_win, z_win, order):
+    """L-BFGS two-loop recursion with a diagonal initial inverse-Hessian ``diag(alpha)``.
+
+    ``order`` lists the ring-buffer column indices newest-first.
+    """
+    q = g.copy()
+    coeffs = []
+    for c in order:
+        s_c, y_c = s_win[:, c], z_win[:, c]
+        sy = s_c @ y_c
+        if not np.isfinite(sy) or sy < 1e-16:  # skip a numerically degenerate pair
+            continue
+        rho = 1.0 / sy
+        a = rho * (s_c @ q)
+        q = q - a * y_c
+        coeffs.append((c, rho, a))
+    r = alpha * q  # H0 = diag(alpha)
+    for c, rho, a in reversed(coeffs):
+        s_c, y_c = s_win[:, c], z_win[:, c]
+        b = rho * (y_c @ r)
+        r = r + s_c * (a - b)
+    return -r
+
+
+def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=None):
+    """Run stochastic L-BFGS, recording a Gaussian-ready iterate at each accepted step.
+
+    Parameters
+    ----------
+    value_grad_fn : callable
+        ``x -> (value, gradient)`` on the *currently active* minibatch. The caller
+        owns which batch is active; this loop never changes it except through
+        ``on_batch_advance``.
+    on_batch_advance : callable
+        Zero-argument hook called once at the end of each step, after the step's
+        curvature pair has been formed, to advance the active minibatch. All
+        gradients within a step are therefore on one batch (Schraudolph pairing).
+    x0 : ndarray, shape (N,)
+        Starting position.
+    num_iters : int
+        Number of optimization steps.
+    config : StochasticLBFGSConfig, optional
+
+    Returns
+    -------
+    Trajectory
+    """
+    config = config or StochasticLBFGSConfig()
+    J = config.maxcor
+    x = np.asarray(x0, dtype=np.float64).copy()
+    N = x.shape[0]
+
+    s_win = np.zeros((N, J))
+    z_win = np.zeros((N, J))
+    win_idx = -1
+    n_valid = 0
+    alpha = np.ones(N)
+
+    traj = Trajectory()
+    f, g = value_grad_fn(x)
+
+    for _ in range(num_iters):
+        traj.n_steps += 1
+
+        if n_valid == 0:
+            d = -alpha * g
+        else:
+            order = [(win_idx - k) % J for k in range(n_valid)]
+            d = _two_loop_direction(g, alpha, s_win, z_win, order)
+
+        gd = g @ d
+        if not np.isfinite(gd) or gd >= 0:  # not a descent direction
+            d = -g
+            gd = g @ d
+
+        # Backtracking Armijo line search on the *fixed* current batch.
+        t = config.init_step
+        f_new, x_new, g_new = f, x, g
+        ls_ok = False
+        for _ls in range(config.maxls):
+            x_trial = x + t * d
+            f_trial = value_grad_fn(x_trial)[0]
+            if np.isfinite(f_trial) and f_trial <= f + config.armijo_c1 * t * gd:
+                f_new, x_new = f_trial, x_trial
+                g_new = value_grad_fn(x_new)[1]
+                ls_ok = True
+                break
+            t *= config.backtrack
+        if not ls_ok:
+            traj.n_ls_failures += 1
+            # A failed line search gives no trusted step: never force an untested
+            # move into the curvature history (that both pollutes the L-BFGS memory
+            # and lets violation_rate read 0% on a stuck run). Hold x, advance the
+            # batch, and try again on fresh data.
+            on_batch_advance()
+            f, g = value_grad_fn(x)
+            continue
+
+        s = x_new - x
+        y = g_new - g
+        s2 = s @ s
+        sy = s @ y
+
+        if s2 < 1e-16:
+            # Null step: the optimizer has effectively stopped moving. Not a
+            # curvature failure; just don't extend the history.
+            traj.n_null += 1
+        elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
+            alpha = alpha_step_numpy(alpha, s, y)
+            win_idx = (win_idx + 1) % J
+            s_win[:, win_idx] = s
+            z_win[:, win_idx] = y
+            n_valid = min(n_valid + 1, J)
+            traj.n_accepted += 1
+            # The sampler reads the window as a chronological sequence and has no
+            # ring index, so hand it oldest-to-newest. Before the ring wraps the
+            # physical layout already is that, with the unused columns last.
+            shift = -(win_idx + 1) % J if n_valid == J else 0
+            traj.iterates.append(
+                {
+                    "x": x_new.copy(),
+                    "g": g_new.copy(),
+                    "alpha": alpha.copy(),
+                    "s_win": np.roll(s_win, shift, axis=1),
+                    "z_win": np.roll(z_win, shift, axis=1),
+                }
+            )
+        else:
+            traj.n_curvature_violations += 1
+
+        x, f, g = x_new, f_new, g_new
+        on_batch_advance()
+        f, g = value_grad_fn(x)  # re-evaluate on the freshly advanced batch
+
+    return traj

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -18,14 +18,9 @@ the difference (unlike differencing across two batches, which leaves the noise a
 routinely produces ``s . y < 0``). Pairs still failing the curvature condition are
 skipped, not forced into the history.
 
-The trajectory records, at every accepted step, exactly the state the pathfinder
-sampler consumes — ``x, g, alpha, s_win, z_win`` — with the ``(N, J)`` ring-buffer
-layout of ``pymc_extras.inference.pathfinder.lbfgs.LBFGSStreamingCallback`` and the
-diagonal update ``alpha_step_numpy`` from ``bfgs_sample``, so ``streaming_pathfinder``
-can feed each iterate straight into ``make_pathfinder_sample_fn``.
-
-The optimizer loop is pure numpy and testable on analytic objectives; only the
-diagonal update is imported from ``bfgs_sample``.
+Each accepted step records the ``(x, g, alpha, s_win, z_win)`` that
+``make_pathfinder_sample_fn`` consumes, with the window ordered oldest-to-newest
+rather than in the physical ring order ``LBFGSStreamingCallback`` hands on.
 """
 
 from dataclasses import dataclass, field
@@ -64,6 +59,14 @@ class StochasticLBFGSConfig:
     maxls: int = 20
     epsilon: float = 1e-8
 
+    def __post_init__(self):
+        # A backtrack outside (0, 1) flips the step direction, which makes the Armijo
+        # bound trivially true: the run then climbs with every counter reading healthy.
+        if not 0.0 < self.backtrack < 1.0:
+            raise ValueError(f"backtrack must be in (0, 1), got {self.backtrack}")
+        if self.maxcor < 1 or self.maxls < 1:
+            raise ValueError(f"maxcor and maxls must be >= 1, got {self.maxcor}, {self.maxls}")
+
 
 @dataclass
 class Trajectory:
@@ -75,7 +78,6 @@ class Trajectory:
     """
 
     iterates: list = field(default_factory=list)
-    n_steps: int = 0
     n_accepted: int = 0
     n_curvature_violations: int = 0
     n_null: int = 0
@@ -83,11 +85,8 @@ class Trajectory:
 
     @property
     def violation_rate(self):
-        """Curvature-rejection rate among steps that actually moved (target < 20%).
-
-        Null steps (the optimizer has effectively stopped, so ``s`` is below the
-        floor) are excluded — they signal convergence, not a curvature failure.
-        """
+        """Curvature-rejection rate among steps that moved. Null steps are excluded:
+        they signal convergence, not a curvature failure."""
         moved = self.n_accepted + self.n_curvature_violations
         return self.n_curvature_violations / moved if moved else 0.0
 
@@ -102,7 +101,9 @@ def _two_loop_direction(g, alpha, s_win, z_win, order):
     for c in order:
         s_c, y_c = s_win[:, c], z_win[:, c]
         sy = s_c @ y_c
-        if not np.isfinite(sy) or sy < 1e-16:  # skip a numerically degenerate pair
+        # s_win columns are strided views, so sy can differ in the last ulp from the
+        # value that passed the acceptance test; rho = 1 / sy must not see a zero.
+        if not np.isfinite(sy) or sy < 1e-16:
             continue
         rho = 1.0 / sy
         a = rho * (s_c @ q)
@@ -116,7 +117,7 @@ def _two_loop_direction(g, alpha, s_win, z_win, order):
     return -r
 
 
-def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=None):
+def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=None, callbacks=()):
     """Run stochastic L-BFGS, recording a Gaussian-ready iterate at each accepted step.
 
     Parameters
@@ -134,6 +135,10 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
     num_iters : int
         Number of optimization steps.
     config : StochasticLBFGSConfig, optional
+    callbacks : iterable of callable, optional
+        Called as ``(approx, losses, i)`` after each step with the minibatch objective,
+        matching ``pm.fit``'s contract; one raising ``StopIteration`` ends the run.
+        There is no ``Approximation`` here, so ``approx`` is ``None``.
 
     Returns
     -------
@@ -153,9 +158,7 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
     traj = Trajectory()
     f, g = value_grad_fn(x)
 
-    for _ in range(num_iters):
-        traj.n_steps += 1
-
+    for i in range(num_iters):
         if n_valid == 0:
             d = -alpha * g
         else:
@@ -169,61 +172,59 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
 
         # Backtracking Armijo line search on the *fixed* current batch.
         t = config.init_step
-        f_new, x_new, g_new = f, x, g
-        ls_ok = False
-        for _ls in range(config.maxls):
+        x_new = g_new = None
+        for _ in range(config.maxls):
             x_trial = x + t * d
-            f_trial = value_grad_fn(x_trial)[0]
+            f_trial, g_trial = value_grad_fn(x_trial)
             if np.isfinite(f_trial) and f_trial <= f + config.armijo_c1 * t * gd:
-                f_new, x_new = f_trial, x_trial
-                g_new = value_grad_fn(x_new)[1]
-                ls_ok = True
+                x_new, g_new = x_trial, g_trial
                 break
             t *= config.backtrack
-        if not ls_ok:
+
+        if x_new is None:
+            # A failed line search gives no trusted step: forcing an untested move into
+            # the history pollutes the L-BFGS memory and lets violation_rate read 0% on
+            # a stuck run. Hold x and retry on fresh data.
             traj.n_ls_failures += 1
-            # A failed line search gives no trusted step: never force an untested
-            # move into the curvature history (that both pollutes the L-BFGS memory
-            # and lets violation_rate read 0% on a stuck run). Hold x, advance the
-            # batch, and try again on fresh data.
-            on_batch_advance()
-            f, g = value_grad_fn(x)
-            continue
-
-        s = x_new - x
-        y = g_new - g
-        s2 = s @ s
-        sy = s @ y
-
-        if s2 < 1e-16:
-            # Null step: the optimizer has effectively stopped moving. Not a
-            # curvature failure; just don't extend the history.
-            traj.n_null += 1
-        elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
-            alpha = alpha_step_numpy(alpha, s, y)
-            win_idx = (win_idx + 1) % J
-            s_win[:, win_idx] = s
-            z_win[:, win_idx] = y
-            n_valid = min(n_valid + 1, J)
-            traj.n_accepted += 1
-            # The sampler reads the window as a chronological sequence and has no
-            # ring index, so hand it oldest-to-newest. Before the ring wraps the
-            # physical layout already is that, with the unused columns last.
-            shift = -(win_idx + 1) % J if n_valid == J else 0
-            traj.iterates.append(
-                {
-                    "x": x_new.copy(),
-                    "g": g_new.copy(),
-                    "alpha": alpha.copy(),
-                    "s_win": np.roll(s_win, shift, axis=1),
-                    "z_win": np.roll(z_win, shift, axis=1),
-                }
-            )
         else:
-            traj.n_curvature_violations += 1
+            s = x_new - x
+            y = g_new - g
+            s2 = s @ s
+            sy = s @ y
+            if s2 < 1e-16:
+                traj.n_null += 1  # stopped moving, which is not a curvature failure
+            # 1e-16 keeps rho = 1 / sy finite, epsilon tests curvature scale-free
+            elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
+                alpha = alpha_step_numpy(alpha, s, y)
+                win_idx = (win_idx + 1) % J
+                s_win[:, win_idx] = s
+                z_win[:, win_idx] = y
+                n_valid = min(n_valid + 1, J)
+                traj.n_accepted += 1
+                # bfgs_sample reads E = triu(S.T @ Z), which is the textbook recursion
+                # only when the columns run oldest-to-newest; the roll puts the oldest
+                # resident pair first. An unfilled ring already reads that way.
+                shift = -(win_idx + 1) % J if n_valid == J else 0
+                traj.iterates.append(
+                    {
+                        "x": x_new.copy(),
+                        "g": g_new.copy(),
+                        "alpha": alpha.copy(),
+                        "s_win": np.roll(s_win, shift, axis=1),
+                        "z_win": np.roll(z_win, shift, axis=1),
+                    }
+                )
+            else:
+                traj.n_curvature_violations += 1
+            x = x_new
 
-        x, f, g = x_new, f_new, g_new
         on_batch_advance()
-        f, g = value_grad_fn(x)  # re-evaluate on the freshly advanced batch
+        f, g = value_grad_fn(x)  # f must be on the batch the next Armijo test uses
+
+        try:
+            for cb in callbacks:
+                cb(None, [f], i + 1)
+        except StopIteration:
+            break
 
     return traj

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -15,15 +15,12 @@ search remains valid, and forms each curvature pair from a **single minibatch**
 
 Both gradients are evaluated on the same batch, so the same noise enters both and cancels in
 the difference: the secant condition ``y ~= H s`` needs both gradients to be of the *same*
-objective. Differencing across two batches -- Schraudolph et al.'s eq. (13), for which they
-report divergence below batch 1000 on their quadratic model -- leaves the noise in. Measured
-over logistic and Gaussian trajectories at batches 4 to 512, same-batch pairing produced no
-negative ``s . y`` on any cell and cross-batch produced 0.3% to 12% of steps; the cross-batch
-rate rises to about one in two once ``||s||`` is below 1e-2, its noise term scaling with
-``||s||`` against the curvature term's ``||s||^2``. Pairs still failing the curvature condition
-are skipped, not forced into the history. Each accepted step records the
-``(x, g, alpha, s_win, z_win)`` that ``make_pathfinder_sample_fn`` consumes, with the window
-ordered oldest-to-newest rather than in physical ring order.
+objective. Differencing across batches (Schraudolph et al.'s eq. (13), for which they report
+divergence) leaves the noise in, and its violation rate grows as the iterates settle, since
+the noise term scales with ``||s||`` against the curvature term's ``||s||^2``. Pairs failing
+the curvature condition are skipped, not forced into the history. Each accepted step records
+the ``(x, g, alpha, s_win, z_win)`` that ``make_pathfinder_sample_fn`` consumes, with the
+window ordered oldest-to-newest rather than in physical ring order.
 """
 
 from dataclasses import dataclass, field
@@ -146,8 +143,7 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         ``Approximation`` here, so ``approx`` is ``None`` and a callback that inspects it, such
         as ``pymc.variational.callbacks.CheckParametersConvergence``, cannot be used.
         ``losses[i - 1]`` is measured on the batch installed *after* step ``i``, not on the
-        value that step's Armijo test accepted: over the 200 steps of the operating
-        configuration the gap averaged +393 with an sd of 1661, so it is not a steady offset.
+        value that step's Armijo test accepted.
 
     Returns
     -------

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -13,10 +13,20 @@ search remains valid, and forms each curvature pair from a **single minibatch**
 
     y_k = grad_{B_k}(x_{k+1}) - grad_{B_k}(x_k)
 
-Both gradients are evaluated on the same batch, so the minibatch noise cancels in
-the difference (unlike differencing across two batches, which leaves the noise and
-routinely produces ``s . y < 0``). Pairs still failing the curvature condition are
-skipped, not forced into the history.
+Both gradients are evaluated on the same batch, so the same noise enters both and
+cancels in the difference. Differencing across two batches leaves it, and ``y`` then
+estimates nothing in particular: the secant condition ``y ~= H s`` needs both gradients
+to be of the *same* objective. Schraudolph et al. give that form as their eq. (13), the
+one that lets sampling noise into the update, and report divergence below batch 1000 on
+their quadratic model.
+
+The sign violation this produces, ``s . y < 0``, is not the common case at the step lengths
+this loop runs at: over logistic and Gaussian trajectories at batches 4 to 512, same-batch
+pairing produced no negative ``s . y`` on any cell, and cross-batch produced 0.3% to 12% of
+steps. It becomes the common case as the step shrinks, because the cross-batch noise term
+scales with ``||s||`` while the curvature term scales with ``||s||^2``; at a fixed point the
+cross-batch rate is about one in two once ``||s||`` is below 1e-2. Pairs still failing the
+curvature condition are skipped, not forced into the history.
 
 Each accepted step records the ``(x, g, alpha, s_win, z_win)`` that
 ``make_pathfinder_sample_fn`` consumes, with the window ordered oldest-to-newest
@@ -148,10 +158,10 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         the batch installed *after* that step -- deliberately not the value that step's
         Armijo test accepted. The accepted value is measured on the very batch the position
         was chosen to minimize and so reads low against the full-data objective, while the
-        recorded one is measured on a batch the step never saw. The offset between the two
-        is close to constant along a run, so a monitor that differences the series, such as
-        ``pymc.variational.callbacks.CheckLossConvergence``, is largely insensitive to the
-        choice; what changes is the level the series reports.
+        recorded one is measured on a batch the step never saw. The two differ by a level
+        shift on average only: over the 200 steps of the operating configuration in
+        ``fit_streaming_pathfinder`` the gap averaged +393 with an sd of 1661, so it is not
+        steady step to step and differencing the series does not cancel it.
         ``test_recorded_loss_is_measured_after_the_batch_advance`` pins the convention.
 
     Returns
@@ -215,8 +225,11 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
             sy = s @ y
             if s2 < 1e-16:
                 traj.n_null += 1  # stopped moving, which is not a curvature failure
-            # epsilon scales with s . s, so on a near-null step it admits pairs the
-            # two-loop then drops on its own sy floor, costing a history column.
+            # Two floors, and which one binds depends on the step length: at the default
+            # epsilon=1e-8, epsilon * s2 falls below the absolute 1e-16 once ||s|| < 1e-4.
+            # So the absolute floor is what decides short steps and the relative curvature
+            # test is what decides ordinary ones. That absolute floor is the same value
+            # _two_loop_direction re-applies to its strided window views.
             elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
                 alpha = alpha_step_numpy(alpha, s, y)
                 win_idx = (win_idx + 1) % J

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -136,9 +136,11 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         Number of optimization steps.
     config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
-        Called as ``(approx, losses, i)`` after each step with the minibatch objective,
-        matching ``pm.fit``'s contract; one raising ``StopIteration`` ends the run.
-        There is no ``Approximation`` here, so ``approx`` is ``None``.
+        Called after each step as ``(approx, losses, i)``, ``pm.fit``'s contract:
+        ``losses`` holds every minibatch objective so far and ``i`` counts from 1. One
+        raising ``StopIteration`` ends the run. There is no ``Approximation`` here, so
+        ``approx`` is ``None`` and a callback that inspects it, such as
+        ``pymc.variational.callbacks.CheckParametersConvergence``, cannot be used.
 
     Returns
     -------
@@ -156,6 +158,7 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
     alpha = np.ones(N)
 
     traj = Trajectory()
+    losses = []
     f, g = value_grad_fn(x)
 
     for i in range(num_iters):
@@ -193,7 +196,8 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
             sy = s @ y
             if s2 < 1e-16:
                 traj.n_null += 1  # stopped moving, which is not a curvature failure
-            # 1e-16 keeps rho = 1 / sy finite, epsilon tests curvature scale-free
+            # epsilon scales with s . s, so on a near-null step it admits pairs the
+            # two-loop then drops on its own sy floor, costing a history column.
             elif np.isfinite(sy) and sy > 1e-16 and sy >= config.epsilon * s2:
                 alpha = alpha_step_numpy(alpha, s, y)
                 win_idx = (win_idx + 1) % J
@@ -221,9 +225,10 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
         on_batch_advance()
         f, g = value_grad_fn(x)  # f must be on the batch the next Armijo test uses
 
+        losses.append(f)
         try:
             for cb in callbacks:
-                cb(None, [f], i + 1)
+                cb(None, losses, i + 1)
         except StopIteration:
             break
 

--- a/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
+++ b/pymc_extras/inference/pathfinder/stochastic_lbfgs.py
@@ -64,8 +64,10 @@ class StochasticLBFGSConfig:
         # bound trivially true: the run then climbs with every counter reading healthy.
         if not 0.0 < self.backtrack < 1.0:
             raise ValueError(f"backtrack must be in (0, 1), got {self.backtrack}")
-        if self.maxcor < 1 or self.maxls < 1:
-            raise ValueError(f"maxcor and maxls must be >= 1, got {self.maxcor}, {self.maxls}")
+        if self.maxcor < 1:
+            raise ValueError(f"maxcor must be >= 1, got {self.maxcor}")
+        if self.maxls < 1:
+            raise ValueError(f"maxls must be >= 1, got {self.maxls}")
 
 
 @dataclass
@@ -137,10 +139,20 @@ def run_stochastic_lbfgs(value_grad_fn, on_batch_advance, x0, num_iters, config=
     config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         Called after each step as ``(approx, losses, i)``, ``pm.fit``'s contract:
-        ``losses`` holds every minibatch objective so far and ``i`` counts from 1. One
-        raising ``StopIteration`` ends the run. There is no ``Approximation`` here, so
+        ``losses`` holds one minibatch objective per step so far and ``i`` counts from 1.
+        One raising ``StopIteration`` ends the run. There is no ``Approximation`` here, so
         ``approx`` is ``None`` and a callback that inspects it, such as
         ``pymc.variational.callbacks.CheckParametersConvergence``, cannot be used.
+
+        ``losses[i - 1]`` is the objective at the position step ``i`` reached, evaluated on
+        the batch installed *after* that step -- deliberately not the value that step's
+        Armijo test accepted. The accepted value is measured on the very batch the position
+        was chosen to minimize and so reads low against the full-data objective, while the
+        recorded one is measured on a batch the step never saw. The offset between the two
+        is close to constant along a run, so a monitor that differences the series, such as
+        ``pymc.variational.callbacks.CheckLossConvergence``, is largely insensitive to the
+        choice; what changes is the level the series reports.
+        ``test_recorded_loss_is_measured_after_the_batch_advance`` pins the convention.
 
     Returns
     -------

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -191,10 +191,8 @@ def fit_streaming_pathfinder(
         Post-hoc reweighting of the returned draws; ``None`` returns the proposal
         draws unweighted. ``"identity"`` weights by the raw log ratio, so like
         ``"psis"``/``"psir"`` it resamples from a larger pool. At the Notes configuration
-        (k=8, N=1e5, three seeds) the 4000-draw pool carried a raw-weight effective sample
-        size of 449-1762, so the weights inform the resampling rather than collapsing onto
-        a few draws; it cost 3.4-3.7x the wall clock of ``None``, which draws a pool of
-        ``num_draws`` only.
+        it cost 3.4-3.7x the wall clock of ``None``, which draws a pool of ``num_draws``
+        only.
     lbfgs_config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
@@ -209,10 +207,12 @@ def fit_streaming_pathfinder(
 
     Notes
     -----
-    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048,
-    ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``, ``num_draws=1000``,
-    ``num_proposal_draws=4000``, PSIS, against an exact full-data Laplace reference. With
-    k=8 coefficients, worst-coordinate error in reference-sd:
+    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048
+    from a *shuffled* loader, ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``,
+    ``num_draws=1000``, ``num_proposal_draws=4000``, PSIS, against an exact full-data
+    Laplace reference. Shuffling is part of the configuration, not a detail: an unshuffled
+    loader replays the same rows in the same order every epoch, and the table below was not
+    measured that way. With k=8 coefficients, worst-coordinate error in reference-sd:
 
     ====== ===================== =========================
     N      ``pareto_k``          worst coordinate (ref-sd)
@@ -299,12 +299,17 @@ def fit_streaming_pathfinder(
 
     # Polyak-Ruppert tail averaging of the iterate positions. Each stochastic L-BFGS step is
     # a full quasi-Newton step plus line search on ONE minibatch, so its accepted point is
-    # essentially that minibatch's MAP: ~sqrt(N / b) full-data posterior-sd off the true MAP
-    # (measured ratio 0.971 over 27 runs), while the same batch pins the posterior sd to
-    # within 1-2%. That makes it a location error, not a covariance one, which is why no rule
-    # that *picks* an iterate can fix it. g is zeroed because the sampler centres the Gaussian
-    # at mu = x - H_inv @ g; keeping the last iterate's gradient costs 2.0-6.6x. Curvature
-    # stays from the last iterate: averaged (s, z) pairs are not a valid L-BFGS memory.
+    # essentially that minibatch's MAP. Newton on 9 batches per size at the Notes k=8, N=1e5
+    # data puts that MAP about sqrt(N / b) full-data posterior-sd away in per-coordinate RMS
+    # (measured / sqrt(N / b) = 0.82, 0.92, 0.75 at b = 512, 2048, 8192; the max-coordinate
+    # norm is ~2x that, so the norm has to be named), while the same batch reproduces the
+    # posterior sd to a few percent (median over coordinates and runs 3.5%, 2.1%, 0.7%; worst
+    # coordinate 8.5%, 3.7%, 1.9%). The damage is in the location, not the covariance, which
+    # is why no rule that *picks* an iterate can fix it.
+    # g is zeroed because the sampler centres the Gaussian at mu = x - H_inv @ g; keeping the
+    # last iterate's gradient moved that centre 1.6-7.3x further from the full-data MAP over
+    # 12 seeds, worse on every one (worst coordinate, reference-sd). Curvature stays from the
+    # last iterate: averaged (s, z) pairs are not a valid L-BFGS memory.
     # Ruppert 1988 (Cornell ORIE TR-781); Polyak & Juditsky 1992, SIAM J. Control Optim.
     # 30(4):838-855; Jain et al., JMLR 18(223), 2018 (tail averaging the last c*n iterates);
     # Mandt, Hoffman & Blei, JMLR 18(134), 2017; Dhaka et al., NeurIPS 2020 and Welandawe

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -14,8 +14,10 @@ unchanged from the deterministic Pathfinder (``bfgs_sample``, ``importance_sampl
 The draws it returns are a proposal, not a posterior; the measured operating range, in both
 dataset size and dimension, is on :func:`fit_streaming_pathfinder`.
 
-What streaming does buy is memory: 6.4x less resident memory than ``fit_pathfinder`` at
-N=4e5 and 11.4x at N=1.6e6, at comparable wall clock for a matched proposal pool.
+What streaming buys is memory: the optimizer only ever holds one minibatch, and the final
+exact ``logP`` is accumulated block by block over ``full_pass``, so nothing here is sized by
+the row count. ``fit_pathfinder`` materializes the whole dataset instead. No ratio is quoted
+because the earlier one did not say what it measured.
 """
 
 from dataclasses import dataclass
@@ -44,8 +46,13 @@ from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
 __all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
 
 # Fraction of the trajectory's iterate positions that the tail average covers. Not a
-# keyword: 0.50 and 0.75 are indistinguishable and the 0.50-0.90 basin is flat, so the
-# only thing a user could learn from the knob is that 1.00 is broken.
+# keyword. Swept over one trajectory per seed at the Notes k=8, N=1e5 configuration, 8 seeds,
+# scoring worst-coordinate |x_avg - full-data MAP| in reference-sd: the medians over
+# 0.50/0.60/0.75/0.90 are 0.86/0.80/0.68/0.80, a spread of 1.26x, while 1.00 is 5.06 (7.4x the
+# best) and 0.10 is 3.17. So the interior is shallow and the endpoint is the cliff. 0.50 vs
+# 0.75 paired per seed differs by +0.13 ref-sd (95% CI -0.05 to +0.31), which 8 seeds do not
+# resolve; 0.75 is the better point estimate and the only thing the knob reliably teaches is
+# that 1.00 is broken.
 _TAIL_AVERAGE_FRAC = 0.75
 
 
@@ -167,8 +174,9 @@ def fit_streaming_pathfinder(
         Defaults to ``4 * num_draws`` when resampling, matching ``fit_pathfinder``'s
         ``num_paths=4`` x ``num_draws_per_path=1000`` pool, and to ``num_draws`` when
         ``importance_sampling=None``. The pool's exact full-data ``logP`` is one
-        O(``num_proposal_draws`` x N) pass and was 85-94% of wall clock at N=1e5, so this
-        setting is very nearly the cost of the fit.
+        O(``num_proposal_draws`` x N) pass, against an optimizer that only ever touches
+        ``num_iters`` x batch rows, so on any large dataset this setting dominates the cost
+        of the fit.
     full_pass : iterable, optional
         An iterable of row blocks visiting every row exactly once, for the final exact
         full-data ``logP``; consumed once. Defaults to iterating ``loader``, which is
@@ -190,9 +198,8 @@ def fit_streaming_pathfinder(
     importance_sampling : {"psis", "psir", "identity", None}
         Post-hoc reweighting of the returned draws; ``None`` returns the proposal
         draws unweighted. ``"identity"`` weights by the raw log ratio, so like
-        ``"psis"``/``"psir"`` it resamples from a larger pool. At the Notes configuration
-        it cost 3.4-3.7x the wall clock of ``None``, which draws a pool of ``num_draws``
-        only.
+        ``"psis"``/``"psir"`` it resamples from a 4x pool, so it pays the ``logP`` pass on
+        four times as many draws as ``None``, which draws ``num_draws`` only.
     lbfgs_config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
@@ -207,34 +214,21 @@ def fit_streaming_pathfinder(
 
     Notes
     -----
-    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048
-    from a *shuffled* loader, ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``,
-    ``num_draws=1000``, ``num_proposal_draws=4000``, PSIS, against an exact full-data
-    Laplace reference. Shuffling is part of the configuration, not a detail: an unshuffled
-    loader replays the same rows in the same order every epoch, and the table below was not
-    measured that way. With k=8 coefficients, worst-coordinate error in reference-sd:
+    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048 from
+    a *shuffled* loader, ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``, ``num_draws=1000``,
+    ``num_proposal_draws=4000``, PSIS, scored against an exact full-data Laplace reference.
+    Shuffling is part of the configuration: an unshuffled loader replays the same rows in the
+    same order every epoch, and none of this was measured that way.
 
-    ====== ===================== =========================
-    N      ``pareto_k``          worst coordinate (ref-sd)
-    ====== ===================== =========================
-    1e5    0.31-0.80 (med 0.69)  0.17-0.58
-    4e5    0.80-0.91 (med 0.87)  1.07-1.56
-    1.6e6  2.05-2.56 (med 2.52)  2.91-4.35
-    ====== ===================== =========================
+    With k=8 at N=1e5, over 12 seeds, ``pareto_k`` ran 0.60-0.80 (median 0.70, over 0.7 on half
+    of them) and the worst posterior-mean coordinate was 0.23-0.58 reference-sd out. Accuracy
+    degrades with N -- ``pareto_k`` 0.76-1.29 and error 0.53-2.24 ref-sd over 6 seeds at N=4e5 --
+    and much faster with dimension: at k=100, N=1e5 it was 2.0-3.8 and 13-64 ref-sd over 4 seeds,
+    and nothing raises, so that fit returns silently wrong draws.
 
-    On the same trajectories before tail averaging, N=1e5 gave ``pareto_k`` 5.80-7.00 and
-    9.71-11.13 ref-sd. But ``pareto_k`` still exceeds 0.7 on 6 of 12 seeds at N=1e5 and on
-    5 of 6 at N=4e5, so read it on every fit: these draws remain a *proposal*, not a
-    posterior, and in the large-N regime that gap is not small.
-
-    The range is in ``k`` as much as in ``N``. At k=100 the tail-averaged ``pareto_k`` is
-    2.2-4.5 and the error 4.6-17.4 ref-sd — unusable, and worse, quiet: with the
-    line-search gradient-finiteness guard the k=100 case no longer raises, it returns a
-    silently wrong posterior. Do not run this above a few tens of dimensions without
-    checking ``pareto_k``.
-
-    Averaging buys a level, not an exponent: the gap still grows roughly 3x per 4x in N.
-    ``violation_rate`` is an optimizer-health counter and read 0.0 on all of these runs.
+    These draws are a *proposal*, not a posterior. Read ``pareto_k`` on every fit, and do not run
+    this above a few tens of dimensions. ``violation_rate`` is an optimizer-health counter, not
+    an accuracy one; it read 0.0 with no line-search failures on every run above.
     """
     model = pm.modelcontext(model)
     if batch_var not in model.named_vars:
@@ -297,24 +291,14 @@ def fit_streaming_pathfinder(
             "smaller jitter, or a larger batch size."
         )
 
-    # Polyak-Ruppert tail averaging of the iterate positions. Each stochastic L-BFGS step is
-    # a full quasi-Newton step plus line search on ONE minibatch, so its accepted point is
-    # essentially that minibatch's MAP. Newton on 9 batches per size at the Notes k=8, N=1e5
-    # data puts that MAP about sqrt(N / b) full-data posterior-sd away in per-coordinate RMS
-    # (measured / sqrt(N / b) = 0.82, 0.92, 0.75 at b = 512, 2048, 8192; the max-coordinate
-    # norm is ~2x that, so the norm has to be named), while the same batch reproduces the
-    # posterior sd to a few percent (median over coordinates and runs 3.5%, 2.1%, 0.7%; worst
-    # coordinate 8.5%, 3.7%, 1.9%). The damage is in the location, not the covariance, which
-    # is why no rule that *picks* an iterate can fix it.
-    # g is zeroed because the sampler centres the Gaussian at mu = x - H_inv @ g; keeping the
-    # last iterate's gradient moved that centre 1.6-7.3x further from the full-data MAP over
-    # 12 seeds, worse on every one (worst coordinate, reference-sd). Curvature stays from the
-    # last iterate: averaged (s, z) pairs are not a valid L-BFGS memory.
-    # Ruppert 1988 (Cornell ORIE TR-781); Polyak & Juditsky 1992, SIAM J. Control Optim.
-    # 30(4):838-855; Jain et al., JMLR 18(223), 2018 (tail averaging the last c*n iterates);
-    # Mandt, Hoffman & Blei, JMLR 18(134), 2017; Dhaka et al., NeurIPS 2020 and Welandawe
-    # et al., JMLR 25(219), 2024 (iterate averaging in VI); Byrd, Hansen, Nocedal & Singer,
-    # SIAM J. Optim. 26(2):1008-1031, 2016 (averaged iterates inside stochastic L-BFGS).
+    # Polyak-Ruppert tail averaging of the iterate positions (Polyak & Juditsky 1992; Jain
+    # et al. 2018). Each step is a full quasi-Newton step plus line search on ONE minibatch, so
+    # its accepted point sits near that minibatch's MAP: measured roughly sqrt(N / b) full-data
+    # posterior-sd away in per-coordinate RMS, on a batch that still reproduces the posterior sd
+    # to within ~10%. The error is in the location, not the covariance, so no rule that *picks*
+    # an iterate removes it. g is zeroed because the sampler centres at mu = x - H_inv @ g, and
+    # keeping the last iterate's g moved that centre further from the full-data MAP on all of
+    # 12 seeds; curvature stays the last iterate's -- averaged (s, z) is not a valid memory.
     m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))
     x_avg = np.mean([it["x"] for it in traj.iterates[-m:]], axis=0)
     last = traj.iterates[-1]

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -6,18 +6,13 @@ data in a ``pm.Data`` placeholder scaled with ``total_size=len(loader)``, so
 ``model.logp()`` already returns the correctly rescaled full-data log-density for
 whatever batch is currently set.
 
-The optimizer core is :func:`run_stochastic_lbfgs`; its stored iterates are scored
-against one fixed evaluation batch with shared Monte-Carlo draws, so the ELBO argmax is
-a paired comparison rather than a lottery over batches, and the winner is then drawn at
-full width and importance-resampled against the exact full-data ``logP``. The compiled
-log-density, Gaussian sampler and PSIS are reused unchanged from the deterministic
-Pathfinder (``bfgs_sample``, ``importance_sampling``).
+The optimizer core is :func:`run_stochastic_lbfgs`. Its iterate positions are tail-averaged
+into a single point, which is then drawn at full width and importance-resampled against the
+exact full-data ``logP``. The compiled log-density, Gaussian sampler and PSIS are reused
+unchanged from the deterministic Pathfinder (``bfgs_sample``, ``importance_sampling``).
 
-The draws it returns are a proposal, not a posterior; the measured operating range is on
-:func:`fit_streaming_pathfinder`. Two causes of the gap are known and neither is fixed
-here: the stochastic trajectory never approaches the MAP as closely as the deterministic
-one, and each iterate's stored gradient is one rescaled minibatch gradient whose noise
-lands directly in the Gaussian mean.
+The draws it returns are a proposal, not a posterior; the measured operating range, in both
+dataset size and dimension, is on :func:`fit_streaming_pathfinder`.
 
 What streaming does buy is memory: 6.4x less resident memory than ``fit_pathfinder`` at
 N=4e5 and 11.4x at N=1.6e6, at comparable wall clock for a matched proposal pool.
@@ -48,6 +43,11 @@ from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
 
 __all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
 
+# Fraction of the trajectory's iterate positions that the tail average covers. Not a
+# keyword: 0.50 and 0.75 are indistinguishable and the 0.50-0.90 basin is flat, so the
+# only thing a user could learn from the knob is that 1.00 is broken.
+_TAIL_AVERAGE_FRAC = 0.75
+
 
 @dataclass
 class StreamingPathfinderResult:
@@ -64,10 +64,6 @@ class StreamingPathfinderResult:
         resampling and are row-aligned with ``samples`` only when importance sampling
         is off (``None``); after resampling they are proposal-space diagnostics, not
         per-``samples``-row densities.
-    elbo_trace : ndarray
-        ELBO of every stored iterate, evaluated on the shared evaluation batch.
-    elbo_argmax : int
-        Index of the selected iterate within ``elbo_trace``.
     pareto_k : float or None
         PSIS Pareto shape diagnostic (None when importance sampling is disabled).
     violation_rate : float
@@ -81,23 +77,9 @@ class StreamingPathfinderResult:
     samples: np.ndarray
     logP: np.ndarray
     logQ: np.ndarray
-    elbo_trace: np.ndarray
-    elbo_argmax: int
     pareto_k: float | None
     violation_rate: float
     n_ls_failures: int
-
-
-def _elbo(logP, logQ):
-    """Mean ELBO over the draws, matching upstream ``LBFGSStreamingCallback``.
-
-    A single draw with non-finite ``logP`` (proposal mass where the target has zero
-    density) collapses the estimate to ``-inf`` rather than being dropped, so a
-    support-violating iterate cannot outscore a valid one.
-    """
-    logP_safe = np.where(np.isfinite(logP), np.asarray(logP), -np.inf)
-    elbo = float(np.mean(logP_safe - np.asarray(logQ)))
-    return elbo if np.isfinite(elbo) else -np.inf
 
 
 def _compile_batched_logp(model, terms, jacobian):
@@ -154,10 +136,8 @@ def fit_streaming_pathfinder(
     *,
     batch_var="batch",
     num_iters=200,
-    num_elbo_draws=10,
     num_draws=1000,
     num_proposal_draws=None,
-    eval_rows=2000,
     full_pass=None,
     jitter=2.0,
     jacobian_correction=True,
@@ -180,8 +160,6 @@ def fit_streaming_pathfinder(
         Name of the ``pm.Data`` placeholder to stream into.
     num_iters : int
         Number of stochastic L-BFGS steps.
-    num_elbo_draws : int
-        Monte-Carlo draws per iterate for ELBO selection.
     num_draws : int
         Draws returned from the selected Gaussian.
     num_proposal_draws : int, optional
@@ -191,8 +169,6 @@ def fit_streaming_pathfinder(
         ``importance_sampling=None``. The pool's exact full-data ``logP`` is one
         O(``num_proposal_draws`` x N) pass and was 85-94% of wall clock at N=1e5, so this
         setting is very nearly the cost of the fit.
-    eval_rows : int
-        Rows in the fixed evaluation batch used for iterate selection.
     full_pass : iterable, optional
         An iterable of row blocks visiting every row exactly once, for the final exact
         full-data ``logP``; consumed once. Defaults to iterating ``loader``, which is
@@ -214,12 +190,11 @@ def fit_streaming_pathfinder(
     importance_sampling : {"psis", "psir", "identity", None}
         Post-hoc reweighting of the returned draws; ``None`` returns the proposal
         draws unweighted. ``"identity"`` weights by the raw log ratio, so like
-        ``"psis"``/``"psir"`` it resamples from a larger pool. At the Pareto-k these fits
-        reach the weights are degenerate — the 4000-draw pool at N=1e5 had an effective
-        sample size of 1.0-1.2 — so resampling acts as selection of the highest-weight
-        draws: it moved the worst coordinate's mean from 12.9 to 11.8 reference-sd and
-        narrowed the worst marginal sd from 0.91-0.93 of the reference to 0.66-0.74, at
-        about 3x the wall clock.
+        ``"psis"``/``"psir"`` it resamples from a larger pool. At the Notes configuration
+        (k=8, N=1e5, three seeds) the 4000-draw pool carried a raw-weight effective sample
+        size of 449-1762, so the weights inform the resampling rather than collapsing onto
+        a few draws; it cost 3.4-3.7x the wall clock of ``None``, which draws a pool of
+        ``num_draws`` only.
     lbfgs_config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
@@ -234,15 +209,32 @@ def fit_streaming_pathfinder(
 
     Notes
     -----
-    Measured against an exact full-data Laplace reference on Bayesian logistic regression
-    (5 coefficients, three seeds, the defaults above): the draws are a proposal, not a
-    posterior, and the gap grows with the dataset. At N=1e5 the worst coordinate's mean
-    sits 7.1-13.3 reference-sd from the MAP at Pareto-k 4.3-6.6; at N=1.6e6, 57-101 sd at
-    Pareto-k 22-39. ``fit_pathfinder`` on the same N=1e5 data is within 0.10 reference-sd
-    at Pareto-k -0.6 to 0.4. Batch size is the lever that works (8192 rows instead of 512:
-    Pareto-k 3.2-3.9, 5.9-6.4 sd); iteration count is not (600 instead of 200 left the
-    selected iterate unchanged on two of three seeds). Read ``pareto_k``;
-    ``violation_rate`` read 0.0 on every one of these runs.
+    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048,
+    ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``, ``num_draws=1000``,
+    ``num_proposal_draws=4000``, PSIS, against an exact full-data Laplace reference. With
+    k=8 coefficients, worst-coordinate error in reference-sd:
+
+    ====== ===================== =========================
+    N      ``pareto_k``          worst coordinate (ref-sd)
+    ====== ===================== =========================
+    1e5    0.31-0.80 (med 0.69)  0.17-0.58
+    4e5    0.80-0.91 (med 0.87)  1.07-1.56
+    1.6e6  2.05-2.56 (med 2.52)  2.91-4.35
+    ====== ===================== =========================
+
+    On the same trajectories before tail averaging, N=1e5 gave ``pareto_k`` 5.80-7.00 and
+    9.71-11.13 ref-sd. But ``pareto_k`` still exceeds 0.7 on 6 of 12 seeds at N=1e5 and on
+    5 of 6 at N=4e5, so read it on every fit: these draws remain a *proposal*, not a
+    posterior, and in the large-N regime that gap is not small.
+
+    The range is in ``k`` as much as in ``N``. At k=100 the tail-averaged ``pareto_k`` is
+    2.2-4.5 and the error 4.6-17.4 ref-sd — unusable, and worse, quiet: with the
+    line-search gradient-finiteness guard the k=100 case no longer raises, it returns a
+    silently wrong posterior. Do not run this above a few tens of dimensions without
+    checking ``pareto_k``.
+
+    Averaging buys a level, not an exponent: the gap still grows roughly 3x per 4x in N.
+    ``violation_rate`` is an optimizer-health counter and read 0.0 on all of these runs.
     """
     model = pm.modelcontext(model)
     if batch_var not in model.named_vars:
@@ -253,7 +245,7 @@ def fit_streaming_pathfinder(
     cfg = lbfgs_config or StochasticLBFGSConfig()
     J = cfg.maxcor
 
-    init_ss, elbo_ss, final_ss, resample_ss = np.random.SeedSequence(random_seed).spawn(4)
+    init_ss, final_ss, resample_ss = np.random.SeedSequence(random_seed).spawn(3)
 
     # Compile once; all functions below close over the batch_var pm.Data shared variable.
     neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=jacobian_correction)
@@ -286,17 +278,7 @@ def fit_streaming_pathfinder(
             epoch = iter(loader)
             return next(epoch)
 
-    # One batch fixed for the whole selection sweep, so every iterate is scored on the
-    # same rows. Not held out: they come off the stream the optimizer also trains on.
     n_total = len(loader)
-    target_rows = min(eval_rows, n_total)
-    chunks, rows = [], 0
-    while rows < target_rows:
-        b = next_batch()
-        chunks.append(b)
-        rows += b.shape[0]
-    eval_batch = np.concatenate(chunks, axis=0)[:target_rows]
-
     init_rng = np.random.default_rng(init_ss)
     x0 = x_base + init_rng.uniform(-jitter, jitter, size=N)
     model.set_data(batch_var, next_batch())
@@ -315,16 +297,29 @@ def fit_streaming_pathfinder(
             "smaller jitter, or a larger batch size."
         )
 
-    model.set_data(batch_var, eval_batch)
-    u_elbo = np.random.default_rng(elbo_ss).standard_normal((num_elbo_draws, N))
-    elbo_trace = np.empty(len(traj.iterates))
-    for k, it in enumerate(traj.iterates):
-        _, logQ, logP, _ = sample_logp(
-            it["x"], it["g"], it["alpha"], it["s_win"], it["z_win"], u_elbo
-        )
-        elbo_trace[k] = _elbo(logP, logQ)
-    elbo_argmax = int(np.argmax(elbo_trace))
-    best = traj.iterates[elbo_argmax]
+    # Polyak-Ruppert tail averaging of the iterate positions. Each stochastic L-BFGS step is
+    # a full quasi-Newton step plus line search on ONE minibatch, so its accepted point is
+    # essentially that minibatch's MAP: ~sqrt(N / b) full-data posterior-sd off the true MAP
+    # (measured ratio 0.971 over 27 runs), while the same batch pins the posterior sd to
+    # within 1-2%. That makes it a location error, not a covariance one, which is why no rule
+    # that *picks* an iterate can fix it. g is zeroed because the sampler centres the Gaussian
+    # at mu = x - H_inv @ g; keeping the last iterate's gradient costs 2.0-6.6x. Curvature
+    # stays from the last iterate: averaged (s, z) pairs are not a valid L-BFGS memory.
+    # Ruppert 1988 (Cornell ORIE TR-781); Polyak & Juditsky 1992, SIAM J. Control Optim.
+    # 30(4):838-855; Jain et al., JMLR 18(223), 2018 (tail averaging the last c*n iterates);
+    # Mandt, Hoffman & Blei, JMLR 18(134), 2017; Dhaka et al., NeurIPS 2020 and Welandawe
+    # et al., JMLR 25(219), 2024 (iterate averaging in VI); Byrd, Hansen, Nocedal & Singer,
+    # SIAM J. Optim. 26(2):1008-1031, 2016 (averaged iterates inside stochastic L-BFGS).
+    m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))
+    x_avg = np.mean([it["x"] for it in traj.iterates[-m:]], axis=0)
+    last = traj.iterates[-1]
+    best = {
+        "x": x_avg,
+        "g": np.zeros_like(x_avg),
+        "alpha": last["alpha"],
+        "s_win": last["s_win"],
+        "z_win": last["z_win"],
+    }
 
     resample = importance_sampling is not None
     if num_proposal_draws is None:
@@ -340,7 +335,7 @@ def fit_streaming_pathfinder(
     )
     samples = np.asarray(phi)
     logQ = np.asarray(logQ)
-    # sample_logp's logP is the eval-batch pseudo-density; the weights need the exact one.
+    # sample_logp's logP is the installed batch's pseudo-density; the weights need the exact one.
     logP = _full_data_logp(
         samples,
         full_pass if full_pass is not None else loader,
@@ -370,8 +365,6 @@ def fit_streaming_pathfinder(
         samples=samples,
         logP=logP,
         logQ=logQ,
-        elbo_trace=elbo_trace,
-        elbo_argmax=elbo_argmax,
         pareto_k=pareto_k,
         violation_rate=traj.violation_rate,
         n_ls_failures=traj.n_ls_failures,

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -218,8 +218,15 @@ def fit_streaming_pathfinder(
     4 seeds it was 2.7-4.3 and 52-59, nothing raises, and two of the four came back with a
     nonzero ``n_ls_failures``; ``violation_rate`` read 0.0 throughout.
 
+    Held-out families at N=1e5, shipped defaults, three seeds each, against full-data Laplace
+    references: a Poisson GLM (4 params) ran ``pareto_k`` 0.08-0.33 with worst coordinate 0.07;
+    Student-t regression with estimated ``nu`` (5 params) ran 0.58-0.84 and 0.26; a hierarchical
+    random-intercept model (23 params) failed at 1.9-2.4 with the worst coordinate 4.7-7.2 out.
+    Partial pooling's coupled scales defeat a single tail-averaged Gaussian well below the
+    dimension wall.
+
     These draws are a *proposal*, not a posterior. Read ``pareto_k`` on every fit, and do not run
-    this above a few tens of dimensions.
+    this above a few tens of dimensions or on hierarchical posteriors.
 
     References
     ----------

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -13,18 +13,11 @@ full width and importance-resampled against the exact full-data ``logP``. The co
 log-density, Gaussian sampler and PSIS are reused unchanged from the deterministic
 Pathfinder (``bfgs_sample``, ``importance_sampling``).
 
-Measured accuracy, against an exact full-data Laplace reference on Bayesian logistic
-regression: the posterior *scale* is right (sd ratio 0.8-1.1), but the *location* is
-not, and the error grows with the dataset. Pareto-k 3.4 at N=1e5 and 11.8 at N=1.6e6,
-against 0.3-0.5 for ``fit_pathfinder`` on the same data; the mean is 3.7 reference-sd
-away at N=1e5 and 22 sd away at N=1.6e6. Larger batches help (Pareto-k 7.8 -> 3.9
-raising the batch from 512 to 8192 rows at N=1e5); more iterations do not help at all.
-Two causes are known and neither is fixed here: the stochastic trajectory never
-approaches the MAP as closely as the deterministic one, and each iterate's stored
-gradient is one rescaled minibatch gradient whose noise lands directly in the Gaussian
-mean. Agreement with ``fit_pathfinder`` at large N is therefore unverified — treat the
-draws as a proposal, and read ``pareto_k``. ``violation_rate`` reads 0.0 on every one of
-those runs including the worst, so it cannot stand in for that check.
+The draws it returns are a proposal, not a posterior; the measured operating range is on
+:func:`fit_streaming_pathfinder`. Two causes of the gap are known and neither is fixed
+here: the stochastic trajectory never approaches the MAP as closely as the deterministic
+one, and each iterate's stored gradient is one rescaled minibatch gradient whose noise
+lands directly in the Gaussian mean.
 
 What streaming does buy is memory: 6.4x less resident memory than ``fit_pathfinder`` at
 N=4e5 and 11.4x at N=1.6e6, at comparable wall clock for a matched proposal pool.
@@ -170,6 +163,7 @@ def fit_streaming_pathfinder(
     jacobian_correction=True,
     importance_sampling="psis",
     lbfgs_config=None,
+    callbacks=(),
     random_seed=None,
 ):
     """Fit a streaming Pathfinder approximation to ``model`` using ``loader``.
@@ -192,20 +186,26 @@ def fit_streaming_pathfinder(
         Draws returned from the selected Gaussian.
     num_proposal_draws : int, optional
         Size of the proposal pool importance sampling resamples down to ``num_draws``.
-        Defaults to ``num_draws``, raised by one when resampling so that PSIS reweights
-        rather than permuting. The final ``logP`` costs one O(``num_proposal_draws`` x N)
-        pass over the data and dominates the fit, so raising this trades wall clock for
-        importance-weight quality roughly one for one.
+        Defaults to ``4 * num_draws`` when resampling, matching ``fit_pathfinder``'s
+        ``num_paths=4`` x ``num_draws_per_path=1000`` pool, and to ``num_draws`` when
+        ``importance_sampling=None``. The pool's exact full-data ``logP`` is one
+        O(``num_proposal_draws`` x N) pass and was 85-94% of wall clock at N=1e5, so this
+        setting is very nearly the cost of the fit.
     eval_rows : int
         Rows in the fixed evaluation batch used for iterate selection.
     full_pass : iterable, optional
-        An iterable yielding every row exactly once, for the final exact full-data
-        ``logP``; consumed once. Defaults to iterating ``loader``, which is correct only
-        when a loader epoch covers every row. ``pymc_extras.variational.DataLoader``
-        drops the trailing ``len(loader) % batch_size`` rows by design, so pass its
-        dataset source here instead — any iterable of row blocks will do, and the batch
-        sizes need not match. A raw source bypasses the loader's ``preprocess_fn``, so
-        apply that here too if one is set.
+        An iterable of row blocks visiting every row exactly once, for the final exact
+        full-data ``logP``; consumed once. Defaults to iterating ``loader``, which is
+        correct only when a loader epoch covers every row: a loader that drops its
+        trailing ``len(loader) % batch_size`` rows does not, and the run raises rather
+        than return a subset-rescaled ``logP``. Block sizes need not match the loader's.
+
+        .. warning::
+            Blocks are installed in ``batch_var`` unchanged. If ``loader`` transforms
+            its batches before yielding them, ``full_pass`` must apply the identical
+            transform. Untransformed rows are indistinguishable from correct ones here,
+            so they produce a wrong ``logP``, and therefore wrong importance weights and
+            wrong draws, with no error and no diagnostic.
     jitter : float
         Uniform jitter added to the prior initial point.
     jacobian_correction : bool
@@ -214,13 +214,35 @@ def fit_streaming_pathfinder(
     importance_sampling : {"psis", "psir", "identity", None}
         Post-hoc reweighting of the returned draws; ``None`` returns the proposal
         draws unweighted. ``"identity"`` weights by the raw log ratio, so like
-        ``"psis"``/``"psir"`` it resamples from a larger pool.
+        ``"psis"``/``"psir"`` it resamples from a larger pool. At the Pareto-k these fits
+        reach the weights are degenerate — the 4000-draw pool at N=1e5 had an effective
+        sample size of 1.0-1.2 — so resampling acts as selection of the highest-weight
+        draws: it moved the worst coordinate's mean from 12.9 to 11.8 reference-sd and
+        narrowed the worst marginal sd from 0.91-0.93 of the reference to 0.66-0.74, at
+        about 3x the wall clock.
     lbfgs_config : StochasticLBFGSConfig, optional
+    callbacks : iterable of callable, optional
+        ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
+        one raising ``StopIteration`` stops the optimization and the fit proceeds with
+        the iterates recorded so far. ``losses`` are minibatch objectives, so they are
+        noisy; ``approx`` is ``None`` because there is no ``Approximation`` here.
     random_seed : int, optional
 
     Returns
     -------
     StreamingPathfinderResult
+
+    Notes
+    -----
+    Measured against an exact full-data Laplace reference on Bayesian logistic regression
+    (5 coefficients, three seeds, the defaults above): the draws are a proposal, not a
+    posterior, and the gap grows with the dataset. At N=1e5 the worst coordinate's mean
+    sits 7.1-13.3 reference-sd from the MAP at Pareto-k 4.3-6.6; at N=1.6e6, 57-101 sd at
+    Pareto-k 22-39. ``fit_pathfinder`` on the same N=1e5 data is within 0.10 reference-sd
+    at Pareto-k -0.6 to 0.4. Batch size is the lever that works (8192 rows instead of 512:
+    Pareto-k 3.2-3.9, 5.9-6.4 sd); iteration count is not (600 instead of 200 left the
+    selected iterate unchanged on two of three seeds). Read ``pareto_k``;
+    ``violation_rate`` read 0.0 on every one of these runs.
     """
     model = pm.modelcontext(model)
     if batch_var not in model.named_vars:
@@ -280,7 +302,12 @@ def fit_streaming_pathfinder(
     model.set_data(batch_var, next_batch())
 
     traj = run_stochastic_lbfgs(
-        value_grad_fn, lambda: model.set_data(batch_var, next_batch()), x0, num_iters, cfg
+        value_grad_fn,
+        lambda: model.set_data(batch_var, next_batch()),
+        x0,
+        num_iters,
+        cfg,
+        callbacks,
     )
     if not traj.iterates:
         raise RuntimeError(
@@ -300,10 +327,13 @@ def fit_streaming_pathfinder(
     best = traj.iterates[elbo_argmax]
 
     resample = importance_sampling is not None
-    # Resampling num_draws out of exactly num_draws candidates is drawing without
-    # replacement from the whole pool: a permutation, not a reweighting. Hence the floor.
-    n_prop = int(num_proposal_draws) if num_proposal_draws is not None else num_draws
-    n_prop = max(n_prop, num_draws + 1 if resample else num_draws)
+    if num_proposal_draws is None:
+        # fit_pathfinder resamples num_draws out of num_paths=4 x num_draws_per_path=1000;
+        # a single streaming path has to supply that 4x pool itself. Unresampled the extra
+        # draws are only dropped, and the pool's logP pass is most of the wall clock.
+        n_prop = 4 * num_draws if resample else num_draws
+    else:
+        n_prop = max(int(num_proposal_draws), num_draws)  # samples[:num_draws] must not be short
     u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
     phi, logQ, _logP_subset, _ = sample_logp(
         best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -14,15 +14,9 @@ unchanged from the deterministic Pathfinder (``bfgs_sample``, ``importance_sampl
 The draws it returns are a proposal, not a posterior; the measured operating range, in both
 dataset size and dimension, is on :func:`fit_streaming_pathfinder`.
 
-What streaming buys is memory: the optimizer only ever holds one minibatch, and the final
-exact ``logP`` is accumulated block by block over ``full_pass``, so the peak is set by the
-block size rather than the row count. The caller sets that block size, though, and
-``full_pass`` defaults to ``loader`` -- hand the whole dataset over as a single block and the
-peak is O(N) again. It is also O(``num_proposal_draws`` x block rows), because each block's
-log-density is evaluated for the whole proposal pool at once: on a 200k-row dataset with 100
-proposal draws, peak traced allocation was 40 MB with 2048-row blocks and 231 MB with one
-block. ``fit_pathfinder`` materializes the whole dataset unconditionally. No ratio against it
-is quoted because the earlier one did not say what it measured.
+What streaming buys is memory: peak is O(``num_proposal_draws`` x ``full_pass`` block rows)
+rather than O(N). On 200k rows with 100 proposal draws, peak traced allocation was 40 MB with
+2048-row blocks and 231 MB with one block; the block size is the caller's to set.
 """
 
 from dataclasses import dataclass
@@ -50,16 +44,10 @@ from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
 
 __all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
 
-# Fraction of the trajectory's iterate positions that the tail average covers. Not a
-# keyword. Swept over one trajectory per seed at the Notes k=8, N=1e5 configuration, 8 seeds,
-# scoring worst-coordinate *position* error |x_avg - full-data MAP| in reference-sd. That is
-# a different quantity from the posterior-mean error the Notes quote, which scores the
-# resampled draws rather than the optimizer's position, and the two do not compare. The
-# medians over 0.50/0.60/0.75/0.90 are 0.86/0.80/0.68/0.80, a spread of 1.26x, while 1.00 is
-# 5.06 (7.4x the best) and 0.10 is 3.17. So the interior is shallow and the endpoint is the
-# cliff. 0.50 vs 0.75 paired per seed differs by +0.13 ref-sd (95% CI -0.05 to +0.31), which
-# 8 seeds do not resolve; 0.75 is the better point estimate and the only thing the knob
-# reliably teaches is that 1.00 is broken.
+# Fraction of the trajectory's iterate positions that the tail average covers. Not a keyword.
+# Swept over 0.50/0.60/0.75/0.90 at the Notes k=8, N=1e5 configuration, scoring worst-coordinate
+# position error |x_avg - full-data MAP| in reference-sd: medians over 8 seeds 0.86/0.80/0.68/0.80,
+# against 5.06 at 1.00. The interior is flat; the only firm result is that 1.00 is broken.
 _TAIL_AVERAGE_FRAC = 0.75
 
 
@@ -171,10 +159,8 @@ def fit_streaming_pathfinder(
         Yields minibatches (arrays whose leading axis is the batch rows) and
         supports ``len(loader) == N`` (the dataset row count).
     batch_var : str
-        Name of the ``pm.Data`` placeholder to stream into. The fit installs batches into
-        it and restores the value it held on entry before returning, on the exception path
-        too, so a ``model.logp()`` or ``pm.sample()`` after the fit scores the data the
-        caller put there rather than the last block this function happened to install.
+        Name of the ``pm.Data`` placeholder to stream into. The value it held on entry is
+        restored before returning, on the exception path too.
     num_iters : int
         Number of stochastic L-BFGS steps.
     num_draws : int
@@ -182,34 +168,25 @@ def fit_streaming_pathfinder(
     num_proposal_draws : int, optional
         Size of the proposal pool importance sampling resamples down to ``num_draws``.
         Defaults to ``4 * num_draws`` when resampling, matching ``fit_pathfinder``'s
-        ``num_paths=4`` x ``num_draws_per_path=1000`` pool, and to ``num_draws`` when
-        ``importance_sampling=None``. The pool's exact full-data ``logP`` is one
-        O(``num_proposal_draws`` x N) pass, against an optimizer that only ever touches
-        ``num_iters`` x batch rows, so on any large dataset this setting dominates the cost
-        of the fit.
+        ``num_paths=4`` x ``num_draws_per_path=1000`` pool, and to ``num_draws`` when not.
+        The pool's exact full-data ``logP`` is an O(``num_proposal_draws`` x N) pass, so on
+        any large dataset this setting dominates the cost of the fit.
     full_pass : iterable, optional
-        An iterable of row blocks visiting every row exactly once, for the final exact
-        full-data ``logP``; consumed once. Defaults to iterating ``loader``, which is
-        correct only when a loader epoch covers every row: a loader that drops its
-        trailing ``len(loader) % batch_size`` rows does not, and the run raises rather
-        than return a subset-rescaled ``logP``. Block sizes need not match the loader's.
-
-        .. warning::
-            Blocks are installed in ``batch_var`` unchanged. If ``loader`` transforms
-            its batches before yielding them, ``full_pass`` must apply the identical
-            transform. Untransformed rows are indistinguishable from correct ones here,
-            so they produce a wrong ``logP``, and therefore wrong importance weights and
-            wrong draws, with no error and no diagnostic.
+        Row blocks visiting every row exactly once, for the final exact full-data ``logP``;
+        consumed once. Defaults to iterating ``loader``, and a loader epoch that drops its
+        trailing rows raises rather than return a subset-rescaled ``logP``. Block sizes need
+        not match the loader's. Blocks are installed in ``batch_var`` unchanged, so if
+        ``loader`` transforms its batches, ``full_pass`` must apply the identical transform:
+        untransformed rows give a wrong ``logP`` and wrong draws, with no error to say so.
     jitter : float
         Uniform jitter added to the prior initial point.
     jacobian_correction : bool
         Include the change-of-variables Jacobian so logp is the unconstrained
         joint density (matches ``fit_pathfinder``).
     importance_sampling : {"psis", "psir", "identity", None}
-        Post-hoc reweighting of the returned draws; ``None`` returns the proposal
-        draws unweighted. ``"identity"`` weights by the raw log ratio, so like
-        ``"psis"``/``"psir"`` it resamples from a 4x pool, so it pays the ``logP`` pass on
-        four times as many draws as ``None``, which draws ``num_draws`` only.
+        Post-hoc reweighting of the returned draws; ``None`` returns the proposal draws
+        unweighted. ``"identity"`` weights by the raw log ratio: a weighting method that
+        still resamples from the 4x pool, not an off switch.
     lbfgs_config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
@@ -224,24 +201,25 @@ def fit_streaming_pathfinder(
 
     Notes
     -----
-    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048 from
-    a *shuffled* loader, ``num_iters=200``, ``maxcor=6``, ``jitter=2.0``, ``num_draws=1000``,
-    ``num_proposal_draws=4000``, PSIS, scored against an exact full-data Laplace reference.
-    Shuffling is part of the configuration: an unshuffled loader replays the same rows in the
-    same order every epoch, and none of this was measured that way.
-
-    With k=8 at N=1e5, over 12 seeds, ``pareto_k`` ran 0.60-0.80 (median 0.70, over 0.7 on half
-    of them) and the worst coordinate of the *resampled posterior mean* was 0.23-0.58
-    reference-sd from the reference mean -- a different quantity from the optimizer-position
-    error swept for ``_TAIL_AVERAGE_FRAC``, which scores ``x_avg`` against the MAP. Accuracy
-    degrades with N -- ``pareto_k`` 0.76-1.29 and error 0.53-2.24 ref-sd over 6 seeds at N=4e5 --
-    and much faster with dimension: at k=100, N=1e5 it was 2.0-3.8 and 13-64 ref-sd over 4 seeds,
-    and nothing raises, so that fit returns silently wrong draws.
+    Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048 from a
+    *shuffled* loader (part of the configuration, not an aside), ``num_iters=200``, ``maxcor=6``,
+    ``jitter=2.0``, ``num_draws=1000``, ``num_proposal_draws=4000``, PSIS, scored against an exact
+    full-data Laplace reference. At k=8, N=1e5 over 12 seeds ``pareto_k`` ran 0.60-0.80 (median
+    0.70, over 0.7 on half of them) and the worst coordinate of the *resampled posterior mean* was
+    0.23-0.58 reference-sd from the reference mean. At N=4e5 over 6 seeds that was 0.76-1.29 and
+    0.53-2.24. At k=100, N=1e5 over 4 seeds it was 2.0-3.8 and 13-64, nothing raises, and two of
+    the four came back with a nonzero ``n_ls_failures``; ``violation_rate`` read 0.0 throughout.
 
     These draws are a *proposal*, not a posterior. Read ``pareto_k`` on every fit, and do not run
-    this above a few tens of dimensions. ``violation_rate`` is an optimizer-health counter, not
-    an accuracy one; it read 0.0 on every run above. ``n_ls_failures`` did not stay at zero:
-    at k=100, N=1e5 two of four seeds came back with a nonzero count.
+    this above a few tens of dimensions.
+
+    References
+    ----------
+    Polyak, B. T., & Juditsky, A. B. (1992). Acceleration of stochastic approximation by
+    averaging. SIAM Journal on Control and Optimization, 30(4), 838-855.
+
+    Jain, P., Kakade, S. M., Kidambi, R., Netrapalli, P., & Sidford, A. (2018). Parallelizing
+    stochastic gradient descent for least squares regression. COLT, 545-604.
     """
     model = pm.modelcontext(model)
     if batch_var not in model.named_vars:
@@ -249,10 +227,7 @@ def fit_streaming_pathfinder(
             f"batch_var {batch_var!r} is not a variable in the model; add a "
             f"pm.Data({batch_var!r}, ...) placeholder that the data stream feeds."
         )
-    # Restored in the finally below. get_value() copies, so a caller that mutates its own
-    # array in place cannot corrupt the saved copy. If the incoming value was itself one
-    # batch rather than the whole dataset, putting it back still leaves the model in the
-    # state the caller built, which is what a restore can promise.
+    # Restored in the finally below; get_value() copies.
     saved_batch = model[batch_var].get_value()
     cfg = lbfgs_config or StochasticLBFGSConfig()
     J = cfg.maxcor
@@ -310,18 +285,13 @@ def fit_streaming_pathfinder(
                 "smaller jitter, or a larger batch size."
             )
 
-        # Polyak-Ruppert tail averaging of the iterate positions (Polyak & Juditsky 1992; Jain
-        # et al. 2018). Each step is a full quasi-Newton step plus line search on ONE minibatch,
-        # so its accepted point sits near that minibatch's MAP: measured roughly sqrt(N / b)
-        # full-data posterior-sd away in per-coordinate RMS, on a batch whose own rescaled
-        # posterior still reproduces the full-data posterior sd -- worst-coordinate relative
-        # error, median over 200 random batches, ran 9.1% at b=512, 4.3% at 2048 and 2.2% at
-        # 8192, though the b=512 tail reached 36%. The error is in the location, not the
-        # covariance, so
-        # no rule that *picks* an iterate removes it. g is zeroed because the sampler centres at
-        # mu = x - H_inv @ g, and keeping the last iterate's g moved that centre further from
-        # the full-data MAP on all of 12 seeds; curvature stays the last iterate's -- averaged
-        # (s, z) is not a valid memory.
+        # Polyak-Ruppert tail averaging of the iterate positions. Each step's accepted point sits
+        # near its own minibatch's MAP -- worst-coordinate relative error, median over 200 random
+        # batches, ran 9.1% at b=512, 4.3% at 2048 and 2.2% at 8192, with the b=512 tail at 36% --
+        # and that error is in the location, not the covariance, so no rule that *picks* an
+        # iterate removes it. g is zeroed because the sampler centres at mu = x - H_inv @ g, and
+        # keeping the last iterate's g moved that centre further from the full-data MAP on all of
+        # 12 seeds; curvature stays the last iterate's -- averaged (s, z) is not a valid memory.
         m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))
         x_avg = np.mean([it["x"] for it in traj.iterates[-m:]], axis=0)
         last = traj.iterates[-1]
@@ -334,14 +304,12 @@ def fit_streaming_pathfinder(
         }
 
         resample = importance_sampling is not None
-        if num_proposal_draws is None:
-            # fit_pathfinder resamples num_draws out of num_paths=4 x num_draws_per_path=1000;
-            # a single streaming path has to supply that 4x pool itself. Unresampled the extra
-            # draws are only dropped, and the pool's logP pass is most of the wall clock.
-            n_prop = 4 * num_draws if resample else num_draws
-        else:
-            # samples[:num_draws] must not be short
-            n_prop = max(int(num_proposal_draws), num_draws)
+        # fit_pathfinder resamples out of a num_paths=4 x num_draws_per_path pool; one streaming
+        # path has to supply that 4x itself. max() keeps samples[:num_draws] from coming back short.
+        default_prop = (4 if resample else 1) * num_draws
+        n_prop = (
+            default_prop if num_proposal_draws is None else max(int(num_proposal_draws), num_draws)
+        )
         u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
         phi, logQ, _logP_subset, _ = sample_logp(
             best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -6,24 +6,28 @@ data in a ``pm.Data`` placeholder scaled with ``total_size=len(loader)``, so
 ``model.logp()`` already returns the correctly rescaled full-data log-density for
 whatever batch is currently set.
 
-Three phases, one compiled graph:
+The optimizer core is :func:`run_stochastic_lbfgs`; its stored iterates are scored
+against one fixed evaluation batch with shared Monte-Carlo draws, so the ELBO argmax is
+a paired comparison rather than a lottery over batches, and the winner is then drawn at
+full width and importance-resampled against the exact full-data ``logP``. The compiled
+log-density, Gaussian sampler and PSIS are reused unchanged from the deterministic
+Pathfinder (``bfgs_sample``, ``importance_sampling``).
 
-1. **Optimize.** Drive :func:`run_stochastic_lbfgs`; before each step a fresh
-   minibatch is written into the placeholder, so every gradient in a step (and
-   therefore each Schraudolph curvature pair) is on one batch. Each accepted step
-   stores the sampler-ready ``(x, g, alpha, s_win, z_win)``.
-2. **Select.** Set one fixed evaluation batch, draw the Monte-Carlo normals *once*
-   (common random numbers), and score every stored iterate's Gaussian ELBO through
-   the same compiled sampler. A shared evaluation batch + shared draws make the
-   comparison paired, so the argmax is not chosen by whichever iterate happened to
-   see the luckiest batch.
-3. **Draw.** Re-sample the best iterate's Gaussian at full width and, optionally,
-   Pareto-smoothed importance resample it.
+Measured accuracy, against an exact full-data Laplace reference on Bayesian logistic
+regression: the posterior *scale* is right (sd ratio 0.8-1.1), but the *location* is
+not, and the error grows with the dataset. Pareto-k 3.4 at N=1e5 and 11.8 at N=1.6e6,
+against 0.3-0.5 for ``fit_pathfinder`` on the same data; the mean is 3.7 reference-sd
+away at N=1e5 and 22 sd away at N=1.6e6. Larger batches help (Pareto-k 7.8 -> 3.9
+raising the batch from 512 to 8192 rows at N=1e5); more iterations do not help at all.
+Two causes are known and neither is fixed here: the stochastic trajectory never
+approaches the MAP as closely as the deterministic one, and each iterate's stored
+gradient is one rescaled minibatch gradient whose noise lands directly in the Gaussian
+mean. Agreement with ``fit_pathfinder`` at large N is therefore unverified — treat the
+draws as a proposal, and read ``pareto_k``. ``violation_rate`` reads 0.0 on every one of
+those runs including the worst, so it cannot stand in for that check.
 
-The optimizer core is in
-:mod:`pymc_extras.inference.pathfinder.stochastic_lbfgs`; the compiled
-log-density, Gaussian sampler, and PSIS are reused unchanged from the
-deterministic Pathfinder (``bfgs_sample``, ``importance_sampling``).
+What streaming does buy is memory: 6.4x less resident memory than ``fit_pathfinder`` at
+N=4e5 and 11.4x at N=1.6e6, at comparable wall clock for a matched proposal pool.
 """
 
 from dataclasses import dataclass
@@ -74,7 +78,9 @@ class StreamingPathfinderResult:
     pareto_k : float or None
         PSIS Pareto shape diagnostic (None when importance sampling is disabled).
     violation_rate : float
-        Curvature-rejection rate of the optimizer (proposal target < 0.20).
+        Fraction of moved optimizer steps whose ``(s, y)`` pair failed the curvature
+        test. An optimizer-health counter; it says nothing about how close the draws
+        are to the posterior — read ``pareto_k`` for that.
     n_ls_failures : int
         Number of line-search failures during optimization.
     """
@@ -96,13 +102,8 @@ def _elbo(logP, logQ):
     density) collapses the estimate to ``-inf`` rather than being dropped, so a
     support-violating iterate cannot outscore a valid one.
     """
-    logP = np.asarray(logP)
-    logQ = np.asarray(logQ)
-    finite = np.isfinite(logP)
-    if not np.any(finite):
-        return -np.inf
-    logP_safe = np.where(finite, logP, -np.inf)
-    elbo = float(np.mean(logP_safe - logQ))
+    logP_safe = np.where(np.isfinite(logP), np.asarray(logP), -np.inf)
+    elbo = float(np.mean(logP_safe - np.asarray(logQ)))
     return elbo if np.isfinite(elbo) else -np.inf
 
 
@@ -137,7 +138,7 @@ def _full_data_logp(phi, full_pass, model, batch_var, prior_fn, obs_fn, n_total)
     Assumes the single-observed-RV, ``total_size=n_total`` minibatch contract.
     """
     phi = np.asarray(phi, dtype=np.float64)
-    lp = np.asarray(prior_fn(phi), dtype=np.float64)  # (M,) prior + Jacobian, once
+    lp = np.asarray(prior_fn(phi), dtype=np.float64)
     seen = 0
     for batch in full_pass:  # one complete epoch; order is irrelevant to the sum
         b = np.asarray(batch)
@@ -147,9 +148,9 @@ def _full_data_logp(phi, full_pass, model, batch_var, prior_fn, obs_fn, n_total)
     if seen != n_total:
         raise RuntimeError(
             f"full-data logp pass visited {seen} rows but len(loader)={n_total}; the "
-            "pass must yield every row exactly once (no drop_last) for an exact logP. "
-            "If the training loader drops a trailing partial batch, pass full_pass= "
-            "an iterable making one complete pass."
+            "pass must yield every row exactly once for an exact logP. A loader epoch "
+            "that drops its trailing partial batch cannot do that, so pass full_pass="
+            "<the loader's dataset source> instead."
         )
     return lp
 
@@ -191,16 +192,20 @@ def fit_streaming_pathfinder(
         Draws returned from the selected Gaussian.
     num_proposal_draws : int, optional
         Size of the proposal pool importance sampling resamples down to ``num_draws``.
-        Defaults to ``4 * num_draws`` when resampling (so PSIS/PSIR actually reweight
-        rather than returning a permutation of ``num_draws`` proposals), else
-        ``num_draws``.
+        Defaults to ``num_draws``, raised by one when resampling so that PSIS reweights
+        rather than permuting. The final ``logP`` costs one O(``num_proposal_draws`` x N)
+        pass over the data and dominates the fit, so raising this trades wall clock for
+        importance-weight quality roughly one for one.
     eval_rows : int
         Rows in the fixed evaluation batch used for iterate selection.
     full_pass : iterable, optional
-        An iterable yielding every row exactly once, used for the final exact
-        full-data ``logP`` (it is consumed once, at the end of the fit). Required
-        when iterating ``loader`` drops a trailing partial batch; defaults to
-        iterating ``loader`` itself.
+        An iterable yielding every row exactly once, for the final exact full-data
+        ``logP``; consumed once. Defaults to iterating ``loader``, which is correct only
+        when a loader epoch covers every row. ``pymc_extras.variational.DataLoader``
+        drops the trailing ``len(loader) % batch_size`` rows by design, so pass its
+        dataset source here instead — any iterable of row blocks will do, and the batch
+        sizes need not match. A raw source bypasses the loader's ``preprocess_fn``, so
+        apply that here too if one is set.
     jitter : float
         Uniform jitter added to the prior initial point.
     jacobian_correction : bool
@@ -226,7 +231,7 @@ def fit_streaming_pathfinder(
     cfg = lbfgs_config or StochasticLBFGSConfig()
     J = cfg.maxcor
 
-    init_ss, elbo_ss, final_ss = np.random.SeedSequence(random_seed).spawn(3)
+    init_ss, elbo_ss, final_ss, resample_ss = np.random.SeedSequence(random_seed).spawn(4)
 
     # Compile once; all functions below close over the batch_var pm.Data shared variable.
     neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=jacobian_correction)
@@ -234,8 +239,6 @@ def fit_streaming_pathfinder(
     x_base = DictToArrayBijection.map(ip).data
     N = x_base.shape[0]
     sample_logp = make_pathfinder_sample_fn(model, N=N, J=J, jacobian=jacobian_correction)
-    # For the exact full-data target density (final logP + PSIS), evaluate the prior
-    # once and the observed likelihood summed across a full epoch (see _full_data_logp).
     if model.potentials and model[batch_var] in set(ancestors(model.potentials)):
         raise NotImplementedError(
             "a pm.Potential that depends on the minibatch cannot be evaluated once "
@@ -261,7 +264,8 @@ def fit_streaming_pathfinder(
             epoch = iter(loader)
             return next(epoch)
 
-    # Fixed held-out evaluation batch: the first eval_rows rows (capped at N).
+    # One batch fixed for the whole selection sweep, so every iterate is scored on the
+    # same rows. Not held out: they come off the stream the optimizer also trains on.
     n_total = len(loader)
     target_rows = min(eval_rows, n_total)
     chunks, rows = [], 0
@@ -273,7 +277,7 @@ def fit_streaming_pathfinder(
 
     init_rng = np.random.default_rng(init_ss)
     x0 = x_base + init_rng.uniform(-jitter, jitter, size=N)
-    model.set_data(batch_var, next_batch())  # prime the first training batch
+    model.set_data(batch_var, next_batch())
 
     traj = run_stochastic_lbfgs(
         value_grad_fn, lambda: model.set_data(batch_var, next_batch()), x0, num_iters, cfg
@@ -295,23 +299,18 @@ def fit_streaming_pathfinder(
     elbo_argmax = int(np.argmax(elbo_trace))
     best = traj.iterates[elbo_argmax]
 
-    # Draw from the selected Gaussian (eval batch still set). Importance resampling
-    # must draw MORE proposals than it returns, or selecting num_draws from num_draws
-    # candidates without replacement is a no-op permutation (every proposal returned
-    # once, no reweighting). Draw a larger proposal pool and resample down to num_draws.
     resample = importance_sampling is not None
-    default_prop = (4 if resample else 1) * num_draws
-    n_prop = int(num_proposal_draws) if num_proposal_draws is not None else default_prop
+    # Resampling num_draws out of exactly num_draws candidates is drawing without
+    # replacement from the whole pool: a permutation, not a reweighting. Hence the floor.
+    n_prop = int(num_proposal_draws) if num_proposal_draws is not None else num_draws
     n_prop = max(n_prop, num_draws + 1 if resample else num_draws)
     u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
     phi, logQ, _logP_subset, _ = sample_logp(
         best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final
     )
-    samples = np.asarray(phi)  # (n_prop, N) proposal draws
-    logQ = np.asarray(logQ)  # Gaussian proposal density (data-independent)
-    # The final importance target must be the EXACT full-data logP, not the eval-subset
-    # density sample_logp just returned (evaluated on the currently-set eval batch, which
-    # targets a rescaled subset pseudo-posterior). Recompute it in one streaming pass.
+    samples = np.asarray(phi)
+    logQ = np.asarray(logQ)
+    # sample_logp's logP is the eval-batch pseudo-density; the weights need the exact one.
     logP = _full_data_logp(
         samples,
         full_pass if full_pass is not None else loader,
@@ -330,9 +329,9 @@ def fit_streaming_pathfinder(
             logQ[None],
             num_draws,
             method=importance_sampling,
-            random_seed=int(final_ss.generate_state(1)[0]),
+            random_seed=int(resample_ss.generate_state(1)[0]),
         )
-        samples = np.asarray(result.samples)  # (num_draws, N) resampled from the n_prop proposals
+        samples = np.asarray(result.samples)
         pareto_k = result.pareto_k
     else:
         samples = samples[:num_draws]

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -1,0 +1,349 @@
+"""Streaming (minibatch) Pathfinder for PyMC.
+
+Runs Pathfinder where the log-density gradients come from minibatches yielded by
+a sized re-iterable loader, rather than the full dataset. The model carries the
+data in a ``pm.Data`` placeholder scaled with ``total_size=len(loader)``, so
+``model.logp()`` already returns the correctly rescaled full-data log-density for
+whatever batch is currently set.
+
+Three phases, one compiled graph:
+
+1. **Optimize.** Drive :func:`run_stochastic_lbfgs`; before each step a fresh
+   minibatch is written into the placeholder, so every gradient in a step (and
+   therefore each Schraudolph curvature pair) is on one batch. Each accepted step
+   stores the sampler-ready ``(x, g, alpha, s_win, z_win)``.
+2. **Select.** Set one fixed evaluation batch, draw the Monte-Carlo normals *once*
+   (common random numbers), and score every stored iterate's Gaussian ELBO through
+   the same compiled sampler. A shared evaluation batch + shared draws make the
+   comparison paired, so the argmax is not chosen by whichever iterate happened to
+   see the luckiest batch.
+3. **Draw.** Re-sample the best iterate's Gaussian at full width and, optionally,
+   Pareto-smoothed importance resample it.
+
+The optimizer core is in
+:mod:`pymc_extras.inference.pathfinder.stochastic_lbfgs`; the compiled
+log-density, Gaussian sampler, and PSIS are reused unchanged from the
+deterministic Pathfinder (``bfgs_sample``, ``importance_sampling``).
+"""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pymc as pm
+import pytensor.tensor as pt
+
+from pymc.blocking import DictToArrayBijection
+from pymc.initial_point import make_initial_point_fn
+from pymc.model.core import Point
+from pymc.pytensorf import compile as pm_compile
+from pytensor.graph import vectorize_graph
+from pytensor.graph.traversal import ancestors
+
+from pymc_extras.inference.pathfinder.bfgs_sample import (
+    get_neg_logp_dlogp_of_ravel_inputs,
+    make_pathfinder_sample_fn,
+)
+from pymc_extras.inference.pathfinder.importance_sampling import importance_sampling as psis_fn
+from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
+    StochasticLBFGSConfig,
+    run_stochastic_lbfgs,
+)
+
+__all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
+
+
+@dataclass
+class StreamingPathfinderResult:
+    """Output of :func:`fit_streaming_pathfinder`.
+
+    Attributes
+    ----------
+    samples : ndarray, shape (num_draws, N)
+        Posterior draws in the model's raveled unconstrained space. When importance
+        sampling is active these are resampled from a larger proposal pool.
+    logP, logQ : ndarray
+        Target and proposal log-densities of the *proposal* draws (length equals the
+        proposal pool, ``num_proposal_draws``). They are the weights behind the
+        resampling and are row-aligned with ``samples`` only when importance sampling
+        is off (``None``); after resampling they are proposal-space diagnostics, not
+        per-``samples``-row densities.
+    elbo_trace : ndarray
+        ELBO of every stored iterate, evaluated on the shared evaluation batch.
+    elbo_argmax : int
+        Index of the selected iterate within ``elbo_trace``.
+    pareto_k : float or None
+        PSIS Pareto shape diagnostic (None when importance sampling is disabled).
+    violation_rate : float
+        Curvature-rejection rate of the optimizer (proposal target < 0.20).
+    n_ls_failures : int
+        Number of line-search failures during optimization.
+    """
+
+    samples: np.ndarray
+    logP: np.ndarray
+    logQ: np.ndarray
+    elbo_trace: np.ndarray
+    elbo_argmax: int
+    pareto_k: float | None
+    violation_rate: float
+    n_ls_failures: int
+
+
+def _elbo(logP, logQ):
+    """Mean ELBO over the draws, matching upstream ``LBFGSStreamingCallback``.
+
+    A single draw with non-finite ``logP`` (proposal mass where the target has zero
+    density) collapses the estimate to ``-inf`` rather than being dropped, so a
+    support-violating iterate cannot outscore a valid one.
+    """
+    logP = np.asarray(logP)
+    logQ = np.asarray(logQ)
+    finite = np.isfinite(logP)
+    if not np.any(finite):
+        return -np.inf
+    logP_safe = np.where(finite, logP, -np.inf)
+    elbo = float(np.mean(logP_safe - logQ))
+    return elbo if np.isfinite(elbo) else -np.inf
+
+
+def _compile_batched_logp(model, terms, jacobian):
+    """Compile ``phi (M, N) -> logp (M,)`` over ``terms``, vectorized across draws.
+
+    Mirrors the vectorization in ``make_pathfinder_sample_fn``: build the single-draw
+    log-density over the raveled unconstrained value vector (same coordinate order as
+    the sampler's ``phi``), then batch it over a leading draw axis.
+    """
+    (logp_single,), single_input = pm.pytensorf.join_nonshared_inputs(
+        model.initial_point(), [model.logp(vars=terms, jacobian=jacobian)], model.value_vars, ()
+    )
+    phi = pt.matrix("phi")
+    batched = vectorize_graph(logp_single, replace={single_input: phi})
+    fn = pm_compile([phi], batched)
+    fn.trust_input = True
+    return fn
+
+
+def _full_data_logp(phi, full_pass, model, batch_var, prior_fn, obs_fn, n_total):
+    """Exact full-data ``logP(phi)`` for out-of-core data, in one streaming pass.
+
+    ``prior_fn`` (prior + Jacobian) is evaluated once; the observed log-likelihood is
+    summed across every batch of ``full_pass``, an iterable that must visit every row
+    exactly once (it is consumed once). Each batch's observed logp carries the model's
+    ``total_size=n_total`` rescaling (``(n_total / b) * batch_sum``), so it is
+    multiplied back by ``b / n_total`` to recover the exact batch sum. The result equals
+    ``model.logp`` on the full dataset (verified to machine precision), not the
+    subset-rescaled pseudo-density.
+
+    Assumes the single-observed-RV, ``total_size=n_total`` minibatch contract.
+    """
+    phi = np.asarray(phi, dtype=np.float64)
+    lp = np.asarray(prior_fn(phi), dtype=np.float64)  # (M,) prior + Jacobian, once
+    seen = 0
+    for batch in full_pass:  # one complete epoch; order is irrelevant to the sum
+        b = np.asarray(batch)
+        model.set_data(batch_var, b)
+        lp = lp + (b.shape[0] / n_total) * np.asarray(obs_fn(phi), dtype=np.float64)
+        seen += b.shape[0]
+    if seen != n_total:
+        raise RuntimeError(
+            f"full-data logp pass visited {seen} rows but len(loader)={n_total}; the "
+            "pass must yield every row exactly once (no drop_last) for an exact logP. "
+            "If the training loader drops a trailing partial batch, pass full_pass= "
+            "an iterable making one complete pass."
+        )
+    return lp
+
+
+def fit_streaming_pathfinder(
+    model,
+    loader,
+    *,
+    batch_var="batch",
+    num_iters=200,
+    num_elbo_draws=10,
+    num_draws=1000,
+    num_proposal_draws=None,
+    eval_rows=2000,
+    full_pass=None,
+    jitter=2.0,
+    jacobian_correction=True,
+    importance_sampling="psis",
+    lbfgs_config=None,
+    random_seed=None,
+):
+    """Fit a streaming Pathfinder approximation to ``model`` using ``loader``.
+
+    Parameters
+    ----------
+    model : pymc.Model
+        A model whose data enter through a ``pm.Data`` placeholder named
+        ``batch_var`` and whose likelihood passes ``total_size=len(loader)``.
+    loader : iterable
+        Yields minibatches (arrays whose leading axis is the batch rows) and
+        supports ``len(loader) == N`` (the dataset row count).
+    batch_var : str
+        Name of the ``pm.Data`` placeholder to stream into.
+    num_iters : int
+        Number of stochastic L-BFGS steps.
+    num_elbo_draws : int
+        Monte-Carlo draws per iterate for ELBO selection.
+    num_draws : int
+        Draws returned from the selected Gaussian.
+    num_proposal_draws : int, optional
+        Size of the proposal pool importance sampling resamples down to ``num_draws``.
+        Defaults to ``4 * num_draws`` when resampling (so PSIS/PSIR actually reweight
+        rather than returning a permutation of ``num_draws`` proposals), else
+        ``num_draws``.
+    eval_rows : int
+        Rows in the fixed evaluation batch used for iterate selection.
+    full_pass : iterable, optional
+        An iterable yielding every row exactly once, used for the final exact
+        full-data ``logP`` (it is consumed once, at the end of the fit). Required
+        when iterating ``loader`` drops a trailing partial batch; defaults to
+        iterating ``loader`` itself.
+    jitter : float
+        Uniform jitter added to the prior initial point.
+    jacobian_correction : bool
+        Include the change-of-variables Jacobian so logp is the unconstrained
+        joint density (matches ``fit_pathfinder``).
+    importance_sampling : {"psis", "psir", "identity", None}
+        Post-hoc reweighting of the returned draws; ``None`` returns the proposal
+        draws unweighted. ``"identity"`` weights by the raw log ratio, so like
+        ``"psis"``/``"psir"`` it resamples from a larger pool.
+    lbfgs_config : StochasticLBFGSConfig, optional
+    random_seed : int, optional
+
+    Returns
+    -------
+    StreamingPathfinderResult
+    """
+    model = pm.modelcontext(model)
+    if batch_var not in model.named_vars:
+        raise KeyError(
+            f"batch_var {batch_var!r} is not a variable in the model; add a "
+            f"pm.Data({batch_var!r}, ...) placeholder that the data stream feeds."
+        )
+    cfg = lbfgs_config or StochasticLBFGSConfig()
+    J = cfg.maxcor
+
+    init_ss, elbo_ss, final_ss = np.random.SeedSequence(random_seed).spawn(3)
+
+    # Compile once; all functions below close over the batch_var pm.Data shared variable.
+    neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=jacobian_correction)
+    ip = Point(make_initial_point_fn(model=model)(None), model=model)
+    x_base = DictToArrayBijection.map(ip).data
+    N = x_base.shape[0]
+    sample_logp = make_pathfinder_sample_fn(model, N=N, J=J, jacobian=jacobian_correction)
+    # For the exact full-data target density (final logP + PSIS), evaluate the prior
+    # once and the observed likelihood summed across a full epoch (see _full_data_logp).
+    if model.potentials and model[batch_var] in set(ancestors(model.potentials)):
+        raise NotImplementedError(
+            "a pm.Potential that depends on the minibatch cannot be evaluated once "
+            "against the full data; move it out of the batch or fold it into the "
+            "observed likelihood."
+        )
+    prior_logp_fn = _compile_batched_logp(
+        model, [*model.free_RVs, *model.potentials], jacobian=jacobian_correction
+    )
+    obs_logp_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
+
+    def value_grad_fn(x):
+        value, grad = neg_logp_dlogp(np.asarray(x, dtype=np.float64))
+        return float(value), np.asarray(grad, dtype=np.float64)
+
+    epoch = iter(loader)
+
+    def next_batch():
+        nonlocal epoch
+        try:
+            return next(epoch)
+        except StopIteration:
+            epoch = iter(loader)
+            return next(epoch)
+
+    # Fixed held-out evaluation batch: the first eval_rows rows (capped at N).
+    n_total = len(loader)
+    target_rows = min(eval_rows, n_total)
+    chunks, rows = [], 0
+    while rows < target_rows:
+        b = next_batch()
+        chunks.append(b)
+        rows += b.shape[0]
+    eval_batch = np.concatenate(chunks, axis=0)[:target_rows]
+
+    init_rng = np.random.default_rng(init_ss)
+    x0 = x_base + init_rng.uniform(-jitter, jitter, size=N)
+    model.set_data(batch_var, next_batch())  # prime the first training batch
+
+    traj = run_stochastic_lbfgs(
+        value_grad_fn, lambda: model.set_data(batch_var, next_batch()), x0, num_iters, cfg
+    )
+    if not traj.iterates:
+        raise RuntimeError(
+            "Streaming L-BFGS produced no accepted steps; try more iterations, a "
+            "smaller jitter, or a larger batch size."
+        )
+
+    model.set_data(batch_var, eval_batch)
+    u_elbo = np.random.default_rng(elbo_ss).standard_normal((num_elbo_draws, N))
+    elbo_trace = np.empty(len(traj.iterates))
+    for k, it in enumerate(traj.iterates):
+        _, logQ, logP, _ = sample_logp(
+            it["x"], it["g"], it["alpha"], it["s_win"], it["z_win"], u_elbo
+        )
+        elbo_trace[k] = _elbo(logP, logQ)
+    elbo_argmax = int(np.argmax(elbo_trace))
+    best = traj.iterates[elbo_argmax]
+
+    # Draw from the selected Gaussian (eval batch still set). Importance resampling
+    # must draw MORE proposals than it returns, or selecting num_draws from num_draws
+    # candidates without replacement is a no-op permutation (every proposal returned
+    # once, no reweighting). Draw a larger proposal pool and resample down to num_draws.
+    resample = importance_sampling is not None
+    default_prop = (4 if resample else 1) * num_draws
+    n_prop = int(num_proposal_draws) if num_proposal_draws is not None else default_prop
+    n_prop = max(n_prop, num_draws + 1 if resample else num_draws)
+    u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
+    phi, logQ, _logP_subset, _ = sample_logp(
+        best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final
+    )
+    samples = np.asarray(phi)  # (n_prop, N) proposal draws
+    logQ = np.asarray(logQ)  # Gaussian proposal density (data-independent)
+    # The final importance target must be the EXACT full-data logP, not the eval-subset
+    # density sample_logp just returned (evaluated on the currently-set eval batch, which
+    # targets a rescaled subset pseudo-posterior). Recompute it in one streaming pass.
+    logP = _full_data_logp(
+        samples,
+        full_pass if full_pass is not None else loader,
+        model,
+        batch_var,
+        prior_logp_fn,
+        obs_logp_fn,
+        n_total,
+    )
+
+    pareto_k = None
+    if resample:
+        result = psis_fn(
+            samples[None],
+            logP[None],
+            logQ[None],
+            num_draws,
+            method=importance_sampling,
+            random_seed=int(final_ss.generate_state(1)[0]),
+        )
+        samples = np.asarray(result.samples)  # (num_draws, N) resampled from the n_prop proposals
+        pareto_k = result.pareto_k
+    else:
+        samples = samples[:num_draws]
+
+    return StreamingPathfinderResult(
+        samples=samples,
+        logP=logP,
+        logQ=logQ,
+        elbo_trace=elbo_trace,
+        elbo_argmax=elbo_argmax,
+        pareto_k=pareto_k,
+        violation_rate=traj.violation_rate,
+        n_ls_failures=traj.n_ls_failures,
+    )

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -46,8 +46,8 @@ __all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
 
 # Fraction of the trajectory's iterate positions that the tail average covers. Not a keyword.
 # Swept over 0.50/0.60/0.75/0.90 at the Notes k=8, N=1e5 configuration, scoring worst-coordinate
-# position error |x_avg - full-data MAP| in reference-sd: medians over 8 seeds 0.86/0.80/0.68/0.80,
-# against 5.06 at 1.00. The interior is flat; the only firm result is that 1.00 is broken.
+# position error |x_avg - full-data MAP| in reference-sd: the interior is flat, and the only firm
+# result is that 1.00 (a plain mean of every iterate) is several times worse.
 _TAIL_AVERAGE_FRAC = 0.75
 
 
@@ -205,11 +205,11 @@ def fit_streaming_pathfinder(
     Measured operating range. Bayesian logistic regression, Normal(0, 2) prior, batch 2048 from a
     *shuffled* loader (part of the configuration, not an aside), ``num_iters=200``, ``maxcor=6``,
     ``jitter=2.0``, ``num_draws=1000``, ``num_proposal_draws=4000``, PSIS, scored against an exact
-    full-data Laplace reference. At k=8, N=1e5 over 12 seeds ``pareto_k`` ran 0.60-0.80 (median
-    0.70, over 0.7 on half of them) and the worst coordinate of the *resampled posterior mean* was
-    0.23-0.58 reference-sd from the reference mean. At N=4e5 over 6 seeds that was 0.76-1.29 and
-    0.53-2.24. At k=100, N=1e5 over 4 seeds it was 2.0-3.8 and 13-64, nothing raises, and two of
-    the four came back with a nonzero ``n_ls_failures``; ``violation_rate`` read 0.0 throughout.
+    full-data Laplace reference. At k=8, N=1e5 over 12 seeds ``pareto_k`` ran 0.26-0.58 and the
+    worst coordinate of the *resampled posterior mean* was 0.05-0.30 reference-sd from the
+    reference mean. At N=4e5 over 6 seeds that was 0.48-1.04 and 0.15-1.58. At k=100, N=1e5 over
+    4 seeds it was 2.7-4.3 and 52-59, nothing raises, and two of the four came back with a
+    nonzero ``n_ls_failures``; ``violation_rate`` read 0.0 throughout.
 
     These draws are a *proposal*, not a posterior. Read ``pareto_k`` on every fit, and do not run
     this above a few tens of dimensions.
@@ -269,9 +269,9 @@ def fit_streaming_pathfinder(
     n_total = getattr(loader, "total_size", None)
     if n_total is None:
         raise TypeError(
-            "loader must expose total_size (the dataset row count N), as "
-            "pymc_extras DataLoader does; wrap a plain iterable in "
-            "DataLoader(source, batch_size=..., total_size=N)."
+            "loader must expose an integer total_size (the dataset row count N); "
+            "construct DataLoader(..., total_size=N or 'auto'), or wrap a plain "
+            "iterable in DataLoader(source, batch_size=..., total_size=N)."
         )
     n_total = int(n_total)
     init_rng = np.random.default_rng(init_ss)
@@ -294,10 +294,11 @@ def fit_streaming_pathfinder(
             )
 
         # Polyak-Ruppert tail averaging of the iterate positions. Each step's accepted point sits
-        # near its own minibatch's MAP -- worst-coordinate relative error, median over 200 random
-        # batches, ran 9.1% at b=512, 4.3% at 2048 and 2.2% at 8192, with the b=512 tail at 36% --
-        # and that error is in the location, not the covariance, so no rule that *picks* an
-        # iterate removes it. g is zeroed because the sampler centres at mu = x - H_inv @ g, and
+        # near its own minibatch's MAP, whose error is in the location, not the covariance:
+        # worst-coordinate, median over 200 random batches against the full-data posterior, the
+        # relative *sd* error ran 9.1% at b=512, 4.3% at 2048 and 2.2% at 8192 (b=512 tail 36%)
+        # while the MAP sat 25/12/6 reference-sd off. No rule that *picks* an iterate removes a
+        # location error. g is zeroed because the sampler centres at mu = x - H_inv @ g, and
         # keeping the last iterate's g moved that centre further from the full-data MAP on all of
         # 12 seeds; curvature stays the last iterate's -- averaged (s, z) is not a valid memory.
         m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -2,7 +2,7 @@
 
 Runs Pathfinder where the log-density gradients come from minibatches yielded by
 a sized re-iterable loader, rather than the full dataset. The model carries the
-data in a ``pm.Data`` placeholder scaled with ``total_size=len(loader)``, so
+data in a ``pm.Data`` placeholder scaled with ``total_size=loader.total_size``, so
 ``model.logp()`` already returns the correctly rescaled full-data log-density for
 whatever batch is currently set.
 
@@ -124,9 +124,9 @@ def _full_data_logp(phi, full_pass, model, batch_var, prior_fn, obs_fn, n_total)
         seen += b.shape[0]
     if seen != n_total:
         raise RuntimeError(
-            f"full-data logp pass visited {seen} rows but len(loader)={n_total}; the "
-            "pass must yield every row exactly once for an exact logP. A loader epoch "
-            "that drops its trailing partial batch cannot do that, so pass full_pass="
+            f"full-data logp pass visited {seen} rows but total_size={n_total}; the "
+            "pass must yield every row exactly once for an exact logP. A shuffled "
+            "DataLoader epoch drops its trailing partial batch, so pass full_pass="
             "<the loader's dataset source> instead."
         )
     return lp
@@ -154,10 +154,11 @@ def fit_streaming_pathfinder(
     ----------
     model : pymc.Model
         A model whose data enter through a ``pm.Data`` placeholder named
-        ``batch_var`` and whose likelihood passes ``total_size=len(loader)``.
+        ``batch_var`` and whose likelihood passes ``total_size=loader.total_size``.
     loader : iterable
         Yields minibatches (arrays whose leading axis is the batch rows) and
-        supports ``len(loader) == N`` (the dataset row count).
+        exposes ``loader.total_size == N`` (the dataset row count), as
+        :class:`pymc_extras.variational.DataLoader` does.
     batch_var : str
         Name of the ``pm.Data`` placeholder to stream into. The value it held on entry is
         restored before returning, on the exception path too.
@@ -173,8 +174,10 @@ def fit_streaming_pathfinder(
         any large dataset this setting dominates the cost of the fit.
     full_pass : iterable, optional
         Row blocks visiting every row exactly once, for the final exact full-data ``logP``;
-        consumed once. Defaults to iterating ``loader``, and a loader epoch that drops its
-        trailing rows raises rather than return a subset-rescaled ``logP``. Block sizes need
+        consumed once. Defaults to iterating ``loader``: an unshuffled DataLoader passes its
+        source through verbatim and is a valid exact pass, while a shuffled epoch drops its
+        trailing partial batch and raises here rather than return a subset-rescaled ``logP``
+        — pass the underlying source in that case. Block sizes need
         not match the loader's. Blocks are installed in ``batch_var`` unchanged, so if
         ``loader`` transforms its batches, ``full_pass`` must apply the identical transform:
         untransformed rows give a wrong ``logP`` and wrong draws, with no error to say so.
@@ -265,7 +268,14 @@ def fit_streaming_pathfinder(
             epoch = iter(loader)
             return next(epoch)
 
-    n_total = len(loader)
+    n_total = getattr(loader, "total_size", None)
+    if n_total is None:
+        raise TypeError(
+            "loader must expose total_size (the dataset row count N), as "
+            "pymc_extras DataLoader does; wrap a plain iterable in "
+            "DataLoader(source, batch_size=..., total_size=N)."
+        )
+    n_total = int(n_total)
     init_rng = np.random.default_rng(init_ss)
     x0 = x_base + init_rng.uniform(-jitter, jitter, size=N)
     try:

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -15,9 +15,14 @@ The draws it returns are a proposal, not a posterior; the measured operating ran
 dataset size and dimension, is on :func:`fit_streaming_pathfinder`.
 
 What streaming buys is memory: the optimizer only ever holds one minibatch, and the final
-exact ``logP`` is accumulated block by block over ``full_pass``, so nothing here is sized by
-the row count. ``fit_pathfinder`` materializes the whole dataset instead. No ratio is quoted
-because the earlier one did not say what it measured.
+exact ``logP`` is accumulated block by block over ``full_pass``, so the peak is set by the
+block size rather than the row count. The caller sets that block size, though, and
+``full_pass`` defaults to ``loader`` -- hand the whole dataset over as a single block and the
+peak is O(N) again. It is also O(``num_proposal_draws`` x block rows), because each block's
+log-density is evaluated for the whole proposal pool at once: on a 200k-row dataset with 100
+proposal draws, peak traced allocation was 40 MB with 2048-row blocks and 231 MB with one
+block. ``fit_pathfinder`` materializes the whole dataset unconditionally. No ratio against it
+is quoted because the earlier one did not say what it measured.
 """
 
 from dataclasses import dataclass
@@ -47,12 +52,14 @@ __all__ = ["StreamingPathfinderResult", "fit_streaming_pathfinder"]
 
 # Fraction of the trajectory's iterate positions that the tail average covers. Not a
 # keyword. Swept over one trajectory per seed at the Notes k=8, N=1e5 configuration, 8 seeds,
-# scoring worst-coordinate |x_avg - full-data MAP| in reference-sd: the medians over
-# 0.50/0.60/0.75/0.90 are 0.86/0.80/0.68/0.80, a spread of 1.26x, while 1.00 is 5.06 (7.4x the
-# best) and 0.10 is 3.17. So the interior is shallow and the endpoint is the cliff. 0.50 vs
-# 0.75 paired per seed differs by +0.13 ref-sd (95% CI -0.05 to +0.31), which 8 seeds do not
-# resolve; 0.75 is the better point estimate and the only thing the knob reliably teaches is
-# that 1.00 is broken.
+# scoring worst-coordinate *position* error |x_avg - full-data MAP| in reference-sd. That is
+# a different quantity from the posterior-mean error the Notes quote, which scores the
+# resampled draws rather than the optimizer's position, and the two do not compare. The
+# medians over 0.50/0.60/0.75/0.90 are 0.86/0.80/0.68/0.80, a spread of 1.26x, while 1.00 is
+# 5.06 (7.4x the best) and 0.10 is 3.17. So the interior is shallow and the endpoint is the
+# cliff. 0.50 vs 0.75 paired per seed differs by +0.13 ref-sd (95% CI -0.05 to +0.31), which
+# 8 seeds do not resolve; 0.75 is the better point estimate and the only thing the knob
+# reliably teaches is that 1.00 is broken.
 _TAIL_AVERAGE_FRAC = 0.75
 
 
@@ -164,7 +171,10 @@ def fit_streaming_pathfinder(
         Yields minibatches (arrays whose leading axis is the batch rows) and
         supports ``len(loader) == N`` (the dataset row count).
     batch_var : str
-        Name of the ``pm.Data`` placeholder to stream into.
+        Name of the ``pm.Data`` placeholder to stream into. The fit installs batches into
+        it and restores the value it held on entry before returning, on the exception path
+        too, so a ``model.logp()`` or ``pm.sample()`` after the fit scores the data the
+        caller put there rather than the last block this function happened to install.
     num_iters : int
         Number of stochastic L-BFGS steps.
     num_draws : int
@@ -221,14 +231,17 @@ def fit_streaming_pathfinder(
     same order every epoch, and none of this was measured that way.
 
     With k=8 at N=1e5, over 12 seeds, ``pareto_k`` ran 0.60-0.80 (median 0.70, over 0.7 on half
-    of them) and the worst posterior-mean coordinate was 0.23-0.58 reference-sd out. Accuracy
+    of them) and the worst coordinate of the *resampled posterior mean* was 0.23-0.58
+    reference-sd from the reference mean -- a different quantity from the optimizer-position
+    error swept for ``_TAIL_AVERAGE_FRAC``, which scores ``x_avg`` against the MAP. Accuracy
     degrades with N -- ``pareto_k`` 0.76-1.29 and error 0.53-2.24 ref-sd over 6 seeds at N=4e5 --
     and much faster with dimension: at k=100, N=1e5 it was 2.0-3.8 and 13-64 ref-sd over 4 seeds,
     and nothing raises, so that fit returns silently wrong draws.
 
     These draws are a *proposal*, not a posterior. Read ``pareto_k`` on every fit, and do not run
     this above a few tens of dimensions. ``violation_rate`` is an optimizer-health counter, not
-    an accuracy one; it read 0.0 with no line-search failures on every run above.
+    an accuracy one; it read 0.0 on every run above. ``n_ls_failures`` did not stay at zero:
+    at k=100, N=1e5 two of four seeds came back with a nonzero count.
     """
     model = pm.modelcontext(model)
     if batch_var not in model.named_vars:
@@ -236,6 +249,11 @@ def fit_streaming_pathfinder(
             f"batch_var {batch_var!r} is not a variable in the model; add a "
             f"pm.Data({batch_var!r}, ...) placeholder that the data stream feeds."
         )
+    # Restored in the finally below. get_value() copies, so a caller that mutates its own
+    # array in place cannot corrupt the saved copy. If the incoming value was itself one
+    # batch rather than the whole dataset, putting it back still leaves the model in the
+    # state the caller built, which is what a restore can promise.
+    saved_batch = model[batch_var].get_value()
     cfg = lbfgs_config or StochasticLBFGSConfig()
     J = cfg.maxcor
 
@@ -275,65 +293,74 @@ def fit_streaming_pathfinder(
     n_total = len(loader)
     init_rng = np.random.default_rng(init_ss)
     x0 = x_base + init_rng.uniform(-jitter, jitter, size=N)
-    model.set_data(batch_var, next_batch())
+    try:
+        model.set_data(batch_var, next_batch())
 
-    traj = run_stochastic_lbfgs(
-        value_grad_fn,
-        lambda: model.set_data(batch_var, next_batch()),
-        x0,
-        num_iters,
-        cfg,
-        callbacks,
-    )
-    if not traj.iterates:
-        raise RuntimeError(
-            "Streaming L-BFGS produced no accepted steps; try more iterations, a "
-            "smaller jitter, or a larger batch size."
+        traj = run_stochastic_lbfgs(
+            value_grad_fn,
+            lambda: model.set_data(batch_var, next_batch()),
+            x0,
+            num_iters,
+            cfg,
+            callbacks,
         )
+        if not traj.iterates:
+            raise RuntimeError(
+                "Streaming L-BFGS produced no accepted steps; try more iterations, a "
+                "smaller jitter, or a larger batch size."
+            )
 
-    # Polyak-Ruppert tail averaging of the iterate positions (Polyak & Juditsky 1992; Jain
-    # et al. 2018). Each step is a full quasi-Newton step plus line search on ONE minibatch, so
-    # its accepted point sits near that minibatch's MAP: measured roughly sqrt(N / b) full-data
-    # posterior-sd away in per-coordinate RMS, on a batch that still reproduces the posterior sd
-    # to within ~10%. The error is in the location, not the covariance, so no rule that *picks*
-    # an iterate removes it. g is zeroed because the sampler centres at mu = x - H_inv @ g, and
-    # keeping the last iterate's g moved that centre further from the full-data MAP on all of
-    # 12 seeds; curvature stays the last iterate's -- averaged (s, z) is not a valid memory.
-    m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))
-    x_avg = np.mean([it["x"] for it in traj.iterates[-m:]], axis=0)
-    last = traj.iterates[-1]
-    best = {
-        "x": x_avg,
-        "g": np.zeros_like(x_avg),
-        "alpha": last["alpha"],
-        "s_win": last["s_win"],
-        "z_win": last["z_win"],
-    }
+        # Polyak-Ruppert tail averaging of the iterate positions (Polyak & Juditsky 1992; Jain
+        # et al. 2018). Each step is a full quasi-Newton step plus line search on ONE minibatch,
+        # so its accepted point sits near that minibatch's MAP: measured roughly sqrt(N / b)
+        # full-data posterior-sd away in per-coordinate RMS, on a batch whose own rescaled
+        # posterior still reproduces the full-data posterior sd -- worst-coordinate relative
+        # error, median over 200 random batches, ran 9.1% at b=512, 4.3% at 2048 and 2.2% at
+        # 8192, though the b=512 tail reached 36%. The error is in the location, not the
+        # covariance, so
+        # no rule that *picks* an iterate removes it. g is zeroed because the sampler centres at
+        # mu = x - H_inv @ g, and keeping the last iterate's g moved that centre further from
+        # the full-data MAP on all of 12 seeds; curvature stays the last iterate's -- averaged
+        # (s, z) is not a valid memory.
+        m = max(1, round(_TAIL_AVERAGE_FRAC * len(traj.iterates)))
+        x_avg = np.mean([it["x"] for it in traj.iterates[-m:]], axis=0)
+        last = traj.iterates[-1]
+        best = {
+            "x": x_avg,
+            "g": np.zeros_like(x_avg),
+            "alpha": last["alpha"],
+            "s_win": last["s_win"],
+            "z_win": last["z_win"],
+        }
 
-    resample = importance_sampling is not None
-    if num_proposal_draws is None:
-        # fit_pathfinder resamples num_draws out of num_paths=4 x num_draws_per_path=1000;
-        # a single streaming path has to supply that 4x pool itself. Unresampled the extra
-        # draws are only dropped, and the pool's logP pass is most of the wall clock.
-        n_prop = 4 * num_draws if resample else num_draws
-    else:
-        n_prop = max(int(num_proposal_draws), num_draws)  # samples[:num_draws] must not be short
-    u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
-    phi, logQ, _logP_subset, _ = sample_logp(
-        best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final
-    )
-    samples = np.asarray(phi)
-    logQ = np.asarray(logQ)
-    # sample_logp's logP is the installed batch's pseudo-density; the weights need the exact one.
-    logP = _full_data_logp(
-        samples,
-        full_pass if full_pass is not None else loader,
-        model,
-        batch_var,
-        prior_logp_fn,
-        obs_logp_fn,
-        n_total,
-    )
+        resample = importance_sampling is not None
+        if num_proposal_draws is None:
+            # fit_pathfinder resamples num_draws out of num_paths=4 x num_draws_per_path=1000;
+            # a single streaming path has to supply that 4x pool itself. Unresampled the extra
+            # draws are only dropped, and the pool's logP pass is most of the wall clock.
+            n_prop = 4 * num_draws if resample else num_draws
+        else:
+            # samples[:num_draws] must not be short
+            n_prop = max(int(num_proposal_draws), num_draws)
+        u_final = np.random.default_rng(final_ss).standard_normal((n_prop, N))
+        phi, logQ, _logP_subset, _ = sample_logp(
+            best["x"], best["g"], best["alpha"], best["s_win"], best["z_win"], u_final
+        )
+        samples = np.asarray(phi)
+        logQ = np.asarray(logQ)
+        # sample_logp's logP is the installed batch's pseudo-density; the weights need the
+        # exact one.
+        logP = _full_data_logp(
+            samples,
+            full_pass if full_pass is not None else loader,
+            model,
+            batch_var,
+            prior_logp_fn,
+            obs_logp_fn,
+            n_total,
+        )
+    finally:
+        model.set_data(batch_var, saved_batch)
 
     pareto_k = None
     if resample:

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -61,11 +61,9 @@ class StreamingPathfinderResult:
         Posterior draws in the model's raveled unconstrained space. When importance
         sampling is active these are resampled from a larger proposal pool.
     logP, logQ : ndarray
-        Target and proposal log-densities of the *proposal* draws (length equals the
-        proposal pool, ``num_proposal_draws``). They are the weights behind the
-        resampling and are row-aligned with ``samples`` only when importance sampling
-        is off (``None``); after resampling they are proposal-space diagnostics, not
-        per-``samples``-row densities.
+        Target and proposal log-densities of the proposal pool. Row-aligned with
+        ``samples`` only when importance sampling is ``None``; after resampling they
+        are proposal-space diagnostics, not per-``samples``-row densities.
     pareto_k : float or None
         PSIS Pareto shape diagnostic (None when importance sampling is disabled).
     violation_rate : float

--- a/pymc_extras/inference/pathfinder/streaming_pathfinder.py
+++ b/pymc_extras/inference/pathfinder/streaming_pathfinder.py
@@ -117,6 +117,8 @@ def _full_data_logp(phi, full_pass, model, batch_var, prior_fn, obs_fn, n_total)
     seen = 0
     for batch in full_pass:  # one complete epoch; order is irrelevant to the sum
         b = np.asarray(batch)
+        if b.shape[0] == 0:
+            continue  # a zero-row block contributes nothing; scoring it makes 0 * inf
         model.set_data(batch_var, b)
         lp = lp + (b.shape[0] / n_total) * np.asarray(obs_fn(phi), dtype=np.float64)
         seen += b.shape[0]
@@ -191,10 +193,15 @@ def fit_streaming_pathfinder(
     lbfgs_config : StochasticLBFGSConfig, optional
     callbacks : iterable of callable, optional
         ``pm.fit`` callbacks, called ``(None, losses, i)`` after each optimizer step;
+        they must not mutate the model's data: the optimizer caches the current batch's
+        value and gradient across the callback boundary.
         one raising ``StopIteration`` stops the optimization and the fit proceeds with
         the iterates recorded so far. ``losses`` are minibatch objectives, so they are
         noisy; ``approx`` is ``None`` because there is no ``Approximation`` here.
     random_seed : int, optional
+        Seeds the initial point, the jitter, the proposal draws, and the resampling.
+        The minibatch sequence is the loader's own: construct the loader with an
+        explicit seed for a reproducible stream.
 
     Returns
     -------
@@ -233,18 +240,22 @@ def fit_streaming_pathfinder(
     cfg = lbfgs_config or StochasticLBFGSConfig()
     J = cfg.maxcor
 
-    init_ss, final_ss, resample_ss = np.random.SeedSequence(random_seed).spawn(3)
+    init_ss, final_ss, resample_ss, ip_ss = np.random.SeedSequence(random_seed).spawn(4)
 
     # Compile once; all functions below close over the batch_var pm.Data shared variable.
     neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=jacobian_correction)
-    ip = Point(make_initial_point_fn(model=model)(None), model=model)
+    # Seeded: an initval="prior" model draws its starting point here, and an unseeded
+    # draw silently breaks the random_seed reproducibility contract.
+    ip_seed = int(ip_ss.generate_state(1)[0])
+    ip = Point(make_initial_point_fn(model=model)(ip_seed), model=model)
     x_base = DictToArrayBijection.map(ip).data
     N = x_base.shape[0]
     sample_logp = make_pathfinder_sample_fn(model, N=N, J=J, jacobian=jacobian_correction)
-    if model.potentials and model[batch_var] in set(ancestors(model.potentials)):
+    once_terms = [*model.free_RVs, *model.potentials]
+    if model[batch_var] in set(ancestors(once_terms)):
         raise NotImplementedError(
-            "a pm.Potential that depends on the minibatch cannot be evaluated once "
-            "against the full data; move it out of the batch or fold it into the "
+            "a prior or pm.Potential that depends on the minibatch cannot be evaluated "
+            "once against the full data; move it out of the batch or fold it into the "
             "observed likelihood."
         )
     prior_logp_fn = _compile_batched_logp(

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -195,14 +195,19 @@ def test_config_rejects_settings_that_make_a_wrong_fit_look_healthy(kw):
 
 def test_a_callback_can_end_the_run_early():
     """StopIteration from a callback ends the loop, so an early-stopping rule written
-    against pm.fit's callback contract works here unchanged."""
+    against pm.fit's callback contract works here unchanged.
+
+    pm.fit hands each callback ``(approx, scores[: i + 1], i + 1)``: the losses so far,
+    and a 1-based step index. A rule that reads more than the last loss — every
+    convergence check does — is silently starved by a one-element list.
+    """
     rng = np.random.default_rng(31)
     M = rng.normal(size=(4, 4))
     A = M @ M.T + 4 * np.eye(4)
-    losses = []
+    seen = []
 
     def stop_at_5(approx, loss, i):
-        losses.append(float(loss[-1]))
+        seen.append((approx, len(loss), i, float(loss[-1])))
         if i == 5:
             raise StopIteration
 
@@ -213,8 +218,9 @@ def test_a_callback_can_end_the_run_early():
         num_iters=50,
         callbacks=(stop_at_5,),
     )
-    assert len(losses) == 5
+    assert [(a, n, i) for a, n, i, _ in seen] == [(None, j, j) for j in range(1, 6)]
     assert len(traj.iterates) <= 5
+    losses = [f for *_, f in seen]
     assert losses == sorted(losses, reverse=True)  # the callback is handed a minimized loss
 
 

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -1,5 +1,6 @@
 """Analytic-objective tests for the stochastic L-BFGS optimizer."""
 
+import collections
 import itertools
 
 import numpy as np
@@ -108,22 +109,25 @@ def test_line_search_decreases_objective_each_step():
 
 
 def test_no_duplicate_gradient_evaluations():
-    """The accepted trial's gradient comes from the call that tested it, not a re-evaluation."""
-    rng = np.random.default_rng(30)
-    A = np.diag([1.0, 2.0, 4.0])
-    vg = quadratic(A, rng.normal(size=3))
+    """The accepted trial's gradient comes from the call that tested it, not a re-evaluation.
+
+    On a well-conditioned quadratic started near the optimum every step accepts its first
+    trial, so a step costs exactly two evaluations: the trial, and the re-measurement on the
+    batch installed after it. Re-fetching the accepted gradient would make it three.
+    """
+    vg = quadratic(np.eye(3), np.zeros(3))
     state = {"batch": 0}
-    seen = []
+    per_batch = collections.Counter()
 
     def tagged(x):
-        seen.append((state["batch"], tuple(x)))
+        per_batch[state["batch"]] += 1
         return vg(x)
 
     def advance():
         state["batch"] += 1
 
-    run_stochastic_lbfgs(tagged, advance, np.array([3.0, -3.0, 3.0]), num_iters=25)
-    assert len(seen) == len(set(seen)), "a point was evaluated twice on the same batch"
+    run_stochastic_lbfgs(tagged, advance, np.array([0.3, -0.2, 0.1]), num_iters=6)
+    assert all(c == 2 for c in list(per_batch.values())[:-1]), dict(per_batch)
 
 
 @pytest.mark.parametrize("kw", [{"backtrack": -0.5}, {"maxcor": 0}])

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -99,9 +99,8 @@ def test_two_loop_direction_matches_dense_bfgs():
     assert np.allclose(d, -H @ g, atol=1e-10)
 
 
-def test_a_pair_with_zero_curvature_drops_out_of_the_recursion():
-    """The recursion divides by ``s . y``, so an exactly orthogonal pair has to be
-    skipped rather than contribute an infinite coefficient."""
+def test_zero_curvature_pair_skipped():
+    """The recursion divides by s.y, so an orthogonal pair is skipped, not divided by."""
     s_win = np.zeros((3, 2))
     z_win = np.zeros((3, 2))
     s_win[:, 0], z_win[:, 0] = [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]
@@ -133,12 +132,8 @@ def test_line_search_decreases_objective_each_step():
     assert all(v2 <= v1 + 1e-9 for v1, v2 in itertools.pairwise(values))
 
 
-def test_no_point_is_evaluated_twice_within_a_step():
-    """The accepted trial's gradient comes from the call that tested it.
-
-    Re-evaluating the accepted point to fetch a gradient the joint value_grad_fn already
-    returned costs a full logp+grad pass per step, and no counter reports it.
-    """
+def test_no_duplicate_gradient_evaluations():
+    """The accepted trial's gradient comes from the call that tested it, not a re-evaluation."""
     rng = np.random.default_rng(30)
     A = np.diag([1.0, 2.0, 4.0])
     vg = quadratic(A, rng.normal(size=3))
@@ -157,17 +152,15 @@ def test_no_point_is_evaluated_twice_within_a_step():
 
 
 @pytest.mark.parametrize("kw", [{"backtrack": -0.5}, {"maxcor": 0}])
-def test_config_rejects_settings_that_make_a_wrong_fit_look_healthy(kw):
-    """backtrack outside (0, 1) is the dangerous one: a negative step length satisfies
-    the Armijo bound trivially, so the run climbs while every counter reads clean."""
+def test_config_rejects_invalid_settings(kw):
+    """Settings that would silently break the line search or the history are refused."""
     with pytest.raises(ValueError):
         StochasticLBFGSConfig(**kw)
 
 
 def test_line_search_exhaustion_handled():
-    """When Armijo can never be satisfied the step is flagged, not crashed, and the loop
-    still moves on to fresh data — holding both x and the batch replays the identical
-    failing step forever, and only n_ls_failures would ever show it."""
+    """When Armijo can never be satisfied the step is flagged, not crashed, and the batch
+    still advances so the next step does not replay the same failure."""
 
     def vg(x):
         # constant value with a nonzero gradient: no step ever decreases f
@@ -280,6 +273,7 @@ def test_both_gradients_of_every_accepted_pair_come_from_one_batch():
     rng = np.random.default_rng(20)
     A = np.diag([1.0, 2.0, 5.0])
     J = 4
+    num_iters = 40
     state = {"batch": 0, "b": rng.normal(0, 0.3, size=3)}
     log = []
 
@@ -296,7 +290,7 @@ def test_both_gradients_of_every_accepted_pair_come_from_one_batch():
         vg,
         advance,
         np.array([4.0, -4.0, 4.0]),
-        num_iters=40,
+        num_iters=num_iters,
         config=StochasticLBFGSConfig(maxcor=J),
     )
     assert traj.n_accepted > J
@@ -312,7 +306,7 @@ def test_both_gradients_of_every_accepted_pair_come_from_one_batch():
         np.testing.assert_array_equal(it["s_win"][:, newest], it["x"] - x_first)
         np.testing.assert_array_equal(it["z_win"][:, newest], it["g"] - g_first)
 
-    assert sorted({b for b, _, _ in log}) == list(range(41))
+    assert sorted({b for b, _, _ in log}) == list(range(num_iters + 1))
 
 
 @pytest.mark.parametrize("J, n_pairs", [(1, 1), (2, 5), (3, 2), (3, 3), (3, 7), (6, 4), (6, 13)])
@@ -384,3 +378,44 @@ def test_window_layout_holds_before_the_ring_wraps():
             )
         np.testing.assert_array_equal(it["s_win"][:, n_valid:], 0.0)
         np.testing.assert_array_equal(it["z_win"][:, n_valid:], 0.0)
+
+
+def test_recorded_loss_is_measured_after_the_batch_advance():
+    """``losses[i]`` is the objective at the position step ``i + 1`` reached, measured on
+    the batch installed *after* that step -- not the value its Armijo test accepted.
+
+    The two differ: the accepted value is measured on the batch the position was chosen to
+    minimize, so it reads low against the full-data objective, while the recorded one is
+    measured on a batch the step never saw. A monitor such as
+    ``pymc.variational.callbacks.CheckLossConvergence`` consumes exactly this series, so
+    which of the two it gets is part of the contract.
+
+    The objective carries a per-batch offset that the gradient does not, so the trajectory
+    is identical on every batch while each recorded value still names the batch it came
+    from: the offset cancels inside the Armijo test, which only ever compares two values on
+    one batch.
+    """
+    offset = 1000.0
+    centre = np.array([1.0, -2.0, 0.5])
+    curv = np.array([1.0, 3.0, 9.0])  # ill-conditioned: no single step reaches the minimum
+    state = {"b": 0}
+
+    def vg(x):
+        d = x - centre
+        return 0.5 * (d * curv) @ d + state["b"] * offset, curv * d
+
+    def advance():
+        state["b"] += 1
+
+    losses = []
+    traj = run_stochastic_lbfgs(
+        vg, advance, np.zeros(3), num_iters=5, callbacks=[lambda a, L, i: losses.append(L[-1])]
+    )
+
+    assert traj.n_accepted == 5, "every step must be accepted for the positions to line up"
+    assert len(losses) == 5
+    for i, it in enumerate(traj.iterates):
+        d = it["x"] - centre
+        quad = 0.5 * (d * curv) @ d
+        # batch (i + 1), not batch i: the advance has already run when the loss is recorded.
+        assert losses[i] == pytest.approx(quad + (i + 1) * offset, rel=1e-12)

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -386,9 +386,8 @@ def test_recorded_loss_is_measured_after_the_batch_advance():
 
     The two differ: the accepted value is measured on the batch the position was chosen to
     minimize, so it reads low against the full-data objective, while the recorded one is
-    measured on a batch the step never saw. A monitor such as
-    ``pymc.variational.callbacks.CheckLossConvergence`` consumes exactly this series, so
-    which of the two it gets is part of the contract.
+    measured on a batch the step never saw. Any loss-based convergence monitor consumes
+    exactly this series, so which of the two it gets is part of the contract.
 
     The objective carries a per-batch offset that the gradient does not, so the trajectory
     is identical on every batch while each recorded value still names the batch it came

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -77,28 +77,6 @@ def test_quadratic_full_batch_converges_to_optimum():
     assert traj.violation_rate == 0.0  # a quadratic never violates curvature
 
 
-def test_two_loop_direction_matches_dense_bfgs():
-    """After one pair, the two-loop direction equals -(diag-init BFGS update) . g."""
-    rng = np.random.default_rng(1)
-    N = 4
-    s = rng.normal(size=N)
-    y = s * np.array([2.0, 3.0, 1.5, 4.0]) + 0.01  # ensure s.y > 0
-    alpha = np.abs(rng.normal(size=N)) + 0.5
-    g = rng.normal(size=N)
-
-    s_win = s[:, None]
-    z_win = y[:, None]
-    d = _two_loop_direction(g, alpha, s_win, z_win, order=[0])
-
-    # Dense reference: H0 = diag(alpha); one BFGS inverse-Hessian update.
-    rho = 1.0 / (s @ y)
-    H0 = np.diag(alpha)
-    Ident = np.eye(N)
-    V = Ident - rho * np.outer(s, y)
-    H = V @ H0 @ V.T + rho * np.outer(s, s)
-    assert np.allclose(d, -H @ g, atol=1e-10)
-
-
 def test_zero_curvature_pair_skipped():
     """The recursion divides by s.y, so an orthogonal pair is skipped, not divided by."""
     s_win = np.zeros((3, 2))
@@ -112,13 +90,6 @@ def test_zero_curvature_pair_skipped():
     np.testing.assert_allclose(
         d, _two_loop_direction(g, alpha, s_win[:, [1]], z_win[:, [1]], order=[0])
     )
-
-
-def test_pair_rejected_when_curvature_violated():
-    """A step crossing a negative-curvature region gives s.y < 0 and is rejected."""
-    traj = run_stochastic_lbfgs(double_well, noop, np.array([0.3]), num_iters=8)
-    assert traj.n_curvature_violations >= 1
-    assert traj.n_accepted + traj.n_curvature_violations + traj.n_null == 8
 
 
 def test_line_search_decreases_objective_each_step():
@@ -381,19 +352,9 @@ def test_window_layout_holds_before_the_ring_wraps():
 
 
 def test_recorded_loss_is_measured_after_the_batch_advance():
-    """``losses[i]`` is the objective at the position step ``i + 1`` reached, measured on
-    the batch installed *after* that step -- not the value its Armijo test accepted.
-
-    The two differ: the accepted value is measured on the batch the position was chosen to
-    minimize, so it reads low against the full-data objective, while the recorded one is
-    measured on a batch the step never saw. Any loss-based convergence monitor consumes
-    exactly this series, so which of the two it gets is part of the contract.
-
-    The objective carries a per-batch offset that the gradient does not, so the trajectory
-    is identical on every batch while each recorded value still names the batch it came
-    from: the offset cancels inside the Armijo test, which only ever compares two values on
-    one batch.
-    """
+    """``losses[i]`` is measured on the batch installed after step ``i + 1``, not the value
+    that step's Armijo test accepted. The per-batch offset is what makes the two
+    distinguishable; it cancels inside Armijo, which only compares values on one batch."""
     offset = 1000.0
     centre = np.array([1.0, -2.0, 0.5])
     curv = np.array([1.0, 3.0, 9.0])  # ill-conditioned: no single step reaches the minimum

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -156,36 +156,7 @@ def test_no_point_is_evaluated_twice_within_a_step():
     assert len(seen) == len(set(seen)), "a point was evaluated twice on the same batch"
 
 
-def test_failed_line_search_holds_x_but_still_advances_the_batch():
-    """A step that cannot satisfy Armijo must still move on to fresh data.
-
-    Holding both x and the batch re-runs the identical failing step forever, and only
-    n_ls_failures would ever show it.
-    """
-    x0 = np.zeros(2)
-    xs = []
-
-    def vg(x):
-        xs.append(tuple(x))
-        return 1.0, np.array([1.0, 1.0])  # constant value, nonzero gradient
-
-    advances = []
-    traj = run_stochastic_lbfgs(
-        vg,
-        lambda: advances.append(1),
-        x0,
-        num_iters=4,
-        config=StochasticLBFGSConfig(maxls=3),
-    )
-    assert traj.n_ls_failures == 4
-    assert len(advances) == 4
-    assert traj.iterates == []
-    assert xs.count(tuple(x0)) == 5  # the opening evaluation plus one per held step
-
-
-@pytest.mark.parametrize(
-    "kw", [{"backtrack": 1.0}, {"backtrack": -0.5}, {"maxcor": 0}, {"maxls": 0}]
-)
+@pytest.mark.parametrize("kw", [{"backtrack": -0.5}, {"maxcor": 0}])
 def test_config_rejects_settings_that_make_a_wrong_fit_look_healthy(kw):
     """backtrack outside (0, 1) is the dangerous one: a negative step length satisfies
     the Armijo bound trivially, so the run climbs while every counter reads clean."""
@@ -193,48 +164,25 @@ def test_config_rejects_settings_that_make_a_wrong_fit_look_healthy(kw):
         StochasticLBFGSConfig(**kw)
 
 
-def test_a_callback_can_end_the_run_early():
-    """StopIteration from a callback ends the loop, so an early-stopping rule written
-    against pm.fit's callback contract works here unchanged.
-
-    pm.fit hands each callback ``(approx, scores[: i + 1], i + 1)``: the losses so far,
-    and a 1-based step index. A rule that reads more than the last loss — every
-    convergence check does — is silently starved by a one-element list.
-    """
-    rng = np.random.default_rng(31)
-    M = rng.normal(size=(4, 4))
-    A = M @ M.T + 4 * np.eye(4)
-    seen = []
-
-    def stop_at_5(approx, loss, i):
-        seen.append((approx, len(loss), i, float(loss[-1])))
-        if i == 5:
-            raise StopIteration
-
-    traj = run_stochastic_lbfgs(
-        quadratic(A, rng.normal(size=4)),
-        noop,
-        np.zeros(4),
-        num_iters=50,
-        callbacks=(stop_at_5,),
-    )
-    assert [(a, n, i) for a, n, i, _ in seen] == [(None, j, j) for j in range(1, 6)]
-    assert len(traj.iterates) <= 5
-    losses = [f for *_, f in seen]
-    assert losses == sorted(losses, reverse=True)  # the callback is handed a minimized loss
-
-
 def test_line_search_exhaustion_handled():
-    """When Armijo can never be satisfied the step is flagged, not crashed."""
+    """When Armijo can never be satisfied the step is flagged, not crashed, and the loop
+    still moves on to fresh data — holding both x and the batch replays the identical
+    failing step forever, and only n_ls_failures would ever show it."""
 
     def vg(x):
         # constant value with a nonzero gradient: no step ever decreases f
         return 1.0, np.array([1.0, 1.0])
 
+    advances = []
     traj = run_stochastic_lbfgs(
-        vg, noop, np.zeros(2), num_iters=3, config=StochasticLBFGSConfig(maxls=5)
+        vg,
+        lambda: advances.append(1),
+        np.zeros(2),
+        num_iters=3,
+        config=StochasticLBFGSConfig(maxls=5),
     )
     assert traj.n_ls_failures == 3
+    assert len(advances) == 3
 
 
 def test_ring_buffer_wraps_after_maxcor_pairs():

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -99,6 +99,22 @@ def test_two_loop_direction_matches_dense_bfgs():
     assert np.allclose(d, -H @ g, atol=1e-10)
 
 
+def test_a_pair_with_zero_curvature_drops_out_of_the_recursion():
+    """The recursion divides by ``s . y``, so an exactly orthogonal pair has to be
+    skipped rather than contribute an infinite coefficient."""
+    s_win = np.zeros((3, 2))
+    z_win = np.zeros((3, 2))
+    s_win[:, 0], z_win[:, 0] = [1.0, 0.0, 0.0], [0.0, 1.0, 0.0]
+    s_win[:, 1], z_win[:, 1] = [0.0, 0.0, 1.0], [0.0, 0.0, 2.0]
+    g, alpha = np.ones(3), np.ones(3)
+
+    d = _two_loop_direction(g, alpha, s_win, z_win, order=[1, 0])
+    assert np.all(np.isfinite(d))
+    np.testing.assert_allclose(
+        d, _two_loop_direction(g, alpha, s_win[:, [1]], z_win[:, [1]], order=[0])
+    )
+
+
 def test_pair_rejected_when_curvature_violated():
     """A step crossing a negative-curvature region gives s.y < 0 and is rejected."""
     traj = run_stochastic_lbfgs(double_well, noop, np.array([0.3]), num_iters=8)

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -1,0 +1,183 @@
+"""Analytic-objective tests for the stochastic L-BFGS optimizer."""
+
+import itertools
+
+import numpy as np
+
+from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
+    StochasticLBFGSConfig,
+    run_stochastic_lbfgs,
+)
+
+
+def quadratic(A, b):
+    """Return value_grad_fn for f(x) = 0.5 x'Ax - b'x (grad = Ax - b, min at A^-1 b)."""
+
+    def vg(x):
+        return 0.5 * x @ A @ x - b @ x, A @ x - b
+
+    return vg
+
+
+def noop():
+    return None
+
+
+def test_quadratic_full_batch_converges_to_optimum():
+    """On a deterministic strongly-convex quadratic the iterate reaches the mode."""
+    rng = np.random.default_rng(0)
+    M = rng.normal(size=(5, 5))
+    A = M @ M.T + 5 * np.eye(5)  # SPD, well-conditioned
+    b = rng.normal(size=5)
+    x_star = np.linalg.solve(A, b)
+    traj = run_stochastic_lbfgs(quadratic(A, b), noop, np.zeros(5), num_iters=60)
+    x_final = traj.iterates[-1]["x"]
+    assert np.allclose(x_final, x_star, atol=1e-6)
+    assert traj.violation_rate == 0.0  # a quadratic never violates curvature
+
+
+def test_two_loop_direction_matches_dense_bfgs():
+    """After one pair, the two-loop direction equals -(diag-init BFGS update) . g."""
+    from pymc_extras.inference.pathfinder.stochastic_lbfgs import _two_loop_direction
+
+    rng = np.random.default_rng(1)
+    N = 4
+    s = rng.normal(size=N)
+    y = s * np.array([2.0, 3.0, 1.5, 4.0]) + 0.01  # ensure s.y > 0
+    alpha = np.abs(rng.normal(size=N)) + 0.5
+    g = rng.normal(size=N)
+
+    s_win = s[:, None]
+    z_win = y[:, None]
+    d = _two_loop_direction(g, alpha, s_win, z_win, order=[0])
+
+    # Dense reference: H0 = diag(alpha); one BFGS inverse-Hessian update.
+    rho = 1.0 / (s @ y)
+    H0 = np.diag(alpha)
+    Ident = np.eye(N)
+    V = Ident - rho * np.outer(s, y)
+    H = V @ H0 @ V.T + rho * np.outer(s, s)
+    assert np.allclose(d, -H @ g, atol=1e-10)
+
+
+def test_pair_rejected_when_curvature_violated():
+    """A step crossing a negative-curvature region gives s.y < 0 and is rejected."""
+
+    def vg(x):
+        # 1-D double well f = 0.25 x^4 - x^2: concave (negative curvature) for
+        # |x| < sqrt(2/3), so a descent step out of x0=0.3 yields s.y < 0.
+        xv = x[0]
+        return 0.25 * xv**4 - xv**2, np.array([xv**3 - 2 * xv])
+
+    traj = run_stochastic_lbfgs(vg, noop, np.array([0.3]), num_iters=8)
+    assert traj.n_curvature_violations >= 1
+    assert traj.n_accepted + traj.n_curvature_violations + traj.n_null == traj.n_steps
+
+
+def test_line_search_decreases_objective_each_step():
+    """Every accepted iterate's value is no worse than the previous one on a fixed objective."""
+    rng = np.random.default_rng(2)
+    A = np.diag([1.0, 3.0, 10.0])
+    b = rng.normal(size=3)
+    vg = quadratic(A, b)
+    traj = run_stochastic_lbfgs(vg, noop, np.array([5.0, 5.0, 5.0]), num_iters=40)
+    values = [vg(it["x"])[0] for it in traj.iterates]
+    assert all(v2 <= v1 + 1e-9 for v1, v2 in itertools.pairwise(values))
+
+
+def test_line_search_exhaustion_handled():
+    """When Armijo can never be satisfied the step is flagged, not crashed."""
+
+    def vg(x):
+        # constant value with a nonzero gradient: no step ever decreases f
+        return 1.0, np.array([1.0, 1.0])
+
+    traj = run_stochastic_lbfgs(
+        vg, noop, np.zeros(2), num_iters=3, config=StochasticLBFGSConfig(maxls=5)
+    )
+    assert traj.n_ls_failures == 3
+    assert traj.n_steps == 3
+
+
+def test_ring_buffer_wraps_after_maxcor_pairs():
+    """The stored history never exceeds maxcor columns and stays two-loop usable."""
+    rng = np.random.default_rng(3)
+    A = rng.normal(size=(6, 6))
+    A = A @ A.T + 6 * np.eye(6)
+    b = rng.normal(size=6)
+    cfg = StochasticLBFGSConfig(maxcor=3)
+    traj = run_stochastic_lbfgs(quadratic(A, b), noop, np.zeros(6), num_iters=20, config=cfg)
+    last = traj.iterates[-1]
+    assert last["s_win"].shape == (6, 3)
+    assert last["z_win"].shape == (6, 3)
+    # still converges with a short history
+    assert np.allclose(last["x"], np.linalg.solve(A, b), atol=1e-5)
+
+
+def test_trajectory_records_expected_shapes():
+    """Every recorded iterate carries the sampler-ready arrays with matching shapes."""
+    rng = np.random.default_rng(4)
+    A = np.diag(np.abs(rng.normal(size=4)) + 1.0)
+    vg = quadratic(A, rng.normal(size=4))
+    cfg = StochasticLBFGSConfig(maxcor=5)
+    traj = run_stochastic_lbfgs(vg, noop, np.zeros(4), num_iters=15, config=cfg)
+    for it in traj.iterates:
+        assert it["x"].shape == (4,)
+        assert it["g"].shape == (4,)
+        assert it["alpha"].shape == (4,)
+        assert it["s_win"].shape == (4, 5)
+
+
+def test_reproducible_given_same_inputs():
+    """A deterministic objective yields a bit-identical trajectory across runs."""
+    rng = np.random.default_rng(5)
+    A = rng.normal(size=(4, 4))
+    A = A @ A.T + 4 * np.eye(4)
+    b = rng.normal(size=4)
+    x0 = rng.normal(size=4)
+    a = run_stochastic_lbfgs(quadratic(A, b), noop, x0, num_iters=25)
+    c = run_stochastic_lbfgs(quadratic(A, b), noop, x0, num_iters=25)
+    assert np.array_equal(a.iterates[-1]["x"], c.iterates[-1]["x"])
+
+
+def test_violation_rate_low_on_streaming_quadratic():
+    """Same-batch pairing keeps the violation rate near zero even with per-step noise.
+
+    Each 'batch' shifts the linear term by fresh noise; because s and y use the
+    same shifted objective within a step, curvature stays clean.
+    """
+    rng = np.random.default_rng(6)
+    A = np.diag([1.0, 2.0, 4.0])
+    state = {"b": np.zeros(3)}
+
+    def vg(x):
+        return 0.5 * x @ A @ x - state["b"] @ x, A @ x - state["b"]
+
+    def advance():
+        state["b"] = rng.normal(0, 0.05, size=3)  # small minibatch-like perturbation
+
+    traj = run_stochastic_lbfgs(vg, advance, np.array([3.0, -3.0, 3.0]), num_iters=60)
+    assert traj.violation_rate < 0.20
+
+
+def test_stored_window_is_chronological_after_the_ring_wraps():
+    """The sampler has no ring index, so the window it receives has to read
+    oldest-to-newest. Physical ring order silently computes the Gaussian for a
+    different update sequence once the buffer wraps."""
+    A = np.array([[3.0, 0.4], [0.4, 1.0]])
+    J = 2
+    traj = run_stochastic_lbfgs(
+        quadratic(A, np.zeros(2)),
+        noop,
+        np.array([2.0, -1.5]),
+        num_iters=12,
+        config=StochasticLBFGSConfig(maxcor=J),
+    )
+    assert traj.n_accepted > J, "the ring never wrapped, so the test proves nothing"
+    xs = [it["x"] for it in traj.iterates]
+    for k in range(J, len(traj.iterates)):
+        window = traj.iterates[k]["s_win"]
+        for age in range(J):  # age 0 is the newest pair, in the last column
+            np.testing.assert_allclose(
+                window[:, J - 1 - age], xs[k - age] - xs[k - age - 1], atol=1e-12
+            )

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -130,7 +130,7 @@ def test_no_duplicate_gradient_evaluations():
     assert all(c == 2 for c in list(per_batch.values())[:-1]), dict(per_batch)
 
 
-@pytest.mark.parametrize("kw", [{"backtrack": -0.5}, {"maxcor": 0}])
+@pytest.mark.parametrize("kw", [{"backtrack": -0.5}, {"maxcor": 0}, {"maxls": 0}])
 def test_config_rejects_invalid_settings(kw):
     """Settings that would silently break the line search or the history are refused."""
     with pytest.raises(ValueError):

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -30,6 +30,12 @@ def double_well(x):
     return float(np.sum(0.25 * x**4 - x**2)), x**3 - 2 * x
 
 
+def spd(n, rng, ridge):
+    """A random (n, n) SPD matrix ``M M' + ridge * I``; the ridge sets the conditioning."""
+    M = rng.normal(size=(n, n))
+    return M @ M.T + ridge * np.eye(n)
+
+
 def dense_inverse_hessian(alpha, pairs):
     """Textbook BFGS inverse-Hessian recursion from H0 = diag(alpha), oldest pair first."""
     ident = np.eye(alpha.size)
@@ -46,8 +52,7 @@ def fill_ring(J, n_pairs, rng, N=5):
 
     Returns ``(s_win, z_win, order)`` with ``order`` newest-first over the resident pairs.
     """
-    M = rng.normal(size=(N, N))
-    P = M @ M.T + N * np.eye(N)  # SPD, so y = P s guarantees s . y > 0
+    P = spd(N, rng, N)  # SPD, so y = P s guarantees s . y > 0
     s_win = np.zeros((N, J))
     z_win = np.zeros((N, J))
     win_idx = -1
@@ -67,8 +72,7 @@ def noop():
 def test_quadratic_full_batch_converges_to_optimum():
     """On a deterministic strongly-convex quadratic the iterate reaches the mode."""
     rng = np.random.default_rng(0)
-    M = rng.normal(size=(5, 5))
-    A = M @ M.T + 5 * np.eye(5)  # SPD, well-conditioned
+    A = spd(5, rng, 5)  # well-conditioned
     b = rng.normal(size=5)
     x_star = np.linalg.solve(A, b)
     traj = run_stochastic_lbfgs(quadratic(A, b), noop, np.zeros(5), num_iters=60)
@@ -152,8 +156,7 @@ def test_line_search_exhaustion_handled():
 def test_ring_buffer_wraps_after_maxcor_pairs():
     """The stored history never exceeds maxcor columns and stays two-loop usable."""
     rng = np.random.default_rng(3)
-    A = rng.normal(size=(6, 6))
-    A = A @ A.T + 6 * np.eye(6)
+    A = spd(6, rng, 6)
     b = rng.normal(size=6)
     cfg = StochasticLBFGSConfig(maxcor=3)
     traj = run_stochastic_lbfgs(quadratic(A, b), noop, np.zeros(6), num_iters=20, config=cfg)
@@ -181,8 +184,7 @@ def test_trajectory_records_expected_shapes():
 def test_reproducible_given_same_inputs():
     """A deterministic objective yields a bit-identical trajectory across runs."""
     rng = np.random.default_rng(5)
-    A = rng.normal(size=(4, 4))
-    A = A @ A.T + 4 * np.eye(4)
+    A = spd(4, rng, 4)
     b = rng.normal(size=4)
     x0 = rng.normal(size=4)
     a = run_stochastic_lbfgs(quadratic(A, b), noop, x0, num_iters=25)
@@ -328,8 +330,7 @@ def test_window_layout_holds_before_the_ring_wraps():
     sampler cannot distinguish from real pairs.
     """
     rng = np.random.default_rng(21)
-    M = rng.normal(size=(5, 5))
-    A = M @ M.T + 0.2 * np.eye(5)  # deliberately ill-conditioned: no early convergence
+    A = spd(5, rng, 0.2)  # deliberately ill-conditioned: no early convergence
     J = 4
     x0 = np.full(5, 3.0)
     traj = run_stochastic_lbfgs(

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -21,17 +21,13 @@ def quadratic(A, b):
     return vg
 
 
-def double_well():
-    """Return value_grad_fn for f(x) = sum(0.25 x^4 - x^2).
+def double_well(x):
+    """value_grad_fn for f(x) = sum(0.25 x^4 - x^2).
 
     The Hessian is negative definite inside ``|x| < sqrt(2/3)``, so descent steps taken
     from there routinely produce ``s . y < 0``.
     """
-
-    def vg(x):
-        return float(np.sum(0.25 * x**4 - x**2)), x**3 - 2 * x
-
-    return vg
+    return float(np.sum(0.25 * x**4 - x**2)), x**3 - 2 * x
 
 
 def dense_inverse_hessian(alpha, pairs):
@@ -105,9 +101,9 @@ def test_two_loop_direction_matches_dense_bfgs():
 
 def test_pair_rejected_when_curvature_violated():
     """A step crossing a negative-curvature region gives s.y < 0 and is rejected."""
-    traj = run_stochastic_lbfgs(double_well(), noop, np.array([0.3]), num_iters=8)
+    traj = run_stochastic_lbfgs(double_well, noop, np.array([0.3]), num_iters=8)
     assert traj.n_curvature_violations >= 1
-    assert traj.n_accepted + traj.n_curvature_violations + traj.n_null == traj.n_steps
+    assert traj.n_accepted + traj.n_curvature_violations + traj.n_null == 8
 
 
 def test_line_search_decreases_objective_each_step():
@@ -121,6 +117,91 @@ def test_line_search_decreases_objective_each_step():
     assert all(v2 <= v1 + 1e-9 for v1, v2 in itertools.pairwise(values))
 
 
+def test_no_point_is_evaluated_twice_within_a_step():
+    """The accepted trial's gradient comes from the call that tested it.
+
+    Re-evaluating the accepted point to fetch a gradient the joint value_grad_fn already
+    returned costs a full logp+grad pass per step, and no counter reports it.
+    """
+    rng = np.random.default_rng(30)
+    A = np.diag([1.0, 2.0, 4.0])
+    vg = quadratic(A, rng.normal(size=3))
+    state = {"batch": 0}
+    seen = []
+
+    def tagged(x):
+        seen.append((state["batch"], tuple(x)))
+        return vg(x)
+
+    def advance():
+        state["batch"] += 1
+
+    run_stochastic_lbfgs(tagged, advance, np.array([3.0, -3.0, 3.0]), num_iters=25)
+    assert len(seen) == len(set(seen)), "a point was evaluated twice on the same batch"
+
+
+def test_failed_line_search_holds_x_but_still_advances_the_batch():
+    """A step that cannot satisfy Armijo must still move on to fresh data.
+
+    Holding both x and the batch re-runs the identical failing step forever, and only
+    n_ls_failures would ever show it.
+    """
+    x0 = np.zeros(2)
+    xs = []
+
+    def vg(x):
+        xs.append(tuple(x))
+        return 1.0, np.array([1.0, 1.0])  # constant value, nonzero gradient
+
+    advances = []
+    traj = run_stochastic_lbfgs(
+        vg,
+        lambda: advances.append(1),
+        x0,
+        num_iters=4,
+        config=StochasticLBFGSConfig(maxls=3),
+    )
+    assert traj.n_ls_failures == 4
+    assert len(advances) == 4
+    assert traj.iterates == []
+    assert xs.count(tuple(x0)) == 5  # the opening evaluation plus one per held step
+
+
+@pytest.mark.parametrize(
+    "kw", [{"backtrack": 1.0}, {"backtrack": -0.5}, {"maxcor": 0}, {"maxls": 0}]
+)
+def test_config_rejects_settings_that_make_a_wrong_fit_look_healthy(kw):
+    """backtrack outside (0, 1) is the dangerous one: a negative step length satisfies
+    the Armijo bound trivially, so the run climbs while every counter reads clean."""
+    with pytest.raises(ValueError):
+        StochasticLBFGSConfig(**kw)
+
+
+def test_a_callback_can_end_the_run_early():
+    """StopIteration from a callback ends the loop, so an early-stopping rule written
+    against pm.fit's callback contract works here unchanged."""
+    rng = np.random.default_rng(31)
+    M = rng.normal(size=(4, 4))
+    A = M @ M.T + 4 * np.eye(4)
+    losses = []
+
+    def stop_at_5(approx, loss, i):
+        losses.append(float(loss[-1]))
+        if i == 5:
+            raise StopIteration
+
+    traj = run_stochastic_lbfgs(
+        quadratic(A, rng.normal(size=4)),
+        noop,
+        np.zeros(4),
+        num_iters=50,
+        callbacks=(stop_at_5,),
+    )
+    assert len(losses) == 5
+    assert len(traj.iterates) <= 5
+    assert losses == sorted(losses, reverse=True)  # the callback is handed a minimized loss
+
+
 def test_line_search_exhaustion_handled():
     """When Armijo can never be satisfied the step is flagged, not crashed."""
 
@@ -132,7 +213,6 @@ def test_line_search_exhaustion_handled():
         vg, noop, np.zeros(2), num_iters=3, config=StochasticLBFGSConfig(maxls=5)
     )
     assert traj.n_ls_failures == 3
-    assert traj.n_steps == 3
 
 
 def test_ring_buffer_wraps_after_maxcor_pairs():
@@ -262,7 +342,7 @@ def test_both_gradients_of_every_accepted_pair_come_from_one_batch():
         np.testing.assert_array_equal(it["s_win"][:, newest], it["x"] - x_first)
         np.testing.assert_array_equal(it["z_win"][:, newest], it["g"] - g_first)
 
-    assert sorted({b for b, _, _ in log}) == list(range(traj.n_steps + 1))
+    assert sorted({b for b, _, _ in log}) == list(range(41))
 
 
 @pytest.mark.parametrize("J, n_pairs", [(1, 1), (2, 5), (3, 2), (3, 3), (3, 7), (6, 4), (6, 13)])
@@ -292,7 +372,7 @@ def test_history_holds_only_pairs_that_passed_the_curvature_test():
     """
     cfg = StochasticLBFGSConfig(maxcor=4)
     traj = run_stochastic_lbfgs(
-        double_well(), noop, np.array([0.05, -0.05, 0.6]), num_iters=30, config=cfg
+        double_well, noop, np.array([0.05, -0.05, 0.6]), num_iters=30, config=cfg
     )
     for it in traj.iterates:
         for s, y in zip(it["s_win"].T, it["z_win"].T):
@@ -301,10 +381,7 @@ def test_history_holds_only_pairs_that_passed_the_curvature_test():
             assert s @ y > 1e-16
             assert s @ y >= cfg.epsilon * (s @ s)
     assert traj.n_accepted == len(traj.iterates)
-    assert (
-        traj.n_accepted + traj.n_curvature_violations + traj.n_null + traj.n_ls_failures
-        == traj.n_steps
-    )
+    assert traj.n_accepted + traj.n_curvature_violations + traj.n_null + traj.n_ls_failures == 30
     assert traj.n_curvature_violations >= 1, "the objective produced no rejections to check"
 
 
@@ -327,7 +404,7 @@ def test_window_layout_holds_before_the_ring_wraps():
         num_iters=9,
         config=StochasticLBFGSConfig(maxcor=J),
     )
-    assert traj.n_accepted == traj.n_steps > J, "every step must be accepted for xs to line up"
+    assert traj.n_accepted == 9 > J, "every step must be accepted for xs to line up"
     xs = [x0, *[it["x"] for it in traj.iterates]]
     for k, it in enumerate(traj.iterates):
         n_valid = min(k + 1, J)

--- a/tests/inference/pathfinder/test_stochastic_lbfgs.py
+++ b/tests/inference/pathfinder/test_stochastic_lbfgs.py
@@ -3,9 +3,11 @@
 import itertools
 
 import numpy as np
+import pytest
 
 from pymc_extras.inference.pathfinder.stochastic_lbfgs import (
     StochasticLBFGSConfig,
+    _two_loop_direction,
     run_stochastic_lbfgs,
 )
 
@@ -17,6 +19,49 @@ def quadratic(A, b):
         return 0.5 * x @ A @ x - b @ x, A @ x - b
 
     return vg
+
+
+def double_well():
+    """Return value_grad_fn for f(x) = sum(0.25 x^4 - x^2).
+
+    The Hessian is negative definite inside ``|x| < sqrt(2/3)``, so descent steps taken
+    from there routinely produce ``s . y < 0``.
+    """
+
+    def vg(x):
+        return float(np.sum(0.25 * x**4 - x**2)), x**3 - 2 * x
+
+    return vg
+
+
+def dense_inverse_hessian(alpha, pairs):
+    """Textbook BFGS inverse-Hessian recursion from H0 = diag(alpha), oldest pair first."""
+    ident = np.eye(alpha.size)
+    H = np.diag(alpha)
+    for s, y in pairs:
+        rho = 1.0 / (s @ y)
+        V = ident - rho * np.outer(s, y)
+        H = V @ H @ V.T + rho * np.outer(s, s)
+    return H
+
+
+def fill_ring(J, n_pairs, rng, N=5):
+    """Write n_pairs curvature pairs into an (N, J) ring exactly as the optimizer does.
+
+    Returns ``(s_win, z_win, order)`` with ``order`` newest-first over the resident pairs.
+    """
+    M = rng.normal(size=(N, N))
+    P = M @ M.T + N * np.eye(N)  # SPD, so y = P s guarantees s . y > 0
+    s_win = np.zeros((N, J))
+    z_win = np.zeros((N, J))
+    win_idx = -1
+    for _ in range(n_pairs):
+        s = rng.normal(size=N)
+        win_idx = (win_idx + 1) % J
+        s_win[:, win_idx] = s
+        z_win[:, win_idx] = P @ s
+    order = [(win_idx - k) % J for k in range(min(n_pairs, J))]
+    return s_win, z_win, order
 
 
 def noop():
@@ -38,8 +83,6 @@ def test_quadratic_full_batch_converges_to_optimum():
 
 def test_two_loop_direction_matches_dense_bfgs():
     """After one pair, the two-loop direction equals -(diag-init BFGS update) . g."""
-    from pymc_extras.inference.pathfinder.stochastic_lbfgs import _two_loop_direction
-
     rng = np.random.default_rng(1)
     N = 4
     s = rng.normal(size=N)
@@ -62,14 +105,7 @@ def test_two_loop_direction_matches_dense_bfgs():
 
 def test_pair_rejected_when_curvature_violated():
     """A step crossing a negative-curvature region gives s.y < 0 and is rejected."""
-
-    def vg(x):
-        # 1-D double well f = 0.25 x^4 - x^2: concave (negative curvature) for
-        # |x| < sqrt(2/3), so a descent step out of x0=0.3 yields s.y < 0.
-        xv = x[0]
-        return 0.25 * xv**4 - xv**2, np.array([xv**3 - 2 * xv])
-
-    traj = run_stochastic_lbfgs(vg, noop, np.array([0.3]), num_iters=8)
+    traj = run_stochastic_lbfgs(double_well(), noop, np.array([0.3]), num_iters=8)
     assert traj.n_curvature_violations >= 1
     assert traj.n_accepted + traj.n_curvature_violations + traj.n_null == traj.n_steps
 
@@ -181,3 +217,123 @@ def test_stored_window_is_chronological_after_the_ring_wraps():
             np.testing.assert_allclose(
                 window[:, J - 1 - age], xs[k - age] - xs[k - age - 1], atol=1e-12
             )
+
+
+def test_both_gradients_of_every_accepted_pair_come_from_one_batch():
+    """s and y are differences of two evaluations made on the same batch.
+
+    Schraudolph pairing is what cancels the minibatch noise in y; differencing across
+    two batches leaves the noise in, and no counter the Trajectory reports can tell the
+    two apart. Each value_grad_fn call is tagged with the batch active when it ran, so
+    the pair stored at each accepted step can be traced back to its two evaluations.
+    """
+    rng = np.random.default_rng(20)
+    A = np.diag([1.0, 2.0, 5.0])
+    J = 4
+    state = {"batch": 0, "b": rng.normal(0, 0.3, size=3)}
+    log = []
+
+    def vg(x):
+        g = A @ x - state["b"]
+        log.append((state["batch"], np.array(x, dtype=float), g.copy()))
+        return 0.5 * x @ A @ x - state["b"] @ x, g
+
+    def advance():
+        state["batch"] += 1
+        state["b"] = rng.normal(0, 0.3, size=3)
+
+    traj = run_stochastic_lbfgs(
+        vg,
+        advance,
+        np.array([4.0, -4.0, 4.0]),
+        num_iters=40,
+        config=StochasticLBFGSConfig(maxcor=J),
+    )
+    assert traj.n_accepted > J
+
+    for k, it in enumerate(traj.iterates):
+        newest = min(k + 1, J) - 1
+        owners = {
+            b for b, xx, gg in log if np.array_equal(xx, it["x"]) and np.array_equal(gg, it["g"])
+        }
+        assert len(owners) == 1, f"iterate {k} gradient traced to batches {owners}"
+        (batch,) = owners
+        x_first, g_first = next((xx, gg) for b, xx, gg in log if b == batch)
+        np.testing.assert_array_equal(it["s_win"][:, newest], it["x"] - x_first)
+        np.testing.assert_array_equal(it["z_win"][:, newest], it["g"] - g_first)
+
+    assert sorted({b for b, _, _ in log}) == list(range(traj.n_steps + 1))
+
+
+@pytest.mark.parametrize("J, n_pairs", [(1, 1), (2, 5), (3, 2), (3, 3), (3, 7), (6, 4), (6, 13)])
+def test_two_loop_direction_matches_dense_recursion_over_the_ring(J, n_pairs):
+    """The two-loop recursion returns -H g for the dense BFGS H built from the resident
+    pairs in ring order, before the buffer wraps (n_pairs <= J) and after it has wrapped
+    several times. Any drift in the ordering or in the H0 = diag(alpha) seed shows up as
+    a different direction once more than one pair is resident.
+    """
+    rng = np.random.default_rng(100 + 31 * J + n_pairs)
+    s_win, z_win, order = fill_ring(J, n_pairs, rng)
+    N = s_win.shape[0]
+    alpha = np.abs(rng.normal(size=N)) + 0.5
+    g = rng.normal(size=N)
+
+    d = _two_loop_direction(g, alpha, s_win, z_win, order)
+    H = dense_inverse_hessian(alpha, [(s_win[:, c], z_win[:, c]) for c in reversed(order)])
+    np.testing.assert_allclose(d, -H @ g, rtol=1e-9, atol=1e-9)
+
+
+def test_history_holds_only_pairs_that_passed_the_curvature_test():
+    """Every column ever handed to the sampler satisfies s.y >= epsilon * s.s, and each
+    step lands in exactly one counter.
+
+    A rejected pair silently entering the ring makes the L-BFGS memory indefinite while
+    violation_rate keeps reading zero, so the counters alone cannot detect it.
+    """
+    cfg = StochasticLBFGSConfig(maxcor=4)
+    traj = run_stochastic_lbfgs(
+        double_well(), noop, np.array([0.05, -0.05, 0.6]), num_iters=30, config=cfg
+    )
+    for it in traj.iterates:
+        for s, y in zip(it["s_win"].T, it["z_win"].T):
+            if not np.any(s):
+                continue
+            assert s @ y > 1e-16
+            assert s @ y >= cfg.epsilon * (s @ s)
+    assert traj.n_accepted == len(traj.iterates)
+    assert (
+        traj.n_accepted + traj.n_curvature_violations + traj.n_null + traj.n_ls_failures
+        == traj.n_steps
+    )
+    assert traj.n_curvature_violations >= 1, "the objective produced no rejections to check"
+
+
+def test_window_layout_holds_before_the_ring_wraps():
+    """A partially filled ring is handed over unrolled: filled columns oldest-to-newest
+    starting at column 0, unused columns zero and trailing.
+
+    Rolling a not-yet-full ring would put the zero columns in the newest slots, which the
+    sampler cannot distinguish from real pairs.
+    """
+    rng = np.random.default_rng(21)
+    M = rng.normal(size=(5, 5))
+    A = M @ M.T + 0.2 * np.eye(5)  # deliberately ill-conditioned: no early convergence
+    J = 4
+    x0 = np.full(5, 3.0)
+    traj = run_stochastic_lbfgs(
+        quadratic(A, rng.normal(size=5)),
+        noop,
+        x0,
+        num_iters=9,
+        config=StochasticLBFGSConfig(maxcor=J),
+    )
+    assert traj.n_accepted == traj.n_steps > J, "every step must be accepted for xs to line up"
+    xs = [x0, *[it["x"] for it in traj.iterates]]
+    for k, it in enumerate(traj.iterates):
+        n_valid = min(k + 1, J)
+        for age in range(n_valid):
+            np.testing.assert_allclose(
+                it["s_win"][:, n_valid - 1 - age], xs[k + 1 - age] - xs[k - age], atol=1e-12
+            )
+        np.testing.assert_array_equal(it["s_win"][:, n_valid:], 0.0)
+        np.testing.assert_array_equal(it["z_win"][:, n_valid:], 0.0)

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -100,6 +100,38 @@ def test_set_data_changes_compiled_objective():
     assert not np.allclose(g_all, g_sub), "gradient did not respond to set_data"
 
 
+def test_a_saturated_trial_point_cannot_poison_the_gradient():
+    """A logit past float64 saturation has a finite logp and a NaN gradient, so the
+    Armijo test on the value alone accepts it. The accepted gradient then becomes the
+    next step's ``g``: the direction is NaN, every later line search fails, and the run
+    ends with no accepted steps at all rather than with a visible error.
+
+    Deterministic: fixed data seed, fixed start, one fixed batch installed throughout.
+    Without the finiteness guard this configuration records ``n_accepted == 0``.
+    """
+    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
+    from pymc_extras.inference.pathfinder.stochastic_lbfgs import run_stochastic_lbfgs
+
+    k = 5
+    X, y, _ = sample_logistic(k=k, n=1000, rng=np.random.default_rng(1))
+    model, packed = logistic_regression(X, y)
+    model.set_data("batch", packed[:64])
+    neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
+
+    def value_grad(x):
+        value, grad = neg_logp_dlogp(np.asarray(x, dtype=np.float64))
+        return float(value), np.asarray(grad, dtype=np.float64)
+
+    x0 = np.random.default_rng(1).uniform(-6.0, 6.0, size=k)
+    assert np.all(np.isfinite(value_grad(x0)[1])), "the start itself must be usable"
+    traj = run_stochastic_lbfgs(value_grad, lambda: None, x0, 30, CFG)
+
+    assert traj.n_accepted > 0, "every line search failed; the trajectory is empty"
+    # mu = x - H_inv @ g, so an iterate carrying a NaN g is a NaN Gaussian mean.
+    for it in traj.iterates:
+        assert np.all(np.isfinite(it["g"]))
+
+
 def test_smoke_streaming_logistic():
     """A short streaming fit on logistic data returns finite, correctly shaped draws."""
     rng = np.random.default_rng(1)
@@ -111,13 +143,11 @@ def test_smoke_streaming_logistic():
         loader,
         num_iters=15,
         num_draws=500,
-        eval_rows=200,
         random_seed=2,
         lbfgs_config=CFG,
     )
     assert res.samples.shape == (500, 2)
     assert np.isfinite(res.samples).all()
-    assert res.elbo_trace.size == len(res.elbo_trace)
     assert 0.0 <= res.violation_rate <= 1.0
 
 
@@ -134,68 +164,78 @@ def test_crn_determinism():
             loader,
             num_iters=20,
             num_draws=400,
-            eval_rows=150,
             random_seed=7,
             lbfgs_config=CFG,
         )
 
     a, b = run(), run()
-    np.testing.assert_array_equal(a.elbo_trace, b.elbo_trace)
+    np.testing.assert_array_equal(a.logQ, b.logQ)
     np.testing.assert_array_equal(a.samples, b.samples)
 
 
-def test_elbo_argmax_selects_max():
-    """The reported argmax is the index of the largest ELBO in the trace."""
+def capture_gaussian(monkeypatch):
+    """Record the (x, g, alpha, s_win, z_win) the final full-width draw is taken from."""
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    seen = {}
+    original = sp.make_pathfinder_sample_fn
+
+    def wrapper(*args, **kwargs):
+        fn = original(*args, **kwargs)
+
+        def tapped(x, g, alpha, s_win, z_win, u):
+            seen["args"] = (x, g, alpha, s_win, z_win)
+            return fn(x, g, alpha, s_win, z_win, u)
+
+        return tapped
+
+    monkeypatch.setattr(sp, "make_pathfinder_sample_fn", wrapper)
+    return seen
+
+
+def test_the_gaussian_is_centred_on_the_tail_averaged_position(monkeypatch):
+    """The proposal centre is the mean of the last 75% of iterate *positions*, not any
+    single iterate.
+
+    Every stochastic step is a full quasi-Newton step plus line search on one minibatch, so
+    each iterate is near that minibatch's MAP rather than the full-data MAP. The error is in
+    the location, so it survives any rule that picks one iterate; averaging the positions is
+    what removes it. Picking the last iterate instead would pass a weaker shape-only check.
+    """
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    seen = capture_gaussian(monkeypatch)
     rng = np.random.default_rng(4)
     X, y, _ = sample_logistic(k=2, n=300, rng=rng)
     model, packed = logistic_regression(X, y)
-    loader = ArrayLoader(packed, batch_size=64)
-    res = fit_streaming_pathfinder(
-        model,
-        loader,
-        num_iters=25,
-        num_draws=300,
-        eval_rows=150,
-        random_seed=5,
-        lbfgs_config=CFG,
-    )
-    assert res.elbo_argmax == int(np.argmax(res.elbo_trace))
 
-
-def test_a_degenerate_iterate_cannot_win_the_argmax():
-    """A draw with zero proposal density scores +inf, which would take the argmax
-    outright; a non-finite score has to fall to -inf instead."""
-    from pymc_extras.inference.pathfinder.streaming_pathfinder import _elbo
-
-    assert _elbo(np.array([1.0, 2.0]), np.array([-np.inf, 0.0])) == -np.inf
-    assert _elbo(np.array([1.0, 2.0]), np.array([0.0, 0.0])) == 1.5
-
-
-def test_evaluation_batch_holds_exactly_eval_rows(monkeypatch):
-    """Rows past eval_rows are ones the loader wrapped around the epoch to fetch again,
-    so the selection sweep would score iterates on a batch with duplicated rows."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(50, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=50)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
-
-    set_data = model.set_data
-    installed = []
+    iterates = []
+    run = sp.run_stochastic_lbfgs
     monkeypatch.setattr(
-        model,
-        "set_data",
-        lambda name, value, **kw: (installed.append(len(value)), set_data(name, value, **kw))[1],
+        sp,
+        "run_stochastic_lbfgs",
+        lambda *a, **k: (lambda t: (iterates.extend(t.iterates), t)[1])(run(*a, **k)),
     )
     fit_streaming_pathfinder(
         model,
-        ArrayLoader(packed, batch_size=16),
-        num_iters=5,
-        num_draws=10,
-        eval_rows=40,
+        ArrayLoader(packed, batch_size=64),
+        num_iters=25,
+        num_draws=300,
         importance_sampling=None,
-        random_seed=0,
+        random_seed=5,
+        lbfgs_config=CFG,
     )
-    assert max(installed) == 40
+
+    m = max(1, round(sp._TAIL_AVERAGE_FRAC * len(iterates)))
+    assert 1 < m < len(iterates), "the average has to span several iterates to mean anything"
+    x, g, alpha, s_win, z_win = seen["args"]
+    np.testing.assert_allclose(x, np.mean([it["x"] for it in iterates[-m:]], axis=0))
+    assert not np.allclose(x, iterates[-1]["x"]), "averaging collapsed to the last iterate"
+    # mu = x - H_inv @ g, so only g = 0 centres the Gaussian on the averaged position.
+    np.testing.assert_array_equal(g, np.zeros_like(x))
+    # Curvature is the last iterate's: averaged (s, z) pairs are not a valid L-BFGS memory.
+    for got, want in ((alpha, "alpha"), (s_win, "s_win"), (z_win, "z_win")):
+        np.testing.assert_array_equal(got, iterates[-1][want])
 
 
 def test_optimizer_health_counters_reach_the_result(monkeypatch):
@@ -221,7 +261,6 @@ def test_optimizer_health_counters_reach_the_result(monkeypatch):
         ArrayLoader(packed, batch_size=20),
         num_iters=6,
         num_draws=10,
-        eval_rows=60,
         importance_sampling=None,
         random_seed=0,
     )
@@ -253,22 +292,30 @@ def test_jitter_starts_two_seeds_at_different_points(monkeypatch):
             ArrayLoader(packed, 20),  # unshuffled: the seed's only entry point is the jitter
             num_iters=4,
             num_draws=10,
-            eval_rows=60,
             importance_sampling=None,
             random_seed=seed,
         )
     assert not np.allclose(firsts[0], firsts[1])
 
 
-def test_callbacks_reach_the_optimizer():
+def test_callbacks_reach_the_optimizer(monkeypatch):
     """The optimizer's callback hook is only worth its lines if a user can reach it: a
-    pm.fit early-stopping rule has to run against a streaming fit unchanged."""
+    pm.fit early-stopping rule has to run against a streaming fit unchanged, and the
+    shortened trajectory has to be the one the fit then averages."""
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
     rng = np.random.default_rng(0)
     X = rng.normal(size=(60, 2))
     y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
     model, packed, *_ = gaussian_regression(X, y, 1.0)
 
-    seen = []
+    seen, iterates = [], []
+    run = sp.run_stochastic_lbfgs
+    monkeypatch.setattr(
+        sp,
+        "run_stochastic_lbfgs",
+        lambda *a, **k: (lambda t: (iterates.extend(t.iterates), t)[1])(run(*a, **k)),
+    )
 
     def stop_at_3(approx, losses, i):
         seen.append((approx, len(losses), i))
@@ -280,13 +327,13 @@ def test_callbacks_reach_the_optimizer():
         ArrayLoader(packed, 20),
         num_iters=30,
         num_draws=10,
-        eval_rows=60,
         importance_sampling=None,
         callbacks=[stop_at_3],
         random_seed=0,
     )
     assert seen == [(None, 1, 1), (None, 2, 2), (None, 3, 3)]
-    assert res.elbo_trace.size <= 3
+    assert 0 < len(iterates) <= 3
+    assert res.samples.shape == (10, 2)
 
 
 def test_missing_batch_var_raises():
@@ -322,7 +369,6 @@ def test_gaussian_equivalence_to_analytic():
             loader,
             num_iters=60,
             num_draws=4000,
-            eval_rows=n,
             random_seed=seed,
             lbfgs_config=CFG,
         )
@@ -352,7 +398,6 @@ def test_batch_size_robustness():
             loader,
             num_iters=150,
             num_draws=3000,
-            eval_rows=1000,
             random_seed=0,
             lbfgs_config=CFG,
         )
@@ -464,7 +509,7 @@ def test_a_drop_last_loader_is_refused_and_told_what_to_pass():
     loader = DropLastLoader(packed, batch_size=128)
     assert sum(b.shape[0] for b in loader) == 256 < len(loader)
 
-    kwargs = dict(num_iters=5, num_draws=50, eval_rows=60, random_seed=0, lbfgs_config=CFG)
+    kwargs = dict(num_iters=5, num_draws=50, random_seed=0, lbfgs_config=CFG)
     with pytest.raises(RuntimeError, match=r"pass full_pass=<the loader's dataset source>"):
         fit_streaming_pathfinder(model, loader, **kwargs)
 
@@ -521,7 +566,6 @@ def test_returned_draws_have_requested_shape(
         num_iters=8,
         num_draws=num_draws,
         num_proposal_draws=num_proposal_draws,
-        eval_rows=60,
         importance_sampling=importance_sampling,
         random_seed=0,
         lbfgs_config=CFG,
@@ -543,7 +587,7 @@ def test_psis_reweights_rather_than_permuting_the_pool():
     y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
     model, packed, *_ = gaussian_regression(X, y, 1.0)
     res = fit_streaming_pathfinder(
-        model, ArrayLoader(packed, 20), num_iters=8, num_draws=20, eval_rows=60, random_seed=0
+        model, ArrayLoader(packed, 20), num_iters=8, num_draws=20, random_seed=0
     )
     assert res.samples.shape == (20, 2)
     assert res.logP.shape == (80,)
@@ -571,7 +615,6 @@ def test_final_target_includes_potentials():
         ArrayLoader(y, 5),
         num_iters=10,
         num_draws=25,
-        eval_rows=n,
         importance_sampling=None,  # keeps logP row-aligned with samples
         random_seed=0,
     )
@@ -618,7 +661,6 @@ def test_identity_is_a_weighting_method_not_an_off_switch(importance_sampling, r
             ArrayLoader(packed, 20),
             num_iters=8,
             num_draws=50,
-            eval_rows=60,
             importance_sampling=importance_sampling,
             random_seed=0,
         )
@@ -640,7 +682,6 @@ def test_proposal_pool_smaller_than_num_draws_still_returns_num_draws():
         num_iters=8,
         num_draws=200,
         num_proposal_draws=20,
-        eval_rows=60,
         importance_sampling=None,
         random_seed=0,
     )
@@ -650,7 +691,7 @@ def test_proposal_pool_smaller_than_num_draws_still_returns_num_draws():
 def test_full_data_logp_installs_every_batch():
     """The streaming pass must install each batch, not read whatever is already there.
 
-    A finished fit leaves the evaluation batch in the placeholder, so a loop that
+    A finished optimization leaves its last minibatch in the placeholder, so a loop that
     forgot ``set_data`` would sum that one subset n_batches times. Existing tests
     miss it because their fixtures happen to leave the full dataset installed, in
     which case the rescaled sum telescopes back to the right answer by accident.

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -1,0 +1,381 @@
+"""Tests for the streaming Pathfinder driver (compiles PyTensor; small models)."""
+
+import numpy as np
+import pymc as pm
+import pytest
+
+from pymc_extras.inference.pathfinder import fit_streaming_pathfinder
+from pymc_extras.inference.pathfinder.stochastic_lbfgs import StochasticLBFGSConfig
+
+CFG = StochasticLBFGSConfig(maxcor=6)
+
+
+class ArrayLoader:
+    """Minimal sized re-iterable batch source over a dense (N, cols) array.
+
+    ``len(loader)`` is the dataset row count N (what the model passes as
+    ``total_size``), and every ``iter()`` is a fresh complete pass over all rows
+    (no dropped tail), so the loader can serve as its own ``full_pass``.
+    """
+
+    def __init__(self, data, batch_size, shuffle=False, seed=0):
+        self.data = np.asarray(data, dtype=np.float64)
+        self.batch_size = batch_size
+        self.shuffle = shuffle
+        self.rng = np.random.default_rng(seed)
+
+    def __len__(self):
+        return self.data.shape[0]
+
+    def __iter__(self):
+        idx = np.arange(self.data.shape[0])
+        if self.shuffle:
+            self.rng.shuffle(idx)
+        for start in range(0, idx.size, self.batch_size):
+            yield self.data[idx[start : start + self.batch_size]]
+
+
+def gaussian_regression(X, y, sigma, prior_sd=10.0):
+    """Linear regression with fixed noise; all-Normal so unconstrained == constrained.
+
+    Returns ``(model, packed_data, analytic_mean, analytic_cov)``. The packed data
+    is ``hstack([X, y])`` for the loader; the analytic Gaussian posterior of ``beta``
+    is the ground truth the streaming fit must recover.
+    """
+    n, k = X.shape
+    packed = np.hstack([X, y[:, None]]).astype(np.float64)
+    with pm.Model() as model:
+        batch = pm.Data("batch", packed)
+        beta = pm.Normal("beta", 0.0, prior_sd, shape=k)
+        mu = pm.math.dot(batch[:, :k], beta)
+        pm.Normal("y", mu, sigma, observed=batch[:, k], total_size=n)
+
+    prec = X.T @ X / sigma**2 + np.eye(k) / prior_sd**2
+    cov = np.linalg.inv(prec)
+    mean = cov @ (X.T @ y / sigma**2)
+    return model, packed, mean, cov
+
+
+def logistic_regression(X, y, prior_sd=2.0):
+    """Bayesian logistic regression with a pm.Data batch placeholder.
+
+    Returns ``(model, packed_data)`` where packed is ``hstack([X, y])``.
+    """
+    n, k = X.shape
+    packed = np.hstack([X, y[:, None]]).astype(np.float64)
+    with pm.Model() as model:
+        batch = pm.Data("batch", packed)
+        beta = pm.Normal("beta", 0.0, prior_sd, shape=k)
+        logit = pm.math.dot(batch[:, :k], beta)
+        pm.Bernoulli("y", logit_p=logit, observed=batch[:, k], total_size=n)
+    return model, packed
+
+
+def sample_logistic(k, n, rng, beta_true=None):
+    """Draw a logistic-regression dataset (X, y, beta_true)."""
+    beta_true = rng.normal(size=k) if beta_true is None else beta_true
+    X = rng.normal(size=(n, k))
+    p = 1.0 / (1.0 + np.exp(-(X @ beta_true)))
+    y = (rng.uniform(size=n) < p).astype(np.float64)
+    return X, y, beta_true
+
+
+def test_set_data_changes_compiled_objective():
+    """The compiled gradient closes over the pm.Data batch: set_data changes it.
+
+    This is the seam the whole streaming design rests on — one compiled graph,
+    different minibatches fed between calls.
+    """
+    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
+
+    rng = np.random.default_rng(0)
+    X, y, _ = sample_logistic(k=2, n=200, rng=rng)
+    model, packed = logistic_regression(X, y)
+    vg = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
+
+    x = np.zeros(2)
+    _, g_all = vg(x)
+    model.set_data("batch", packed[:50])  # a sub-batch
+    _, g_sub = vg(x)
+    assert not np.allclose(g_all, g_sub), "gradient did not respond to set_data"
+
+
+def test_smoke_streaming_logistic():
+    """A short streaming fit on logistic data returns finite, correctly shaped draws."""
+    rng = np.random.default_rng(1)
+    X, y, _ = sample_logistic(k=2, n=400, rng=rng)
+    model, packed = logistic_regression(X, y)
+    loader = ArrayLoader(packed, batch_size=64)
+    res = fit_streaming_pathfinder(
+        model,
+        loader,
+        num_iters=15,
+        num_draws=500,
+        eval_rows=200,
+        random_seed=2,
+        lbfgs_config=CFG,
+    )
+    assert res.samples.shape == (500, 2)
+    assert np.isfinite(res.samples).all()
+    assert res.elbo_trace.size == len(res.elbo_trace)
+    assert 0.0 <= res.violation_rate <= 1.0
+
+
+def test_crn_determinism():
+    """Same seed gives an identical fit (loader, optimizer, and draws are all seeded)."""
+    rng = np.random.default_rng(3)
+    X, y, _ = sample_logistic(k=2, n=300, rng=rng)
+    model, packed = logistic_regression(X, y)
+
+    def run():
+        loader = ArrayLoader(packed, batch_size=64)
+        return fit_streaming_pathfinder(
+            model,
+            loader,
+            num_iters=20,
+            num_draws=400,
+            eval_rows=150,
+            random_seed=7,
+            lbfgs_config=CFG,
+        )
+
+    a, b = run(), run()
+    np.testing.assert_array_equal(a.elbo_trace, b.elbo_trace)
+    np.testing.assert_array_equal(a.samples, b.samples)
+
+
+def test_elbo_argmax_selects_max():
+    """The reported argmax is the index of the largest ELBO in the trace."""
+    rng = np.random.default_rng(4)
+    X, y, _ = sample_logistic(k=2, n=300, rng=rng)
+    model, packed = logistic_regression(X, y)
+    loader = ArrayLoader(packed, batch_size=64)
+    res = fit_streaming_pathfinder(
+        model,
+        loader,
+        num_iters=25,
+        num_draws=300,
+        eval_rows=150,
+        random_seed=5,
+        lbfgs_config=CFG,
+    )
+    assert res.elbo_argmax == int(np.argmax(res.elbo_trace))
+
+
+def test_missing_batch_var_raises():
+    """A model without the named placeholder gives an actionable error."""
+    rng = np.random.default_rng(6)
+    X, y, _ = sample_logistic(k=2, n=100, rng=rng)
+    model, packed = logistic_regression(X, y)
+    loader = ArrayLoader(packed, batch_size=32)
+    with pytest.raises(KeyError, match=r"pm\.Data"):
+        fit_streaming_pathfinder(model, loader, batch_var="nope", num_iters=3)
+
+
+@pytest.mark.slow
+def test_gaussian_equivalence_to_analytic():
+    """On a Gaussian posterior the streaming fit recovers the analytic mean and sd.
+
+    Full-batch loader = deterministic Pathfinder; the target is exactly Gaussian,
+    which Pathfinder is built to represent, so mean/sd must match the closed-form
+    posterior within Monte-Carlo error across seeds.
+    """
+    rng = np.random.default_rng(10)
+    k, n, sigma = 3, 500, 1.0
+    beta_true = np.array([1.5, -2.0, 0.5])
+    X = rng.normal(size=(n, k))
+    y = X @ beta_true + rng.normal(0, sigma, size=n)
+    model, packed, amean, acov = gaussian_regression(X, y, sigma)
+    asd = np.sqrt(np.diag(acov))
+
+    for seed in range(3):
+        loader = ArrayLoader(packed, batch_size=n)  # full batch
+        res = fit_streaming_pathfinder(
+            model,
+            loader,
+            num_iters=60,
+            num_draws=4000,
+            eval_rows=n,
+            random_seed=seed,
+            lbfgs_config=CFG,
+        )
+        post_mean = res.samples.mean(0)
+        post_sd = res.samples.std(0)
+        se = asd / np.sqrt(res.samples.shape[0])
+        assert np.all(np.abs(post_mean - amean) < 6 * se + 0.01), (
+            f"seed {seed}: mean {post_mean} vs analytic {amean}"
+        )
+        assert np.all(np.abs(post_sd - asd) < 0.3 * asd), (
+            f"seed {seed}: sd {post_sd} vs analytic {asd}"
+        )
+
+
+@pytest.mark.slow
+def test_batch_size_robustness():
+    """Posterior means agree across batch sizes, down to small minibatches."""
+    rng = np.random.default_rng(11)
+    X, y, _ = sample_logistic(k=3, n=2000, rng=rng)
+    model, packed = logistic_regression(X, y)
+
+    means = {}
+    for bs in (2000, 256):
+        loader = ArrayLoader(packed, batch_size=bs, shuffle=(bs < 2000), seed=0)
+        res = fit_streaming_pathfinder(
+            model,
+            loader,
+            num_iters=150,
+            num_draws=3000,
+            eval_rows=1000,
+            random_seed=0,
+            lbfgs_config=CFG,
+        )
+        means[bs] = res.samples.mean(0)
+    # minibatch mean tracks the full-batch mean to within a modest tolerance
+    assert np.all(np.abs(means[256] - means[2000]) < 0.25 + 0.15 * np.abs(means[2000]))
+
+
+@pytest.mark.slow
+def test_violation_rate_below_20pct():
+    """Same-batch pairing keeps the curvature-violation rate under the proposal's 20%."""
+    rng = np.random.default_rng(12)
+    X, y, _ = sample_logistic(k=4, n=4000, rng=rng)
+    model, packed = logistic_regression(X, y)
+    loader = ArrayLoader(packed, batch_size=256, shuffle=True, seed=1)
+    res = fit_streaming_pathfinder(
+        model,
+        loader,
+        num_iters=200,
+        num_draws=500,
+        eval_rows=1000,
+        random_seed=0,
+        lbfgs_config=CFG,
+    )
+    assert res.violation_rate < 0.20, f"violation rate {res.violation_rate:.3f}"
+
+
+def test_full_data_logp_exact_with_tail():
+    """Streaming full-data logP equals model.logp over the whole dataset, including the
+    trailing partial batch a drop-last training loader would skip."""
+    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
+    from pymc_extras.inference.pathfinder.streaming_pathfinder import (
+        _compile_batched_logp,
+        _full_data_logp,
+    )
+
+    rng = np.random.default_rng(0)
+    k, n = 3, 350  # 350 is not divisible by 128 -> a genuine partial tail
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([1.0, -0.5, 0.3]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    # An explicit complete pass: every row exactly once, partial tail batch included.
+    full_pass = [packed[i : i + 128] for i in range(0, n, 128)]
+    assert sum(b.shape[0] for b in full_pass) == n
+    assert full_pass[-1].shape[0] == n % 128  # the tail is genuinely partial
+
+    prior_fn = _compile_batched_logp(model, model.free_RVs, jacobian=True)
+    obs_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
+    nlp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
+    phi = rng.normal(size=(5, k))
+    got = _full_data_logp(phi, full_pass, model, "batch", prior_fn, obs_fn, n)
+    for i in range(phi.shape[0]):
+        model.set_data("batch", packed)  # full data in the placeholder = the exact truth
+        truth = -nlp(phi[i].astype(np.float64))[0]
+        assert abs(got[i] - truth) < 1e-6, (i, got[i], truth)
+
+
+def potential_model(y, n):
+    """Normal-normal model carrying a pm.Potential that pulls theta away from the data."""
+    with pm.Model() as model:
+        theta = pm.Normal("theta", 0.0, 10.0)
+        batch = pm.Data("batch", y[: len(y)])
+        pm.Potential("penalty", -100.0 * (theta - 3.0) ** 2)
+        pm.Normal("obs", theta, 1.0, observed=batch, total_size=n)
+    return model
+
+
+def test_final_target_includes_potentials():
+    """model.logp(vars=[...]) drops pm.Potential terms, so the returned weights would
+    target a different posterior than the one the optimizer walked."""
+    n = 10
+    y = np.zeros(n)
+    model = potential_model(y, n)
+    result = fit_streaming_pathfinder(
+        model,
+        ArrayLoader(y, 5),
+        num_iters=10,
+        num_draws=25,
+        eval_rows=n,
+        importance_sampling=None,  # keeps logP row-aligned with samples
+        random_seed=0,
+    )
+    model.set_data("batch", y)
+    logp = model.compile_logp()
+    truth = np.array([logp({"theta": float(t)}) for t in result.samples[:, 0]])
+    np.testing.assert_allclose(result.logP, truth, atol=1e-8)
+
+
+def test_batch_dependent_potential_is_refused():
+    """The prior term is evaluated once, so a potential over the batch cannot be honored."""
+    n = 10
+    y = np.zeros(n)
+    with pm.Model() as model:
+        theta = pm.Normal("theta", 0.0, 10.0)
+        batch = pm.Data("batch", y)
+        pm.Potential("batchy", -pm.math.sum(batch) * theta)
+        pm.Normal("obs", theta, 1.0, observed=batch, total_size=n)
+    with pytest.raises(NotImplementedError, match="depends on the minibatch"):
+        fit_streaming_pathfinder(model, ArrayLoader(y, 5), num_iters=4, random_seed=0)
+
+
+@pytest.mark.parametrize(
+    "importance_sampling, resamples",
+    [("identity", True), (None, False)],
+    ids=["identity-reweights", "none-returns-proposals"],
+)
+def test_identity_is_a_weighting_method_not_an_off_switch(importance_sampling, resamples):
+    """identity means raw log-importance weights, which the upstream sampler implements;
+    treating it as 'off' silently returned unweighted proposals."""
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    called = []
+    original = sp.psis_fn
+    sp.psis_fn = lambda *a, **k: (called.append(k.get("method")), original(*a, **k))[1]
+    try:
+        result = fit_streaming_pathfinder(
+            model,
+            ArrayLoader(packed, 20),
+            num_iters=8,
+            num_draws=50,
+            eval_rows=60,
+            importance_sampling=importance_sampling,
+            random_seed=0,
+        )
+    finally:
+        sp.psis_fn = original
+    assert called == (["identity"] if resamples else [])
+    assert result.samples.shape == (50, 2)
+
+
+def test_proposal_pool_smaller_than_num_draws_still_returns_num_draws():
+    """Without a floor, samples[:num_draws] quietly returned a shorter array."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    result = fit_streaming_pathfinder(
+        model,
+        ArrayLoader(packed, 20),
+        num_iters=8,
+        num_draws=200,
+        num_proposal_draws=20,
+        eval_rows=60,
+        importance_sampling=None,
+        random_seed=0,
+    )
+    assert result.samples.shape == (200, 2)

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -89,6 +89,33 @@ def sample_logistic(k, n, rng, beta_true=None):
     return X, y, beta_true
 
 
+def logistic_case(seed=0, k=2, n=200):
+    """Seeded logistic-regression model and its packed data (the Gaussian case's twin)."""
+    rng = np.random.default_rng(seed)
+    X, y, _ = sample_logistic(k, n, rng)
+    return logistic_regression(X, y)
+
+
+def record_trajectory(monkeypatch, edit=lambda traj: None):
+    """Return the list the driver's Trajectories land in, one per fit run after this call.
+
+    ``edit`` runs on each Trajectory before the fit reads it, for tests that need counters
+    the optimizer would not produce on its own.
+    """
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    run, recorded = sp.run_stochastic_lbfgs, []
+
+    def wrapper(*args, **kwargs):
+        traj = run(*args, **kwargs)
+        edit(traj)
+        recorded.append(traj)
+        return traj
+
+    monkeypatch.setattr(sp, "run_stochastic_lbfgs", wrapper)
+    return recorded
+
+
 def test_set_data_changes_compiled_objective():
     """The compiled gradient closes over the pm.Data batch: set_data changes it.
 
@@ -97,9 +124,7 @@ def test_set_data_changes_compiled_objective():
     """
     from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
 
-    rng = np.random.default_rng(0)
-    X, y, _ = sample_logistic(k=2, n=200, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=0, n=200)
     vg = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
 
     x = np.zeros(2)
@@ -116,8 +141,7 @@ def test_saturated_trial_point_rejected():
     from pymc_extras.inference.pathfinder.stochastic_lbfgs import run_stochastic_lbfgs
 
     k = 5
-    X, y, _ = sample_logistic(k=k, n=1000, rng=np.random.default_rng(1))
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=1, k=k, n=1000)
     model.set_data("batch", packed[:64])
     neg_logp_dlogp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
 
@@ -137,9 +161,7 @@ def test_saturated_trial_point_rejected():
 
 def test_smoke_streaming_logistic():
     """A short streaming fit on logistic data returns finite, correctly shaped draws."""
-    rng = np.random.default_rng(1)
-    X, y, _ = sample_logistic(k=2, n=400, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=1, n=400)
     loader = ArrayLoader(packed, batch_size=64)
     res = fit_streaming_pathfinder(
         model,
@@ -156,9 +178,7 @@ def test_smoke_streaming_logistic():
 
 def test_crn_determinism():
     """Same seed gives an identical fit (loader, optimizer, and draws are all seeded)."""
-    rng = np.random.default_rng(3)
-    X, y, _ = sample_logistic(k=2, n=300, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=3, n=300)
 
     def run():
         loader = ArrayLoader(packed, batch_size=64)
@@ -183,9 +203,7 @@ def test_gaussian_is_centred_on_tail_averaged_position(monkeypatch):
 
     from pymc_extras.inference.pathfinder.bfgs_sample import make_pathfinder_sample_fn
 
-    rng = np.random.default_rng(4)
-    X, y, _ = sample_logistic(k=2, n=300, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=4, n=300)
 
     # Record the Gaussian the final draw is taken from, and the iterates it came from.
     gaussian = {}
@@ -196,16 +214,7 @@ def test_gaussian_is_centred_on_tail_averaged_position(monkeypatch):
         return sample_fn(x, g, alpha, s_win, z_win, u)
 
     monkeypatch.setattr(sp, "make_pathfinder_sample_fn", lambda *a, **k: record_gaussian)
-
-    iterates = []
-    run = sp.run_stochastic_lbfgs
-
-    def record_iterates(*args, **kwargs):
-        traj = run(*args, **kwargs)
-        iterates.extend(traj.iterates)
-        return traj
-
-    monkeypatch.setattr(sp, "run_stochastic_lbfgs", record_iterates)
+    trajectories = record_trajectory(monkeypatch)
     fit_streaming_pathfinder(
         model,
         ArrayLoader(packed, batch_size=64),
@@ -216,31 +225,27 @@ def test_gaussian_is_centred_on_tail_averaged_position(monkeypatch):
         lbfgs_config=CFG,
     )
 
-    m = max(1, round(sp._TAIL_AVERAGE_FRAC * len(iterates)))
-    assert 1 < m < len(iterates), "the average has to span several iterates to mean anything"
+    (traj,) = trajectories  # the fit walks one path, so it builds one trajectory
+    m = max(1, round(sp._TAIL_AVERAGE_FRAC * len(traj.iterates)))
+    assert 1 < m < len(traj.iterates), "the average has to span several iterates to mean anything"
     x = gaussian["x"]
-    np.testing.assert_allclose(x, np.mean([it["x"] for it in iterates[-m:]], axis=0))
-    assert not np.allclose(x, iterates[-1]["x"]), "averaging collapsed to the last iterate"
+    np.testing.assert_allclose(x, np.mean([it["x"] for it in traj.iterates[-m:]], axis=0))
+    assert not np.allclose(x, traj.iterates[-1]["x"]), "averaging collapsed to the last iterate"
     # mu = x - H_inv @ g, so only g = 0 centres the Gaussian on the averaged position.
     np.testing.assert_array_equal(gaussian["g"], np.zeros_like(x))
     # Curvature is the last iterate's: averaged (s, z) pairs are not a valid L-BFGS memory.
     for key in ("alpha", "s_win", "z_win"):
-        np.testing.assert_array_equal(gaussian[key], iterates[-1][key])
+        np.testing.assert_array_equal(gaussian[key], traj.iterates[-1][key])
 
 
 def test_health_counters_reach_the_result(monkeypatch):
     """violation_rate and n_ls_failures are read off the trajectory, not defaulted."""
-    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
-    run = sp.run_stochastic_lbfgs
-
-    def struggling(*args, **kwargs):
-        traj = run(*args, **kwargs)
+    def struggle(traj):
         traj.n_curvature_violations = traj.n_accepted
         traj.n_ls_failures = 7
-        return traj
 
-    monkeypatch.setattr(sp, "run_stochastic_lbfgs", struggling)
+    record_trajectory(monkeypatch, struggle)
     model, packed, _ = gaussian_case()
     result = fit_streaming_pathfinder(
         model,
@@ -256,17 +261,8 @@ def test_health_counters_reach_the_result(monkeypatch):
 
 def test_jitter_varies_the_start_by_seed(monkeypatch):
     """Without jitter every seed starts at the same prior point and retraces one trajectory."""
-    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
-
     model, packed, _ = gaussian_case()
-    run, firsts = sp.run_stochastic_lbfgs, []
-
-    def record(*args, **kwargs):
-        traj = run(*args, **kwargs)
-        firsts.append(traj.iterates[0]["x"])
-        return traj
-
-    monkeypatch.setattr(sp, "run_stochastic_lbfgs", record)
+    trajectories = record_trajectory(monkeypatch)
     for seed in (0, 1):
         fit_streaming_pathfinder(
             model,
@@ -276,7 +272,8 @@ def test_jitter_varies_the_start_by_seed(monkeypatch):
             importance_sampling=None,
             random_seed=seed,
         )
-    assert not np.allclose(firsts[0], firsts[1])
+    first, second = (traj.iterates[0]["x"] for traj in trajectories)
+    assert not np.allclose(first, second)
 
 
 def test_callbacks_get_pm_fit_arguments():
@@ -304,9 +301,7 @@ def test_callbacks_get_pm_fit_arguments():
 
 def test_missing_batch_var_raises():
     """A model without the named placeholder gives an actionable error."""
-    rng = np.random.default_rng(6)
-    X, y, _ = sample_logistic(k=2, n=100, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=6, n=100)
     loader = ArrayLoader(packed, batch_size=32)
     with pytest.raises(KeyError, match=r"pm\.Data"):
         fit_streaming_pathfinder(model, loader, batch_var="nope", num_iters=3)
@@ -352,9 +347,7 @@ def test_gaussian_equivalence_to_analytic():
 @pytest.mark.slow
 def test_batch_size_robustness():
     """Posterior means agree across batch sizes, down to small minibatches."""
-    rng = np.random.default_rng(11)
-    X, y, _ = sample_logistic(k=3, n=2000, rng=rng)
-    model, packed = logistic_regression(X, y)
+    model, packed = logistic_case(seed=11, k=3, n=2000)
 
     means = {}
     for bs in (2000, 256):
@@ -425,7 +418,7 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
 
 def test_drop_last_loader_is_refused():
     """A drop-last epoch cannot give an exact logP; the error names full_pass, which works."""
-    k, n = 2, 350
+    n = 350
     model, packed, _ = gaussian_case(seed=24, n=n)
 
     class DropLastLoader(ArrayLoader):
@@ -468,7 +461,7 @@ def test_fit_restores_the_batch_placeholder():
     model.logp() or pm.sample() straight after a fit silently scores that block rescaled by
     total_size instead of the dataset.
     """
-    model, packed, loader = _restore_case(31)
+    model, _, loader = _restore_case(31)
     before = np.array(model["batch"].get_value(), copy=True)
     assert before.shape[0] == len(loader)
 

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -653,3 +653,16 @@ def test_full_data_logp_installs_every_batch():
         n,
     )
     np.testing.assert_allclose(got, truth, rtol=1e-9)
+
+
+def test_loader_without_total_size_is_refused():
+    """A loader that cannot report N would leave the driver guessing the scale of
+    the likelihood; it must refuse up front rather than mis-weight silently."""
+    model, packed, _ = gaussian_case()
+
+    class UnsizedLoader:
+        def __iter__(self):
+            return iter([packed[:20]])
+
+    with pytest.raises(TypeError, match="total_size"):
+        fit_streaming_pathfinder(model, UnsizedLoader(), num_iters=4, random_seed=0)

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -229,6 +229,66 @@ def test_optimizer_health_counters_reach_the_result(monkeypatch):
     assert result.n_ls_failures == 7
 
 
+def test_jitter_starts_two_seeds_at_different_points(monkeypatch):
+    """Without the jitter every fit starts at the same deterministic prior point, so a
+    second seed retraces the first trajectory and multi-path Pathfinder degenerates."""
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    run, firsts = sp.run_stochastic_lbfgs, []
+
+    def record(*args, **kwargs):
+        traj = run(*args, **kwargs)
+        firsts.append(traj.iterates[0]["x"])
+        return traj
+
+    monkeypatch.setattr(sp, "run_stochastic_lbfgs", record)
+    for seed in (0, 1):
+        fit_streaming_pathfinder(
+            model,
+            ArrayLoader(packed, 20),  # unshuffled: the seed's only entry point is the jitter
+            num_iters=4,
+            num_draws=10,
+            eval_rows=60,
+            importance_sampling=None,
+            random_seed=seed,
+        )
+    assert not np.allclose(firsts[0], firsts[1])
+
+
+def test_callbacks_reach_the_optimizer():
+    """The optimizer's callback hook is only worth its lines if a user can reach it: a
+    pm.fit early-stopping rule has to run against a streaming fit unchanged."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    seen = []
+
+    def stop_at_3(approx, losses, i):
+        seen.append((approx, len(losses), i))
+        if i == 3:
+            raise StopIteration
+
+    res = fit_streaming_pathfinder(
+        model,
+        ArrayLoader(packed, 20),
+        num_iters=30,
+        num_draws=10,
+        eval_rows=60,
+        importance_sampling=None,
+        callbacks=[stop_at_3],
+        random_seed=0,
+    )
+    assert seen == [(None, 1, 1), (None, 2, 2), (None, 3, 3)]
+    assert res.elbo_trace.size <= 3
+
+
 def test_missing_batch_var_raises():
     """A model without the named placeholder gives an actionable error."""
     rng = np.random.default_rng(6)
@@ -433,9 +493,9 @@ def test_incomplete_full_pass_is_refused():
     [
         (None, None, 50, False),
         (None, 137, 137, False),
-        ("identity", None, 51, False),
+        ("identity", None, 200, False),
         ("identity", 137, 137, False),
-        ("psis", None, 51, True),
+        ("psis", None, 200, True),
         ("psis", 137, 137, True),
     ],
     ids=["none", "none-pool", "identity", "identity-pool", "psis", "psis-pool"],
@@ -446,9 +506,9 @@ def test_returned_draws_have_requested_shape(
     """samples is (num_draws, N) for every weighting method and proposal-pool size, while
     logP and logQ stay the length of the proposal pool they were computed on.
 
-    The pool defaults to num_draws, plus one when resampling so PSIS reweights instead of
-    permuting; an explicit num_proposal_draws overrides both, and none of that may leak
-    into the returned draw count.
+    The pool defaults to 4x num_draws when resampling, matching fit_pathfinder's
+    num_paths x num_draws_per_path, and to num_draws when not; an explicit
+    num_proposal_draws overrides both, and none of that may leak into the returned count.
     """
     num_draws = 50
     rng = np.random.default_rng(23)
@@ -471,6 +531,23 @@ def test_returned_draws_have_requested_shape(
     assert res.logQ.shape == (n_prop,)
     assert np.isfinite(res.samples).all()
     assert (res.pareto_k is not None) == has_pareto_k
+
+
+def test_psis_reweights_rather_than_permuting_the_pool():
+    """The default pool has to be a multiple of num_draws. Resampling num_draws out of
+    num_draws + 1 without replacement (importance_sampling.py sets replace=False for
+    "psis") returns the pool minus one draw whatever the weights are, and arviz's Pareto
+    tail fit needs 5 tail draws, so num_draws <= 23 raised outright."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    res = fit_streaming_pathfinder(
+        model, ArrayLoader(packed, 20), num_iters=8, num_draws=20, eval_rows=60, random_seed=0
+    )
+    assert res.samples.shape == (20, 2)
+    assert res.logP.shape == (80,)
+    assert res.pareto_k is not None
 
 
 def potential_model(y, n):

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -2,6 +2,7 @@
 
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
 
 from pymc_extras.inference.pathfinder import fit_streaming_pathfinder
@@ -158,6 +159,66 @@ def test_saturated_trial_point_rejected():
     # mu = x - H_inv @ g, so an iterate carrying a NaN g is a NaN Gaussian mean.
     for it in traj.iterates:
         assert np.all(np.isfinite(it["g"]))
+
+
+def test_batch_dependent_prior_is_rejected():
+    """A prior that reads the minibatch would be scored once, on a stale batch, silently."""
+    full = np.array([0.0, 0.0, 10.0, 10.0])
+    with pm.Model() as m:
+        batch = pm.Data("batch", full[:2])
+        theta = pm.Normal("theta", mu=pt.mean(batch), sigma=1)
+        pm.Normal("obs", theta, 1, observed=batch, total_size=4)
+    loader = ArrayLoader(full[:, None], batch_size=2)
+    with pytest.raises(NotImplementedError, match=r"prior or pm\.Potential"):
+        fit_streaming_pathfinder(m, loader, num_iters=2, random_seed=0, lbfgs_config=CFG)
+
+
+def test_prior_initval_is_reproducible():
+    """initval="prior" draws the starting point inside the fit; same seed, same draws."""
+
+    def make():
+        model, packed = logistic_case(seed=1, n=400)
+        with model:
+            pm.Normal("extra", 0, 1, initval="prior")
+        return model, packed
+
+    results = []
+    for _ in range(2):
+        model, packed = make()
+        loader = ArrayLoader(packed, batch_size=64)
+        results.append(
+            fit_streaming_pathfinder(
+                model,
+                loader,
+                num_iters=10,
+                num_draws=100,
+                jitter=0.0,
+                random_seed=11,
+                lbfgs_config=CFG,
+            )
+        )
+    assert np.array_equal(results[0].samples, results[1].samples)
+
+
+def test_empty_blocks_in_full_pass_are_skipped():
+    """A zero-row block must not poison logP with 0 * inf."""
+    model, packed = logistic_case(seed=1, n=400)
+    loader = ArrayLoader(packed, batch_size=64)
+
+    def full_pass_with_empties():
+        yield packed[:0]
+        yield from (packed[i : i + 100] for i in range(0, 400, 100))
+
+    res = fit_streaming_pathfinder(
+        model,
+        loader,
+        num_iters=10,
+        num_draws=100,
+        random_seed=3,
+        lbfgs_config=CFG,
+        full_pass=full_pass_with_empties(),
+    )
+    assert np.isfinite(res.logP).all()
 
 
 def test_zero_accepted_steps_raises():

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -13,7 +13,7 @@ CFG = StochasticLBFGSConfig(maxcor=6)
 class ArrayLoader:
     """Minimal sized re-iterable batch source over a dense (N, cols) array.
 
-    ``len(loader)`` is the dataset row count N (what the model passes as
+    ``total_size`` is the dataset row count N (what the model passes as
     ``total_size``), and every ``iter()`` is a fresh complete pass over all rows
     (no dropped tail), so the loader can serve as its own ``full_pass``.
     """
@@ -24,7 +24,8 @@ class ArrayLoader:
         self.shuffle = shuffle
         self.rng = np.random.default_rng(seed)
 
-    def __len__(self):
+    @property
+    def total_size(self):
         return self.data.shape[0]
 
     def __iter__(self):
@@ -423,11 +424,11 @@ def test_drop_last_loader_is_refused():
 
     class DropLastLoader(ArrayLoader):
         def __iter__(self):
-            for start in range(0, len(self) - self.batch_size + 1, self.batch_size):
+            for start in range(0, self.total_size - self.batch_size + 1, self.batch_size):
                 yield self.data[start : start + self.batch_size]
 
     loader = DropLastLoader(packed, batch_size=128)
-    assert sum(b.shape[0] for b in loader) == 256 < len(loader)
+    assert sum(b.shape[0] for b in loader) == 256 < loader.total_size
 
     with pytest.raises(RuntimeError, match=r"pass full_pass=<the loader's dataset source>"):
         fit_streaming_pathfinder(model, loader, num_iters=5, num_draws=50, random_seed=0)
@@ -440,7 +441,7 @@ def test_incomplete_full_pass_is_refused():
     model, packed, rng = gaussian_case(seed=22, n=n, beta=(0.5, 0.25))
     full_data_logp, prior_fn, obs_fn, _, phi = full_data_logp_parts(model, k, rng)
 
-    with pytest.raises(RuntimeError, match=r"visited 25 rows but len\(loader\)=40"):
+    with pytest.raises(RuntimeError, match=r"visited 25 rows but total_size=40"):
         full_data_logp(phi, [packed[:25]], model, "batch", prior_fn, obs_fn, n)
 
 
@@ -463,7 +464,7 @@ def test_fit_restores_the_batch_placeholder():
     """
     model, _, loader = _restore_case(31)
     before = np.array(model["batch"].get_value(), copy=True)
-    assert before.shape[0] == len(loader)
+    assert before.shape[0] == loader.total_size
 
     fit_streaming_pathfinder(
         model, loader, num_iters=5, num_draws=50, random_seed=0, lbfgs_config=CFG
@@ -478,7 +479,7 @@ def test_batch_placeholder_is_restored_when_the_fit_raises():
     model, packed, loader = _restore_case(32)
     before = np.array(model["batch"].get_value(), copy=True)
 
-    with pytest.raises(RuntimeError, match=r"visited 50 rows but len\(loader\)=300"):
+    with pytest.raises(RuntimeError, match=r"visited 50 rows but total_size=300"):
         fit_streaming_pathfinder(
             model,
             loader,

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -56,6 +56,15 @@ def gaussian_regression(X, y, sigma, prior_sd=10.0):
     return model, packed, mean, cov
 
 
+def gaussian_case(seed=0, n=60, beta=(1.0, -0.5)):
+    """Seeded Gaussian-regression model, its packed data, and the rng that drew them."""
+    rng = np.random.default_rng(seed)
+    X = rng.normal(size=(n, len(beta)))
+    y = X @ np.asarray(beta) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    return model, packed, rng
+
+
 def logistic_regression(X, y, prior_sd=2.0):
     """Bayesian logistic regression with a pm.Data batch placeholder.
 
@@ -168,11 +177,8 @@ def test_crn_determinism():
 
 
 def test_gaussian_is_centred_on_tail_averaged_position(monkeypatch):
-    """The proposal centre is the mean of the last 75% of iterate positions, not one iterate.
-
-    Each step's accepted point is near its own minibatch's MAP, so the error is in the
-    location and survives any rule that picks a single iterate.
-    """
+    """The proposal centre is the mean of the last 75% of iterate positions, not one iterate,
+    because each step's accepted point sits near its own minibatch's MAP."""
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
     from pymc_extras.inference.pathfinder.bfgs_sample import make_pathfinder_sample_fn
@@ -235,10 +241,7 @@ def test_health_counters_reach_the_result(monkeypatch):
         return traj
 
     monkeypatch.setattr(sp, "run_stochastic_lbfgs", struggling)
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, _ = gaussian_case()
     result = fit_streaming_pathfinder(
         model,
         ArrayLoader(packed, batch_size=20),
@@ -255,11 +258,7 @@ def test_jitter_varies_the_start_by_seed(monkeypatch):
     """Without jitter every seed starts at the same prior point and retraces one trajectory."""
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
-
+    model, packed, _ = gaussian_case()
     run, firsts = sp.run_stochastic_lbfgs, []
 
     def record(*args, **kwargs):
@@ -282,10 +281,7 @@ def test_jitter_varies_the_start_by_seed(monkeypatch):
 
 def test_callbacks_get_pm_fit_arguments():
     """Callbacks see ``(None, losses_so_far, 1-based step)`` and one can stop the fit early."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, _ = gaussian_case()
     seen = []
 
     def stop_at_3(approx, losses, i):
@@ -376,37 +372,6 @@ def test_batch_size_robustness():
     assert np.all(np.abs(means[256] - means[2000]) < 0.25 + 0.15 * np.abs(means[2000]))
 
 
-def test_full_data_logp_exact_with_tail():
-    """Streaming full-data logP equals model.logp over the whole dataset, including the
-    trailing partial batch a drop-last training loader would skip."""
-    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
-    from pymc_extras.inference.pathfinder.streaming_pathfinder import (
-        _compile_batched_logp,
-        _full_data_logp,
-    )
-
-    rng = np.random.default_rng(0)
-    k, n = 3, 350  # 350 is not divisible by 128 -> a genuine partial tail
-    X = rng.normal(size=(n, k))
-    y = X @ np.array([1.0, -0.5, 0.3]) + rng.normal(0, 1.0, size=n)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
-
-    # An explicit complete pass: every row exactly once, partial tail batch included.
-    full_pass = [packed[i : i + 128] for i in range(0, n, 128)]
-    assert sum(b.shape[0] for b in full_pass) == n
-    assert full_pass[-1].shape[0] == n % 128  # the tail is genuinely partial
-
-    prior_fn = _compile_batched_logp(model, model.free_RVs, jacobian=True)
-    obs_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
-    nlp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
-    phi = rng.normal(size=(5, k))
-    got = _full_data_logp(phi, full_pass, model, "batch", prior_fn, obs_fn, n)
-    for i in range(phi.shape[0]):
-        model.set_data("batch", packed)  # full data in the placeholder = the exact truth
-        truth = -nlp(phi[i].astype(np.float64))[0]
-        assert abs(got[i] - truth) < 1e-6, (i, got[i], truth)
-
-
 def full_data_logp_parts(model, k, rng, n_phi=4):
     """Return ``(_full_data_logp, prior_fn, obs_fn, exact_logp, phi)`` for ``model``.
 
@@ -437,11 +402,8 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
     Every batch's contribution is un-rescaled by its own row count, so a pass of uneven
     or single-row batches, or one that visits the rows shuffled, must not shift the total.
     """
-    rng = np.random.default_rng(21)
     k, n = 2, 60
-    X = rng.normal(size=(n, k))
-    y = X @ np.array([0.8, -1.2]) + rng.normal(0, 1.0, size=n)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, rng = gaussian_case(seed=21, beta=(0.8, -1.2))
     full_data_logp, prior_fn, obs_fn, exact_logp, phi = full_data_logp_parts(model, k, rng)
 
     shuffled = packed[rng.permutation(n)]
@@ -463,11 +425,8 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
 
 def test_drop_last_loader_is_refused():
     """A drop-last epoch cannot give an exact logP; the error names full_pass, which works."""
-    rng = np.random.default_rng(24)
     k, n = 2, 350
-    X = rng.normal(size=(n, k))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=n)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, _ = gaussian_case(seed=24, n=n)
 
     class DropLastLoader(ArrayLoader):
         def __iter__(self):
@@ -477,24 +436,15 @@ def test_drop_last_loader_is_refused():
     loader = DropLastLoader(packed, batch_size=128)
     assert sum(b.shape[0] for b in loader) == 256 < len(loader)
 
-    kwargs = dict(num_iters=5, num_draws=50, random_seed=0, lbfgs_config=CFG)
     with pytest.raises(RuntimeError, match=r"pass full_pass=<the loader's dataset source>"):
-        fit_streaming_pathfinder(model, loader, **kwargs)
-
-    res = fit_streaming_pathfinder(
-        model, loader, full_pass=[packed[i : i + 97] for i in range(0, n, 97)], **kwargs
-    )
-    assert res.samples.shape == (50, k)
+        fit_streaming_pathfinder(model, loader, num_iters=5, num_draws=50, random_seed=0)
 
 
 def test_incomplete_full_pass_is_refused():
     """A pass that does not visit every row is rejected rather than returning a
     subset-rescaled density that silently looks like the full-data one."""
-    rng = np.random.default_rng(22)
     k, n = 2, 40
-    X = rng.normal(size=(n, k))
-    y = X @ np.array([0.5, 0.25]) + rng.normal(0, 1.0, size=n)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, rng = gaussian_case(seed=22, n=n, beta=(0.5, 0.25))
     full_data_logp, prior_fn, obs_fn, _, phi = full_data_logp_parts(model, k, rng)
 
     with pytest.raises(RuntimeError, match=r"visited 25 rows but len\(loader\)=40"):
@@ -504,11 +454,8 @@ def test_incomplete_full_pass_is_refused():
 def _restore_case(seed):
     """A model whose batch placeholder holds all n rows, plus a loader that does not
     divide n, so any block the fit installs differs from the incoming value."""
-    rng = np.random.default_rng(seed)
-    k, n = 2, 300
-    X = rng.normal(size=(n, k))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=n)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    n = 300
+    model, packed, _ = gaussian_case(seed=seed, n=n)
     loader = ArrayLoader(packed, batch_size=64)  # 300 = 4 x 64 + 44
     assert [b.shape[0] for b in loader] == [64, 64, 64, 64, 44]
     return model, packed, loader
@@ -522,10 +469,7 @@ def test_fit_restores_the_batch_placeholder():
     total_size instead of the dataset.
     """
     model, packed, loader = _restore_case(31)
-    point = {"beta": np.array([0.7, -0.4])}
-    logp_fn = model.compile_logp()
     before = np.array(model["batch"].get_value(), copy=True)
-    logp_before = float(np.asarray(logp_fn(point)))
     assert before.shape[0] == len(loader)
 
     fit_streaming_pathfinder(
@@ -533,7 +477,6 @@ def test_fit_restores_the_batch_placeholder():
     )
 
     np.testing.assert_array_equal(model["batch"].get_value(), before)
-    assert float(np.asarray(logp_fn(point))) == logp_before
 
 
 def test_batch_placeholder_is_restored_when_the_fit_raises():
@@ -579,10 +522,7 @@ def test_returned_draws_have_requested_shape(
     num_proposal_draws overrides both, and none of that may leak into the returned count.
     """
     num_draws = 50
-    rng = np.random.default_rng(23)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, _ = gaussian_case(seed=23)
     res = fit_streaming_pathfinder(
         model,
         ArrayLoader(packed, 20),
@@ -600,22 +540,16 @@ def test_returned_draws_have_requested_shape(
     assert (res.pareto_k is not None) == has_pareto_k
 
 
-def potential_model(y, n):
-    """Normal-normal model carrying a pm.Potential that pulls theta away from the data."""
-    with pm.Model() as model:
-        theta = pm.Normal("theta", 0.0, 10.0)
-        batch = pm.Data("batch", y[: len(y)])
-        pm.Potential("penalty", -100.0 * (theta - 3.0) ** 2)
-        pm.Normal("obs", theta, 1.0, observed=batch, total_size=n)
-    return model
-
-
 def test_final_target_includes_potentials():
     """model.logp(vars=[...]) drops pm.Potential terms, so the returned weights would
     target a different posterior than the one the optimizer walked."""
     n = 10
     y = np.zeros(n)
-    model = potential_model(y, n)
+    with pm.Model() as model:  # a potential that pulls theta away from the data
+        theta = pm.Normal("theta", 0.0, 10.0)
+        batch = pm.Data("batch", y)
+        pm.Potential("penalty", -100.0 * (theta - 3.0) ** 2)
+        pm.Normal("obs", theta, 1.0, observed=batch, total_size=n)
     result = fit_streaming_pathfinder(
         model,
         ArrayLoader(y, 5),
@@ -653,11 +587,7 @@ def test_identity_is_a_weighting_method_not_an_off_switch(importance_sampling, r
     treating it as 'off' silently returned unweighted proposals."""
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
-
+    model, packed, _ = gaussian_case()
     called = []
     original = sp.psis_fn
     sp.psis_fn = lambda *a, **k: (called.append(k.get("method")), original(*a, **k))[1]
@@ -678,10 +608,7 @@ def test_identity_is_a_weighting_method_not_an_off_switch(importance_sampling, r
 
 def test_proposal_pool_smaller_than_num_draws_still_returns_num_draws():
     """Without a floor, samples[:num_draws] quietly returned a shorter array."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    model, packed, _ = gaussian_case()
     result = fit_streaming_pathfinder(
         model,
         ArrayLoader(packed, 20),

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -501,6 +501,61 @@ def test_incomplete_full_pass_is_refused():
         full_data_logp(phi, [packed[:25]], model, "batch", prior_fn, obs_fn, n)
 
 
+def _restore_case(seed):
+    """A model whose batch placeholder holds all n rows, plus a loader that does not
+    divide n, so any block the fit installs differs from the incoming value."""
+    rng = np.random.default_rng(seed)
+    k, n = 2, 300
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    loader = ArrayLoader(packed, batch_size=64)  # 300 = 4 x 64 + 44
+    assert [b.shape[0] for b in loader] == [64, 64, 64, 64, 44]
+    return model, packed, loader
+
+
+def test_fit_restores_the_batch_placeholder():
+    """The fit hands the model back with the placeholder the caller set up.
+
+    Without the restore it keeps whatever block the final logP pass installed last, so a
+    model.logp() or pm.sample() straight after a fit silently scores that block rescaled by
+    total_size instead of the dataset.
+    """
+    model, packed, loader = _restore_case(31)
+    point = {"beta": np.array([0.7, -0.4])}
+    logp_fn = model.compile_logp()
+    before = np.array(model["batch"].get_value(), copy=True)
+    logp_before = float(np.asarray(logp_fn(point)))
+    assert before.shape[0] == len(loader)
+
+    fit_streaming_pathfinder(
+        model, loader, num_iters=5, num_draws=50, random_seed=0, lbfgs_config=CFG
+    )
+
+    np.testing.assert_array_equal(model["batch"].get_value(), before)
+    assert float(np.asarray(logp_fn(point))) == logp_before
+
+
+def test_batch_placeholder_is_restored_when_the_fit_raises():
+    """The restore is on the exception path too, so a caller that catches the error and
+    goes on using the model is not handed a mutated one."""
+    model, packed, loader = _restore_case(32)
+    before = np.array(model["batch"].get_value(), copy=True)
+
+    with pytest.raises(RuntimeError, match=r"visited 50 rows but len\(loader\)=300"):
+        fit_streaming_pathfinder(
+            model,
+            loader,
+            num_iters=5,
+            num_draws=50,
+            full_pass=[packed[:50]],
+            random_seed=0,
+            lbfgs_config=CFG,
+        )
+
+    np.testing.assert_array_equal(model["batch"].get_value(), before)
+
+
 @pytest.mark.parametrize(
     "importance_sampling, num_proposal_draws, n_prop, has_pareto_k",
     [

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -104,10 +104,9 @@ def test_a_saturated_trial_point_cannot_poison_the_gradient():
     """A logit past float64 saturation has a finite logp and a NaN gradient, so the
     Armijo test on the value alone accepts it. The accepted gradient then becomes the
     next step's ``g``: the direction is NaN, every later line search fails, and the run
-    ends with no accepted steps at all rather than with a visible error.
-
-    Deterministic: fixed data seed, fixed start, one fixed batch installed throughout.
-    Without the finiteness guard this configuration records ``n_accepted == 0``.
+    ends with no accepted steps at all rather than with a visible error. Deterministic —
+    fixed data seed, fixed start, one batch installed throughout — and without the
+    finiteness guard it records ``n_accepted == 0``.
     """
     from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
     from pymc_extras.inference.pathfinder.stochastic_lbfgs import run_stochastic_lbfgs
@@ -298,24 +297,19 @@ def test_jitter_starts_two_seeds_at_different_points(monkeypatch):
     assert not np.allclose(firsts[0], firsts[1])
 
 
-def test_callbacks_reach_the_optimizer(monkeypatch):
-    """The optimizer's callback hook is only worth its lines if a user can reach it: a
-    pm.fit early-stopping rule has to run against a streaming fit unchanged, and the
-    shortened trajectory has to be the one the fit then averages."""
-    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+def test_callbacks_reach_the_optimizer():
+    """A pm.fit early-stopping rule has to run against a streaming fit unchanged, and the
+    fit has to finish on the trajectory the rule shortened.
 
+    pm.fit hands each callback ``(approx, scores[: i + 1], i + 1)``: the losses so far and
+    a 1-based step index. A rule reading more than the last loss — every convergence check
+    does — is silently starved by a one-element list.
+    """
     rng = np.random.default_rng(0)
     X = rng.normal(size=(60, 2))
     y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
     model, packed, *_ = gaussian_regression(X, y, 1.0)
-
-    seen, iterates = [], []
-    run = sp.run_stochastic_lbfgs
-    monkeypatch.setattr(
-        sp,
-        "run_stochastic_lbfgs",
-        lambda *a, **k: (lambda t: (iterates.extend(t.iterates), t)[1])(run(*a, **k)),
-    )
+    seen = []
 
     def stop_at_3(approx, losses, i):
         seen.append((approx, len(losses), i))
@@ -332,7 +326,6 @@ def test_callbacks_reach_the_optimizer(monkeypatch):
         random_seed=0,
     )
     assert seen == [(None, 1, 1), (None, 2, 2), (None, 3, 3)]
-    assert 0 < len(iterates) <= 3
     assert res.samples.shape == (10, 2)
 
 
@@ -492,9 +485,10 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
 
 
 def test_a_drop_last_loader_is_refused_and_told_what_to_pass():
-    """A DataLoader epoch yields floor(N / batch_size) * batch_size rows, so for almost
-    any N the default full_pass cannot produce an exact logP. The error has to name the
-    remedy: it fires only after the whole optimization has been paid for."""
+    """A DataLoader epoch yields floor(N / batch_size) * batch_size rows, so for almost any
+    N the default full_pass cannot produce an exact logP. The error has to name the remedy —
+    it fires only after the whole optimization has been paid for — and passing that remedy
+    has to actually take effect."""
     rng = np.random.default_rng(24)
     k, n = 2, 350
     X = rng.normal(size=(n, k))
@@ -575,23 +569,6 @@ def test_returned_draws_have_requested_shape(
     assert res.logQ.shape == (n_prop,)
     assert np.isfinite(res.samples).all()
     assert (res.pareto_k is not None) == has_pareto_k
-
-
-def test_psis_reweights_rather_than_permuting_the_pool():
-    """The default pool has to be a multiple of num_draws. Resampling num_draws out of
-    num_draws + 1 without replacement (importance_sampling.py sets replace=False for
-    "psis") returns the pool minus one draw whatever the weights are, and arviz's Pareto
-    tail fit needs 5 tail draws, so num_draws <= 23 raised outright."""
-    rng = np.random.default_rng(0)
-    X = rng.normal(size=(60, 2))
-    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
-    model, packed, *_ = gaussian_regression(X, y, 1.0)
-    res = fit_streaming_pathfinder(
-        model, ArrayLoader(packed, 20), num_iters=8, num_draws=20, random_seed=0
-    )
-    assert res.samples.shape == (20, 2)
-    assert res.logP.shape == (80,)
-    assert res.pareto_k is not None
 
 
 def potential_model(y, n):

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -284,6 +284,119 @@ def test_full_data_logp_exact_with_tail():
         assert abs(got[i] - truth) < 1e-6, (i, got[i], truth)
 
 
+def full_data_logp_parts(model, k, rng, n_phi=4):
+    """Return ``(_full_data_logp, prior_fn, obs_fn, exact_logp, phi)`` for ``model``.
+
+    ``exact_logp`` evaluates the target on whatever is in the placeholder; call it with the
+    whole dataset set to get the value ``_full_data_logp`` reproduces from a streamed pass.
+    """
+    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
+    from pymc_extras.inference.pathfinder.streaming_pathfinder import (
+        _compile_batched_logp,
+        _full_data_logp,
+    )
+
+    prior_fn = _compile_batched_logp(model, model.free_RVs, jacobian=True)
+    obs_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
+    nlp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
+    phi = rng.normal(size=(n_phi, k))
+
+    def exact_logp():
+        return np.array([-nlp(row.astype(np.float64))[0] for row in phi])
+
+    return _full_data_logp, prior_fn, obs_fn, exact_logp, phi
+
+
+def test_full_data_logp_invariant_to_batch_order_and_size():
+    """logP is the exact full-data density, so any partition of the rows into batches, in
+    any order, gives the same value as evaluating the target on the whole dataset.
+
+    Every batch's contribution is un-rescaled by its own row count, so a pass of uneven
+    or single-row batches, or one that visits the rows shuffled, must not shift the total.
+    """
+    rng = np.random.default_rng(21)
+    k, n = 2, 60
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([0.8, -1.2]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    full_data_logp, prior_fn, obs_fn, exact_logp, phi = full_data_logp_parts(model, k, rng)
+
+    shuffled = packed[rng.permutation(n)]
+    passes = {
+        "one-batch": [packed],
+        "uneven-tail": [packed[i : i + 7] for i in range(0, n, 7)],
+        "single-rows": [packed[i : i + 1] for i in range(n)],
+        "shuffled": [shuffled[i : i + 13] for i in range(0, n, 13)],
+    }
+    got = {
+        name: full_data_logp(phi, p, model, "batch", prior_fn, obs_fn, n)
+        for name, p in passes.items()
+    }
+    model.set_data("batch", packed)
+    truth = exact_logp()
+    for name, value in got.items():
+        np.testing.assert_allclose(value, truth, atol=1e-8, err_msg=name)
+
+
+def test_incomplete_full_pass_is_refused():
+    """A pass that does not visit every row is rejected rather than returning a
+    subset-rescaled density that silently looks like the full-data one."""
+    rng = np.random.default_rng(22)
+    k, n = 2, 40
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([0.5, 0.25]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    full_data_logp, prior_fn, obs_fn, _, phi = full_data_logp_parts(model, k, rng)
+
+    with pytest.raises(RuntimeError, match=r"visited 25 rows but len\(loader\)=40"):
+        full_data_logp(phi, [packed[:25]], model, "batch", prior_fn, obs_fn, n)
+
+
+@pytest.mark.parametrize(
+    "importance_sampling, num_proposal_draws, n_prop, has_pareto_k",
+    [
+        (None, None, 50, False),
+        (None, 137, 137, False),
+        ("identity", None, 200, False),
+        ("identity", 137, 137, False),
+        ("psis", None, 200, True),
+        ("psis", 137, 137, True),
+    ],
+    ids=["none", "none-pool", "identity", "identity-pool", "psis", "psis-pool"],
+)
+def test_returned_draws_have_requested_shape(
+    importance_sampling, num_proposal_draws, n_prop, has_pareto_k
+):
+    """samples is (num_draws, N) for every weighting method and proposal-pool size, while
+    logP and logQ stay the length of the proposal pool they were computed on.
+
+    The pool defaults to 4x num_draws when resampling and to num_draws otherwise; an
+    explicit num_proposal_draws overrides both, and none of that may leak into the
+    returned draw count.
+    """
+    num_draws = 50
+    rng = np.random.default_rng(23)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    res = fit_streaming_pathfinder(
+        model,
+        ArrayLoader(packed, 20),
+        num_iters=8,
+        num_draws=num_draws,
+        num_proposal_draws=num_proposal_draws,
+        eval_rows=60,
+        importance_sampling=importance_sampling,
+        random_seed=0,
+        lbfgs_config=CFG,
+    )
+    assert res.samples.shape == (num_draws, 2)
+    assert res.logP.shape == (n_prop,)
+    assert res.logQ.shape == (n_prop,)
+    assert np.isfinite(res.samples).all()
+    assert (res.pareto_k is not None) == has_pareto_k
+
+
 def potential_model(y, n):
     """Normal-normal model carrying a pm.Potential that pulls theta away from the data."""
     with pm.Model() as model:
@@ -379,3 +492,45 @@ def test_proposal_pool_smaller_than_num_draws_still_returns_num_draws():
         random_seed=0,
     )
     assert result.samples.shape == (200, 2)
+
+
+def test_full_data_logp_installs_every_batch():
+    """The streaming pass must install each batch, not read whatever is already there.
+
+    A finished fit leaves the evaluation batch in the placeholder, so a loop that
+    forgot ``set_data`` would sum that one subset n_batches times. Existing tests
+    miss it because their fixtures happen to leave the full dataset installed, in
+    which case the rescaled sum telescopes back to the right answer by accident.
+    """
+    from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
+    from pymc_extras.inference.pathfinder.streaming_pathfinder import (
+        _compile_batched_logp,
+        _full_data_logp,
+    )
+
+    rng = np.random.default_rng(0)
+    k, n, chunk = 2, 40, 10
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    phi = rng.normal(size=(4, k))
+
+    nlp = get_neg_logp_dlogp_of_ravel_inputs(model, jacobian=True)
+    model.set_data("batch", packed)
+    truth = np.array([-nlp(row.astype(np.float64))[0] for row in phi])
+
+    prior_fn = _compile_batched_logp(
+        model, [*model.free_RVs, *model.potentials], jacobian=True
+    )
+    obs_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
+    model.set_data("batch", packed[:chunk])  # the stale batch a finished fit leaves behind
+    got = _full_data_logp(
+        phi,
+        [packed[i : i + chunk] for i in range(0, n, chunk)],
+        model,
+        "batch",
+        prior_fn,
+        obs_fn,
+        n,
+    )
+    np.testing.assert_allclose(got, truth, rtol=1e-9)

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -162,6 +162,73 @@ def test_elbo_argmax_selects_max():
     assert res.elbo_argmax == int(np.argmax(res.elbo_trace))
 
 
+def test_a_degenerate_iterate_cannot_win_the_argmax():
+    """A draw with zero proposal density scores +inf, which would take the argmax
+    outright; a non-finite score has to fall to -inf instead."""
+    from pymc_extras.inference.pathfinder.streaming_pathfinder import _elbo
+
+    assert _elbo(np.array([1.0, 2.0]), np.array([-np.inf, 0.0])) == -np.inf
+    assert _elbo(np.array([1.0, 2.0]), np.array([0.0, 0.0])) == 1.5
+
+
+def test_evaluation_batch_holds_exactly_eval_rows(monkeypatch):
+    """Rows past eval_rows are ones the loader wrapped around the epoch to fetch again,
+    so the selection sweep would score iterates on a batch with duplicated rows."""
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(50, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=50)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    set_data = model.set_data
+    installed = []
+    monkeypatch.setattr(
+        model,
+        "set_data",
+        lambda name, value, **kw: (installed.append(len(value)), set_data(name, value, **kw))[1],
+    )
+    fit_streaming_pathfinder(
+        model,
+        ArrayLoader(packed, batch_size=16),
+        num_iters=5,
+        num_draws=10,
+        eval_rows=40,
+        importance_sampling=None,
+        random_seed=0,
+    )
+    assert max(installed) == 40
+
+
+def test_optimizer_health_counters_reach_the_result(monkeypatch):
+    """Both counters are read off the trajectory, so a fit that struggled cannot come
+    back reporting a clean one."""
+    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+
+    run = sp.run_stochastic_lbfgs
+
+    def struggling(*args, **kwargs):
+        traj = run(*args, **kwargs)
+        traj.n_curvature_violations = traj.n_accepted
+        traj.n_ls_failures = 7
+        return traj
+
+    monkeypatch.setattr(sp, "run_stochastic_lbfgs", struggling)
+    rng = np.random.default_rng(0)
+    X = rng.normal(size=(60, 2))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+    result = fit_streaming_pathfinder(
+        model,
+        ArrayLoader(packed, batch_size=20),
+        num_iters=6,
+        num_draws=10,
+        eval_rows=60,
+        importance_sampling=None,
+        random_seed=0,
+    )
+    assert result.violation_rate == 0.5
+    assert result.n_ls_failures == 7
+
+
 def test_missing_batch_var_raises():
     """A model without the named placeholder gives an actionable error."""
     rng = np.random.default_rng(6)

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -100,14 +100,9 @@ def test_set_data_changes_compiled_objective():
     assert not np.allclose(g_all, g_sub), "gradient did not respond to set_data"
 
 
-def test_a_saturated_trial_point_cannot_poison_the_gradient():
-    """A logit past float64 saturation has a finite logp and a NaN gradient, so the
-    Armijo test on the value alone accepts it. The accepted gradient then becomes the
-    next step's ``g``: the direction is NaN, every later line search fails, and the run
-    ends with no accepted steps at all rather than with a visible error. Deterministic —
-    fixed data seed, fixed start, one batch installed throughout — and without the
-    finiteness guard it records ``n_accepted == 0``.
-    """
+def test_saturated_trial_point_rejected():
+    """A saturated logit has a finite logp and a NaN gradient, so Armijo on the value alone
+    would accept it and every later step would inherit the NaN direction."""
     from pymc_extras.inference.pathfinder.bfgs_sample import get_neg_logp_dlogp_of_ravel_inputs
     from pymc_extras.inference.pathfinder.stochastic_lbfgs import run_stochastic_lbfgs
 
@@ -172,49 +167,39 @@ def test_crn_determinism():
     np.testing.assert_array_equal(a.samples, b.samples)
 
 
-def capture_gaussian(monkeypatch):
-    """Record the (x, g, alpha, s_win, z_win) the final full-width draw is taken from."""
-    import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
+def test_gaussian_is_centred_on_tail_averaged_position(monkeypatch):
+    """The proposal centre is the mean of the last 75% of iterate positions, not one iterate.
 
-    seen = {}
-    original = sp.make_pathfinder_sample_fn
-
-    def wrapper(*args, **kwargs):
-        fn = original(*args, **kwargs)
-
-        def tapped(x, g, alpha, s_win, z_win, u):
-            seen["args"] = (x, g, alpha, s_win, z_win)
-            return fn(x, g, alpha, s_win, z_win, u)
-
-        return tapped
-
-    monkeypatch.setattr(sp, "make_pathfinder_sample_fn", wrapper)
-    return seen
-
-
-def test_the_gaussian_is_centred_on_the_tail_averaged_position(monkeypatch):
-    """The proposal centre is the mean of the last 75% of iterate *positions*, not any
-    single iterate.
-
-    Every stochastic step is a full quasi-Newton step plus line search on one minibatch, so
-    each iterate is near that minibatch's MAP rather than the full-data MAP. The error is in
-    the location, so it survives any rule that picks one iterate; averaging the positions is
-    what removes it. Picking the last iterate instead would pass a weaker shape-only check.
+    Each step's accepted point is near its own minibatch's MAP, so the error is in the
+    location and survives any rule that picks a single iterate.
     """
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
-    seen = capture_gaussian(monkeypatch)
+    from pymc_extras.inference.pathfinder.bfgs_sample import make_pathfinder_sample_fn
+
     rng = np.random.default_rng(4)
     X, y, _ = sample_logistic(k=2, n=300, rng=rng)
     model, packed = logistic_regression(X, y)
 
+    # Record the Gaussian the final draw is taken from, and the iterates it came from.
+    gaussian = {}
+    sample_fn = make_pathfinder_sample_fn(model, N=2, J=CFG.maxcor, jacobian=True)
+
+    def record_gaussian(x, g, alpha, s_win, z_win, u):
+        gaussian.update(x=x, g=g, alpha=alpha, s_win=s_win, z_win=z_win)
+        return sample_fn(x, g, alpha, s_win, z_win, u)
+
+    monkeypatch.setattr(sp, "make_pathfinder_sample_fn", lambda *a, **k: record_gaussian)
+
     iterates = []
     run = sp.run_stochastic_lbfgs
-    monkeypatch.setattr(
-        sp,
-        "run_stochastic_lbfgs",
-        lambda *a, **k: (lambda t: (iterates.extend(t.iterates), t)[1])(run(*a, **k)),
-    )
+
+    def record_iterates(*args, **kwargs):
+        traj = run(*args, **kwargs)
+        iterates.extend(traj.iterates)
+        return traj
+
+    monkeypatch.setattr(sp, "run_stochastic_lbfgs", record_iterates)
     fit_streaming_pathfinder(
         model,
         ArrayLoader(packed, batch_size=64),
@@ -227,19 +212,18 @@ def test_the_gaussian_is_centred_on_the_tail_averaged_position(monkeypatch):
 
     m = max(1, round(sp._TAIL_AVERAGE_FRAC * len(iterates)))
     assert 1 < m < len(iterates), "the average has to span several iterates to mean anything"
-    x, g, alpha, s_win, z_win = seen["args"]
+    x = gaussian["x"]
     np.testing.assert_allclose(x, np.mean([it["x"] for it in iterates[-m:]], axis=0))
     assert not np.allclose(x, iterates[-1]["x"]), "averaging collapsed to the last iterate"
     # mu = x - H_inv @ g, so only g = 0 centres the Gaussian on the averaged position.
-    np.testing.assert_array_equal(g, np.zeros_like(x))
+    np.testing.assert_array_equal(gaussian["g"], np.zeros_like(x))
     # Curvature is the last iterate's: averaged (s, z) pairs are not a valid L-BFGS memory.
-    for got, want in ((alpha, "alpha"), (s_win, "s_win"), (z_win, "z_win")):
-        np.testing.assert_array_equal(got, iterates[-1][want])
+    for key in ("alpha", "s_win", "z_win"):
+        np.testing.assert_array_equal(gaussian[key], iterates[-1][key])
 
 
-def test_optimizer_health_counters_reach_the_result(monkeypatch):
-    """Both counters are read off the trajectory, so a fit that struggled cannot come
-    back reporting a clean one."""
+def test_health_counters_reach_the_result(monkeypatch):
+    """violation_rate and n_ls_failures are read off the trajectory, not defaulted."""
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
     run = sp.run_stochastic_lbfgs
@@ -267,9 +251,8 @@ def test_optimizer_health_counters_reach_the_result(monkeypatch):
     assert result.n_ls_failures == 7
 
 
-def test_jitter_starts_two_seeds_at_different_points(monkeypatch):
-    """Without the jitter every fit starts at the same deterministic prior point, so a
-    second seed retraces the first trajectory and multi-path Pathfinder degenerates."""
+def test_jitter_varies_the_start_by_seed(monkeypatch):
+    """Without jitter every seed starts at the same prior point and retraces one trajectory."""
     import pymc_extras.inference.pathfinder.streaming_pathfinder as sp
 
     rng = np.random.default_rng(0)
@@ -297,14 +280,8 @@ def test_jitter_starts_two_seeds_at_different_points(monkeypatch):
     assert not np.allclose(firsts[0], firsts[1])
 
 
-def test_callbacks_reach_the_optimizer():
-    """A pm.fit early-stopping rule has to run against a streaming fit unchanged, and the
-    fit has to finish on the trajectory the rule shortened.
-
-    pm.fit hands each callback ``(approx, scores[: i + 1], i + 1)``: the losses so far and
-    a 1-based step index. A rule reading more than the last loss — every convergence check
-    does — is silently starved by a one-element list.
-    """
+def test_callbacks_get_pm_fit_arguments():
+    """Callbacks see ``(None, losses_so_far, 1-based step)`` and one can stop the fit early."""
     rng = np.random.default_rng(0)
     X = rng.normal(size=(60, 2))
     y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=60)
@@ -484,11 +461,8 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
         np.testing.assert_allclose(value, truth, atol=1e-8, err_msg=name)
 
 
-def test_a_drop_last_loader_is_refused_and_told_what_to_pass():
-    """A DataLoader epoch yields floor(N / batch_size) * batch_size rows, so for almost any
-    N the default full_pass cannot produce an exact logP. The error has to name the remedy —
-    it fires only after the whole optimization has been paid for — and passing that remedy
-    has to actually take effect."""
+def test_drop_last_loader_is_refused():
+    """A drop-last epoch cannot give an exact logP; the error names full_pass, which works."""
     rng = np.random.default_rng(24)
     k, n = 2, 350
     X = rng.normal(size=(n, k))

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -234,25 +234,6 @@ def test_batch_size_robustness():
     assert np.all(np.abs(means[256] - means[2000]) < 0.25 + 0.15 * np.abs(means[2000]))
 
 
-@pytest.mark.slow
-def test_violation_rate_below_20pct():
-    """Same-batch pairing keeps the curvature-violation rate under the proposal's 20%."""
-    rng = np.random.default_rng(12)
-    X, y, _ = sample_logistic(k=4, n=4000, rng=rng)
-    model, packed = logistic_regression(X, y)
-    loader = ArrayLoader(packed, batch_size=256, shuffle=True, seed=1)
-    res = fit_streaming_pathfinder(
-        model,
-        loader,
-        num_iters=200,
-        num_draws=500,
-        eval_rows=1000,
-        random_seed=0,
-        lbfgs_config=CFG,
-    )
-    assert res.violation_rate < 0.20, f"violation rate {res.violation_rate:.3f}"
-
-
 def test_full_data_logp_exact_with_tail():
     """Streaming full-data logP equals model.logp over the whole dataset, including the
     trailing partial batch a drop-last training loader would skip."""
@@ -338,6 +319,34 @@ def test_full_data_logp_invariant_to_batch_order_and_size():
         np.testing.assert_allclose(value, truth, atol=1e-8, err_msg=name)
 
 
+def test_a_drop_last_loader_is_refused_and_told_what_to_pass():
+    """A DataLoader epoch yields floor(N / batch_size) * batch_size rows, so for almost
+    any N the default full_pass cannot produce an exact logP. The error has to name the
+    remedy: it fires only after the whole optimization has been paid for."""
+    rng = np.random.default_rng(24)
+    k, n = 2, 350
+    X = rng.normal(size=(n, k))
+    y = X @ np.array([1.0, -0.5]) + rng.normal(0, 1.0, size=n)
+    model, packed, *_ = gaussian_regression(X, y, 1.0)
+
+    class DropLastLoader(ArrayLoader):
+        def __iter__(self):
+            for start in range(0, len(self) - self.batch_size + 1, self.batch_size):
+                yield self.data[start : start + self.batch_size]
+
+    loader = DropLastLoader(packed, batch_size=128)
+    assert sum(b.shape[0] for b in loader) == 256 < len(loader)
+
+    kwargs = dict(num_iters=5, num_draws=50, eval_rows=60, random_seed=0, lbfgs_config=CFG)
+    with pytest.raises(RuntimeError, match=r"pass full_pass=<the loader's dataset source>"):
+        fit_streaming_pathfinder(model, loader, **kwargs)
+
+    res = fit_streaming_pathfinder(
+        model, loader, full_pass=[packed[i : i + 97] for i in range(0, n, 97)], **kwargs
+    )
+    assert res.samples.shape == (50, k)
+
+
 def test_incomplete_full_pass_is_refused():
     """A pass that does not visit every row is rejected rather than returning a
     subset-rescaled density that silently looks like the full-data one."""
@@ -357,9 +366,9 @@ def test_incomplete_full_pass_is_refused():
     [
         (None, None, 50, False),
         (None, 137, 137, False),
-        ("identity", None, 200, False),
+        ("identity", None, 51, False),
         ("identity", 137, 137, False),
-        ("psis", None, 200, True),
+        ("psis", None, 51, True),
         ("psis", 137, 137, True),
     ],
     ids=["none", "none-pool", "identity", "identity-pool", "psis", "psis-pool"],
@@ -370,9 +379,9 @@ def test_returned_draws_have_requested_shape(
     """samples is (num_draws, N) for every weighting method and proposal-pool size, while
     logP and logQ stay the length of the proposal pool they were computed on.
 
-    The pool defaults to 4x num_draws when resampling and to num_draws otherwise; an
-    explicit num_proposal_draws overrides both, and none of that may leak into the
-    returned draw count.
+    The pool defaults to num_draws, plus one when resampling so PSIS reweights instead of
+    permuting; an explicit num_proposal_draws overrides both, and none of that may leak
+    into the returned draw count.
     """
     num_draws = 50
     rng = np.random.default_rng(23)
@@ -519,9 +528,7 @@ def test_full_data_logp_installs_every_batch():
     model.set_data("batch", packed)
     truth = np.array([-nlp(row.astype(np.float64))[0] for row in phi])
 
-    prior_fn = _compile_batched_logp(
-        model, [*model.free_RVs, *model.potentials], jacobian=True
-    )
+    prior_fn = _compile_batched_logp(model, [*model.free_RVs, *model.potentials], jacobian=True)
     obs_fn = _compile_batched_logp(model, model.observed_RVs, jacobian=False)
     model.set_data("batch", packed[:chunk])  # the stale batch a finished fit leaves behind
     got = _full_data_logp(

--- a/tests/inference/pathfinder/test_streaming_pathfinder.py
+++ b/tests/inference/pathfinder/test_streaming_pathfinder.py
@@ -160,6 +160,14 @@ def test_saturated_trial_point_rejected():
         assert np.all(np.isfinite(it["g"]))
 
 
+def test_zero_accepted_steps_raises():
+    """A run that never accepts a step must refuse to sample, not sample garbage."""
+    model, packed = logistic_case(seed=1, n=400)
+    loader = ArrayLoader(packed, batch_size=64)
+    with pytest.raises(RuntimeError, match="no accepted steps"):
+        fit_streaming_pathfinder(model, loader, num_iters=0, random_seed=2, lbfgs_config=CFG)
+
+
 def test_smoke_streaming_logistic():
     """A short streaming fit on logistic data returns finite, correctly shaped draws."""
     model, packed = logistic_case(seed=1, n=400)


### PR DESCRIPTION
Adds `fit_streaming_pathfinder`: Pathfinder initialization for datasets that never fit in memory, driven through the merged DataLoader contract. The loader must expose `total_size` (the dataset row count N); the driver refuses one that cannot, since the importance weights need an exact full-data pass and there is no honest way to guess N.

Two design decisions carry the PR.

**Curvature pairs come from a single minibatch.** Both gradients of each `(s, y)` pair are evaluated on the same batch, so the batch noise cancels in the difference (Schraudolph, Yu & Günter 2007); the batch advances only after the pair is formed. Cross-batch pairing violated the curvature condition on 0.3-30% of steps, rising with batch size; same-batch produced zero violations on every cell run.

**Polyak-Ruppert tail averaging replaces ELBO iterate selection.** Every step is a quasi-Newton step plus line search on one minibatch, so each accepted iterate sits near that batch's MAP — a location error, not a covariance one, which no rule that picks an iterate can fix (an oracle over all 200 iterates only reached pareto_k 2.4). Averaging the last 75% of positions does: against an exact full-data Laplace reference (Bayesian logistic regression, batch 2048, `num_iters=200`), pareto_k at k=8, N=1e5 runs 0.26-0.58 over 12 seeds with the worst posterior-mean coordinate 0.05-0.30 reference-sd out. On real data the picture is friendlier because the objective is quadratic: 1M rows of Binance tick data against a closed-form posterior streamed through the same loader gives pareto_k 0.45 and 0.03 reference-sd; 30.7M rows give 0.30 and 0.11.

**Where it degrades, stated plainly.** A pre-registered held-out battery (three families never used during development, shipped defaults, three seeds each against full-data Laplace references) puts sharper edges on the range: a Poisson GLM (4 params) is clean at pareto_k 0.08-0.33; Student-t regression with estimated nu (5 params) is marginal at 0.58-0.84 with mean error within 0.26 ref-sd; a hierarchical random-intercept model (23 params) fails outright at 1.9-2.4 with the worst coordinate 4.7-7.2 ref-sd out. Partial pooling's coupled scales defeat a single tail-averaged Gaussian well below the dimension wall, and the docstring now says so. Accuracy falls with N — pareto_k 0.48-1.04 and error up to 1.58 ref-sd over 6 seeds at N=4e5, above 0.7 on three of six — and much faster with dimension: at k=100 it is 2.7-4.3 and 52-59 ref-sd, and nothing raises, because the line search's gradient-finiteness guard turns what used to be a crash into a quiet failure. I do not quote a growth rate; three cells do not pin one. These draws are a proposal, not a posterior; read `pareto_k` on every fit. One more caveat: if the loader transforms its batches, `full_pass` must apply the same transform, or the weights go wrong with no diagnostic.

**The loss series has a documented convention.** `losses[i-1]` is the objective at the position step `i` reached, evaluated on the batch installed after that step — not the value the step's Armijo test accepted, which is measured on the very batch the position was chosen to minimize and reads optimistically low. Measured against the exact full-data objective over 6 seeds x 1200 steps, the recorded series is not detectably biased (mean error +10.2, se 7.2) while the accepted-value alternative is biased at -367.7 (se 9.7). `test_recorded_loss_is_measured_after_the_batch_advance` pins it. This matters because the convergence callback in #733 is the intended consumer of exactly this series.

Out of scope: the exact-full-data-gradient variant, the positions-only `Trajectory` refactor, initial-step scaling. The tail fraction is what I am least sure of: I hard-coded 0.75 rather than add a knob. Sweeping 0.50/0.60/0.75/0.90, the interior is flat and only 1.00 is clearly wrong; the exact medians moved between reruns, so I kept only the claim both reruns agree on.

AI disclosure, per the PyMC GSoC 2026 guidance: I used Claude extensively on this PR, for implementation, test generation, and for re-deriving the claims above. Every number in this description and in the docstrings was verified by running code, and several earlier versions of them were wrong and were corrected or deleted on that basis. All commits except the two original hand-written ones carry a `Co-Authored-By` trailer.
