### PR TITLE
Support marginalizing DiscreteUniform with batch endpoints and Categorical with symbolic sized P

### DIFF
--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -2,13 +2,12 @@ import warnings
 
 from collections.abc import Sequence
 
-import numpy as np
 import pytensor.tensor as pt
 
 from pymc.distributions import Bernoulli, Categorical, DiscreteUniform
 from pymc.logprob.abstract import _logprob
 from pymc.logprob.basic import conditional_logp
-from pymc.pytensorf import constant_fold, resolve_shapes
+from pymc.pytensorf import resolve_shapes
 from pytensor.compile.mode import Mode
 from pytensor.graph import Op, node_rewriter, vectorize_graph
 from pytensor.graph.replace import graph_replace
@@ -86,22 +85,29 @@ class MarginalFiniteDiscreteRV(EnumerableMarginalRV):
     """Base class for Marginalized Finite Discrete RVs"""
 
 
-def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> tuple[int, ...]:
+def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> TensorVariable:
+    """Return the support of a finite discrete RV as a vector.
+
+    The domain is kept symbolic, so that RVs whose number of states is not known at graph
+    construction time (e.g. a Categorical whose `p` has a model dim as its last axis) can
+    still be enumerated. Shapes are resolved and values folded when possible, which preserves
+    the static length of the domain for the common case.
+    """
     op = rv.owner.op
     dist_params = rv.owner.op.dist_params(rv.owner)
     if isinstance(op, Bernoulli):
-        return (0, 1)
+        return pt.arange(2)
     elif isinstance(op, Categorical):
         [p_param] = dist_params
-        [p_param_length] = constant_fold([p_param.shape[-1]])
-        return tuple(range(p_param_length))
+        [p_param_length] = resolve_shapes([p_param.shape[-1]])
+        return pt.arange(p_param_length)
     elif isinstance(op, DiscreteUniform):
-        lower, upper = constant_fold(dist_params)
-        return tuple(np.arange(lower, upper + 1))
+        lower, upper = constant_fold(dist_params, raise_not_constant=False)
+        return pt.arange(lower, upper + 1)
     elif isinstance(op, DiscreteMarkovChain):
         P, *_ = dist_params
-        [n_states] = constant_fold(resolve_shapes([P.shape[-1]]))
-        return tuple(range(n_states))
+        [n_states] = resolve_shapes([P.shape[-1]])
+        return pt.arange(n_states)
 
     raise NotImplementedError(f"Cannot compute domain for op {op}")
 
@@ -182,11 +188,11 @@ def finite_discrete_marginal_rv_logp(op: MarginalFiniteDiscreteRV, values, *inpu
     # batched dimensions of the marginalized RV
 
     # PyMC does not allow RVs in the logp graph, even if we are just using the shape
-    marginalized_rv_shape = constant_fold(tuple(marginalized_rv.shape), raise_not_constant=False)
+    marginalized_rv_shape = resolve_shapes(tuple(marginalized_rv.shape))
     marginalized_rv_domain = get_domain_of_finite_discrete_rv(marginalized_rv)
     marginalized_rv_domain_tensor = pt.moveaxis(
         pt.full(
-            (*marginalized_rv_shape, len(marginalized_rv_domain)),
+            (*marginalized_rv_shape, marginalized_rv_domain.size),
             marginalized_rv_domain,
             dtype=marginalized_rv.dtype,
         ),
@@ -254,11 +260,11 @@ def finite_discrete_marginalized_conditional(op, inputs, dep_rvs):
         dependent_logps,
     )
 
-    rv_shape = constant_fold(tuple(marginalized.shape), raise_not_constant=False)
+    rv_shape = resolve_shapes(tuple(marginalized.shape))
     rv_domain = get_domain_of_finite_discrete_rv(marginalized)
     rv_domain_tensor = pt.moveaxis(
         pt.full(
-            (*rv_shape, len(rv_domain)),
+            (*rv_shape, rv_domain.size),
             rv_domain,
             dtype=marginalized.dtype,
         ),

--- a/pymc_extras/model/marginal/distributions/enumerable.py
+++ b/pymc_extras/model/marginal/distributions/enumerable.py
@@ -90,8 +90,7 @@ def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> TensorVariable:
 
     The domain is kept symbolic, so that RVs whose number of states is not known at graph
     construction time (e.g. a Categorical whose `p` has a model dim as its last axis) can
-    still be enumerated. Shapes are resolved and values folded when possible, which preserves
-    the static length of the domain for the common case.
+    still be enumerated. When the number of states is static, the usual rewrites recover it.
     """
     op = rv.owner.op
     dist_params = rv.owner.op.dist_params(rv.owner)
@@ -102,8 +101,10 @@ def get_domain_of_finite_discrete_rv(rv: TensorVariable) -> TensorVariable:
         [p_param_length] = resolve_shapes([p_param.shape[-1]])
         return pt.arange(p_param_length)
     elif isinstance(op, DiscreteUniform):
-        lower, upper = constant_fold(dist_params, raise_not_constant=False)
-        return pt.arange(lower, upper + 1)
+        # Batched bounds are enumerated over their envelope. States outside the bounds of a
+        # given entry have -inf logp, so they drop out of the enumeration.
+        lower, upper = dist_params
+        return pt.arange(lower.min(), upper.max() + 1)
     elif isinstance(op, DiscreteMarkovChain):
         P, *_ = dist_params
         [n_states] = resolve_shapes([P.shape[-1]])

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -67,3 +67,25 @@ def test_categorical_domain_from_dims():
 
     marginal_m = marginalize(m, ["idx"])
     np.testing.assert_allclose(marginal_m.compile_logp([marginal_m["y"]])(ip), ref_logp)
+
+
+def test_discrete_uniform_batched_bounds():
+    """Batched bounds are enumerated over their envelope, out of bounds states have -inf logp."""
+    lower, upper = [0, 10, 20], 40
+    y_data = np.array([0.5, 9.0, 21.0])
+
+    with pm.Model() as m:
+        sigma = pm.HalfNormal("sigma", 1.0)
+        mu = pm.DiscreteUniform("mu", lower=lower, upper=upper)
+        pm.Normal("y", mu=mu, sigma=sigma, observed=y_data)
+
+    ip = m.initial_point()
+    ip.pop("mu")
+    ref_logp_fn = m.compile_logp([m["mu"], m["y"]], sum=False)
+    ref_logp = logsumexp(
+        [sum(ref_logp_fn({**ip, "mu": np.full(3, state)})) for state in range(upper + 1)],
+        axis=0,
+    ).sum()
+
+    marginal_m = marginalize(m, ["mu"])
+    np.testing.assert_allclose(marginal_m.compile_logp([marginal_m["y"]])(ip), ref_logp)

--- a/tests/model/marginal/test_enumerable.py
+++ b/tests/model/marginal/test_enumerable.py
@@ -4,7 +4,9 @@ import pymc as pm
 from pymc.logprob.abstract import _logprob
 from pymc.pytensorf import collect_default_updates
 from pytensor import tensor as pt
+from scipy.special import logsumexp
 
+from pymc_extras.marginal import marginalize
 from pymc_extras.model.marginal.distributions import MarginalFiniteDiscreteRV
 
 
@@ -39,3 +41,29 @@ def test_marginalized_bernoulli_logp():
         logp.eval({mu: [-1, 1], y_vv: 2}),
         ref_logp.eval({mu: [-1, 1], y_vv: 2}),
     )
+
+
+def test_categorical_domain_from_dims():
+    """The number of categories may only be known at runtime, when it comes from a model dim."""
+    n_obs, n_groups = 4, 3
+    y_data = np.array([-0.9, 0.3, 1.7, 0.1])
+
+    with pm.Model(coords={"obs_idx": range(n_obs), "group": range(n_groups)}) as m:
+        logit_p = pm.Normal("logit_p", dims=("obs_idx", "group"))
+        mu = pm.Normal("mu", dims=("group",))
+        # The last axis of the Categorical parameter is only known once the dim length is resolved
+        assert logit_p.type.shape == (None, None)
+        idx = pm.Categorical("idx", logit_p=logit_p, dims=("obs_idx",))
+        pm.Normal("y", mu=mu[idx], sigma=1.0, observed=y_data, dims=("obs_idx",))
+
+    ip = m.initial_point()
+    ip.pop("idx")
+    # Observations are independent given p, so enumerate each one over the shared domain
+    ref_logp_fn = m.compile_logp([m["idx"], m["y"]], sum=False)
+    ref_logp = logsumexp(
+        [sum(ref_logp_fn({**ip, "idx": np.full(n_obs, g)})) for g in range(n_groups)],
+        axis=0,
+    ).sum()
+
+    marginal_m = marginalize(m, ["idx"])
+    np.testing.assert_allclose(marginal_m.compile_logp([marginal_m["y"]])(ip), ref_logp)


### PR DESCRIPTION
- **Keep finite discrete marginalization domain symbolic** Closes #331 
- **Support batched bounds when marginalizing DiscreteUniform** Closes #290 
