### PR TITLE
Fix nested Prior objects failing in .preliz property

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -1029,7 +1029,12 @@ class Prior:
         """
         import preliz as pz
 
-        return getattr(pz, self.distribution)(**self.parameters)
+        params = {
+            key: value.preliz if isinstance(value, Prior) else value
+            for key, value in self.parameters.items()
+        }
+
+        return getattr(pz, self.distribution)(**params)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert the prior to dictionary format.

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -157,6 +157,12 @@ def test_preliz() -> None:
     assert isinstance(dist, preliz_distributions.Distribution)
 
 
+def test_preliz_with_nested_prior() -> None:
+    var = Prior("Truncated", dist=Prior("Normal", mu=0, sigma=1), lower=0, upper=1)
+    dist = var.preliz
+    assert isinstance(dist, preliz_distributions.Distribution)
+
+
 @pytest.mark.parametrize(
     "var, expected",
     [


### PR DESCRIPTION
## Summary
Fixes #605

The `.preliz` property on `Prior` passed `self.parameters` directly into
the preliz distribution constructor without converting nested `Prior`
objects first. This caused an `AttributeError` whenever a `Prior`'s
parameters included another `Prior` (e.g. `Truncated` wrapping a `Normal`).

## Fix
Convert any parameter that is itself a `Prior` into its own `.preliz`
form before passing it along, recursively handling nested `Prior` objects.

## Testing
- Added `test_preliz_with_nested_prior`, using the exact reproduction
  case from #605
- Ran the full `test_prior.py` suite (110 passed, 2 skipped — unrelated,
  missing optional `graphviz`)
- Verified manually against the reproduction script in the issue

## Reproduction (before fix)
```python
from pymc_extras.prior import Prior
p = Prior("Truncated", dist=Prior("Normal", mu=0, sigma=1), lower=0, upper=1)
p.preliz  # AttributeError: 'Prior' object has no attribute 'kind'
```