### PR TITLE
Add pymc_extras.terms: composable subgraphs for PyMC + xarray

### DIFF
--- a/docs/api/terms.rst
+++ b/docs/api/terms.rst
@@ -1,19 +1,27 @@
 Composable model terms
 =====================
 
-Declarative, composable terms for building ``pymc.dims`` subgraphs from
-xarray datasets. Terms compose with ``+``, ``*``, and ``-`` operators
-and handle coordinates, data registration, tensor construction, and
-prediction data updating.
+``pymc_extras.terms`` provides a small, expressive core of building blocks
+for ``pymc.dims`` subgraphs from xarray data.  The built-in terms
+(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``) cover common
+linear-predictor pieces, but **this module is not a full modeling toolkit** ---
+it does not ship complete hierarchical, domain-specific, or
+observation-model wrappers.  It is designed
+to be **extended**: subclass ``ModelTerm`` for domain-specific terms
+(gather/index, media transforms, group effects); they compose with
+built-ins via ``+``, ``*``, and ``-`` and use the same helpers.  See the
+``pymc_extras.terms`` module docstring **Extending** section for a full
+custom-term recipe.
 
 .. currentmodule:: pymc_extras.terms
 .. autosummary::
    :toctree: ../generated/
 
    ModelTerm
+   Parameter
+   Intercept
    Sum
    Product
-   Intercept
    Dot
    Transform
    build_param

--- a/docs/api/terms.rst
+++ b/docs/api/terms.rst
@@ -1,0 +1,24 @@
+Composable model terms
+=====================
+
+Declarative, composable terms for building ``pymc.dims`` subgraphs from
+xarray datasets. Terms compose with ``+``, ``*``, and ``-`` operators
+and handle coordinates, data registration, tensor construction, and
+prediction data updating.
+
+.. currentmodule:: pymc_extras.terms
+.. autosummary::
+   :toctree: ../generated/
+
+   ModelTerm
+   Sum
+   Product
+   Intercept
+   Dot
+   Transform
+   build_param
+   get_coords
+   register_data
+   set_data
+   collect_terms
+   collect_coords

--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -10,5 +10,6 @@ API Reference
    api/inference
    api/distributions
    api/statespace
+   api/terms
    api/prior
    api/utils

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -97,6 +97,46 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
+
+Extending
+---------
+``Parameter`` and ``Intercept`` are the same kind of term.  ``Intercept``
+is a convenience alias with ``name`` defaulting to ``"intercept"``; use
+``Parameter`` when the role is not an intercept (e.g. a cohort scale or
+product effect).  When the prior carries ``dims``, coordinates are
+automatically extracted from the dataset during ``collect_coords``.
+
+Custom terms subclass ``ModelTerm`` and implement the five lifecycle
+methods.  Here is an example of a gather / index term that maps a
+cohort-level parameter to customer-level via an index column.  This is
+**not shipped** — copy it into your project as a starting point:
+
+.. code-block:: python
+
+    @dataclass
+    class Indexed(ModelTerm):
+        base: Any  # e.g. Parameter("alpha", prior=Prior(..., dims="cohort"))
+        index_var: str  # e.g. "cohort_idx" (integer codes, dims="customer_id")
+
+        def get_coords(self, ds):
+            return get_coords(self.base, ds)
+
+        def register_data(self, ds):
+            register_data(self.base, ds=ds)
+            model = pm.modelcontext(None)
+            if self.index_var not in model:
+                pmd.Data(self.index_var, ds[self.index_var], dims=ds[self.index_var].dims)
+
+        def create_variable(self):
+            base_val = build_param(self.base)
+            model = pm.modelcontext(None)
+            idx = model[self.index_var]
+            return base_val[idx]
+
+        def set_data(self, ds, model=None):
+            set_data(self.base, ds=ds, model=model)
+            if self.index_var in ds:
+                pm.set_data({self.index_var: ds[self.index_var].values}, model=model)
 """
 
 from __future__ import annotations
@@ -118,6 +158,7 @@ __all__ = [
     "Dot",
     "Intercept",
     "ModelTerm",
+    "Parameter",
     "Product",
     "Sum",
     "Transform",
@@ -300,29 +341,64 @@ class Product:
 
 
 @dataclass
-class Intercept(ModelTerm):
-    """Constant intercept term.
+class Parameter(ModelTerm):
+    """Named free parameter (scalar or dimensional via ``prior.dims``).
 
-    Each intercept in the same ``pm.Model`` must have a unique ``name``.
-    Two intercepts with the same name (even in different parameter trees,
+    ``Parameter`` is the general-purpose leaf for free random variables.
+    ``Intercept`` is a convenience alias that defaults ``name`` to
+    ``"intercept"``; both share the same lifecycle.
+
+    Each parameter in the same ``pm.Model`` must have a unique ``name``.
+    Two parameters with the same name (even in different expression trees,
     e.g., a ``mu`` expression and a ``sigma`` expression) will clash when
     ``build_param`` creates the variables.
 
     Parameters
     ----------
     name : str
-        Name for the PyMC variable.
+        Name for the PyMC variable (required).
     prior : VariableFactory
-        Prior distribution for the intercept. Any ``VariableFactory``
+        Prior distribution for the parameter. Any ``VariableFactory``
         (``Prior``, ``Censored``, ``Scaled``, custom) is accepted.
+        When the prior carries ``dims`` (e.g. ``Prior(..., dims="cohort")``),
+        ``get_coords`` will extract those coordinates from the dataset.
+    """
+
+    name: str
+    prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from ``prior.dims`` present in the dataset."""
+        dims = getattr(self.prior, "dims", None)
+        if dims is None:
+            return {}
+        if isinstance(dims, str):
+            dims = (dims,)
+        return {d: ds.coords[d].values.tolist() for d in dims if d in ds.coords}
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build a free parameter variable."""
+        return self.prior.create_variable(self.name, xdist=True)
+
+
+@dataclass
+class Intercept(Parameter):
+    """GLM-style intercept term; same as :class:`Parameter` with a default name.
+
+    ``Intercept`` is provided for familiar GLM notation.  It is identical
+    to ``Parameter`` in behavior and lifecycle.  Use ``Parameter`` when the
+    role is not an intercept (e.g. a cohort scale or product effect).
+
+    Parameters
+    ----------
+    name : str
+        Name for the PyMC variable.  Defaults to ``"intercept"``.
+    prior : VariableFactory
+        Prior distribution.  Any ``VariableFactory`` is accepted.
     """
 
     name: str = "intercept"
     prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
-
-    def create_variable(self) -> pt.TensorVariable:
-        """Build a scalar intercept variable."""
-        return self.prior.create_variable(self.name, xdist=True)
 
 
 @dataclass(kw_only=True)

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -282,6 +282,12 @@ class Product:
             **get_coords(self.right, ds),
         }
 
+    def __mul__(self, other: Any) -> Product:
+        return Product(self, other)
+
+    def __rmul__(self, other: Any) -> Product:
+        return Product(other, self)
+
     def register_data(self, ds: xr.Dataset) -> None:
         """Register shared data for both operands."""
         register_data(self, ds=ds)

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -58,7 +58,7 @@ Examples
         register_data,
     )
 
-    mu = Intercept(name="mu") + Dot("x", prior=Prior("Normal", dims="feature"))
+    mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
 
     coords = collect_coords(mu, sigma, ds=ds)
@@ -74,11 +74,11 @@ Gotchas
   (via ``pmd.Normal`` with ``xdist=True``, or ``pytensor.xtensor``).
   Mixing non-xtensor output (e.g., regular ``pm.Normal``) with xtensor
   output in a ``Sum`` will fail when ``build_param`` composes them.
-- Two ``Dot`` terms referencing the same ``data_var`` will share the
+- Two ``Dot`` terms referencing the same ``var_name`` will share the
   ``pmd.Data`` variable automatically (duplicate registration is skipped).
-- Two ``Dot`` terms with the same ``data_var`` will also create identically
-  named beta variables (``{data_var}_beta``), causing a PyMC "already
-  exists" error. Use different ``data_var`` values to avoid this.
+- Two ``Dot`` terms with the same ``var_name`` will also create identically
+  named beta variables (``{var_name}_beta``), causing a PyMC "already
+  exists" error. Use different ``var_name`` values to avoid this.
 - ``build_param`` is not idempotent --- call it once to create PyMC
   variables, then sample. Calling it a second time tries to create
   variables with the same name, causing a PyMC error.
@@ -324,7 +324,7 @@ class Intercept(ModelTerm):
         return self.prior.create_variable(self.name, xdist=True)
 
 
-@dataclass
+@dataclass(kw_only=True)
 class Dot(ModelTerm):
     """Linear predictor term: ``data @ beta``.
 
@@ -332,7 +332,7 @@ class Dot(ModelTerm):
 
     Parameters
     ----------
-    data_var : str
+    var_name : str
         Name of the data variable in the dataset.
     prior : VariableFactory
         Prior for the beta coefficients. Any ``VariableFactory`` is
@@ -340,31 +340,31 @@ class Dot(ModelTerm):
         data variable.
     """
 
-    data_var: str
+    var_name: str
     prior: VariableFactory
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Extract coordinates from the data variable."""
-        return {k: v.values.tolist() for k, v in ds[self.data_var].coords.items()}
+        return {k: v.values.tolist() for k, v in ds[self.var_name].coords.items()}
 
     def register_data(self, ds: xr.Dataset) -> None:
         """Register the data variable as ``pmd.Data``."""
         model = pm.modelcontext(None)
-        if self.data_var not in model:
-            pmd.Data(self.data_var, ds[self.data_var])
+        if self.var_name not in model:
+            pmd.Data(self.var_name, ds[self.var_name])
 
     def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
         """Update ``pmd.Data`` for prediction."""
-        if self.data_var in ds:
-            da = ds[self.data_var]
+        if self.var_name in ds:
+            da = ds[self.var_name]
             coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
-            pm.set_data({self.data_var: da.values}, model=model, coords=coords)
+            pm.set_data({self.var_name: da.values}, model=model, coords=coords)
 
     def create_variable(self) -> pt.TensorVariable:
         """Build ``data @ beta`` tensor."""
         model = pm.modelcontext(None)
-        data = model[self.data_var]
-        beta = self.prior.create_variable(f"{self.data_var}_beta", xdist=True)
+        data = model[self.var_name]
+        beta = self.prior.create_variable(f"{self.var_name}_beta", xdist=True)
         return data @ beta
 
 

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -14,40 +14,133 @@
 
 """Composable model terms for building ``pymc.dims`` subgraphs from xarray data.
 
-Terms define reusable recipes for creating PyMC model components from an
-``xarray.Dataset``. They compose with ``+``, ``*``, and ``-`` operators and
-produce coordinates, data registration, tensor construction, and data updating.
+``pymc_extras.terms`` provides a small set of built-in pieces
+(``Parameter`` / ``Intercept``, ``Dot``, ``Transform``) that compose with
+``+``, ``*``, and ``-`` into predictors.  **This module is not a full
+modeling toolkit** --- it does not ship complete hierarchical,
+domain-specific, or observation-model wrappers.  It is a **thin, expressive
+core** that lets you build what you need by subclassing ``ModelTerm`` and
+reusing the same helpers and operators that built-ins use.  If a term is
+missing from this package, that is the intended path: write a custom term,
+compose it with ``+`` / ``*`` / ``-``, and the framework handles coords,
+data registration, tensor construction, and prediction updates.
 
-The framework is ``pymc.dims``-native. ``create_variable()`` returns an
-``XTensorVariable`` (dimensional tensor). Built-in terms use ``pmd.Data``
+The framework is ``pymc.dims``-native.  ``create_variable()`` returns an
+``XTensorVariable`` (dimensional tensor).  Built-in terms use ``pmd.Data``
 for shared data and ``pmd.Normal`` with ``xdist=True`` for variables.
 Custom terms should use ``pymc.dims`` and ``pytensor.xtensor`` throughout
 to ensure compatibility during composition.
 
-Each term implements five lifecycle methods:
+Extending
+---------
+This module is designed so that **the parts you do not find here are the
+parts you are meant to write.**  ``ModelTerm`` is the extension base;
+subclass it, implement five lifecycle methods, and the result composes
+with the built-ins via ``+`` / ``*`` / ``-`` --- no framework changes
+required.
 
+Lifecycle (per term)
+^^^^^^^^^^^^^^^^^^^^
 - ``get_coords(ds)`` -- return coordinates from data variables (outside model)
-- ``add_coords(ds)`` -- add coordinates to the model (inside model context)
+- ``add_coords(ds)`` -- add model-only coordinates, if not in dataset (inside model context)
 - ``register_data(ds)`` -- register ``pmd.Data`` shared variables (inside model)
 - ``create_variable()`` -- build a dimensional tensor **inside** a ``pm.Model`` context
 - ``set_data(ds, model)`` -- update shared variables for prediction
 
-The ``register_data`` helper calls ``add_coords`` before ``register_data``
-on each ``ModelTerm``, so dynamic coordinates are handled automatically.
-Override ``add_coords`` for coordinates that are not discoverable from the
-dataset alone (e.g., unique group labels from a data column).
+``register_data`` calls ``add_coords`` before ``register_data`` on each
+``ModelTerm``, so dynamic coordinates are handled automatically.
 
-The ``build_param`` helper accepts any ``VariableFactory`` (``Prior``,
-``Censored``, ``Scaled``, custom), ``ModelTerm``, ``xr.DataArray``,
-or numeric literal. ``Prior.create_variable`` is called with ``xdist=True``
-to produce dimensional output.
+Rules
+^^^^^
+- ``get_coords`` should be **pure** (no model context).
+- Guard ``pmd.Data`` registration with ``if name not in model`` to share
+  data between terms.
+- ``create_variable`` must return a dims-compatible (xtensor) tensor.
+- Each RV name must be unique across the full expression tree.
+- ``build_param`` accepts ``VariableFactory``, ``ModelTerm``, ``xr.DataArray``,
+  or numeric literal.  ``Prior.create_variable`` is called with ``xdist=True``.
+
+``Parameter`` and ``Intercept``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+These are the same kind of term: a named free parameter whose shape
+comes from the prior (scalar when no ``dims``; dimensional when the prior
+carries ``dims``).  ``Intercept`` is a convenience alias with ``name``
+defaulting to ``"intercept"``; use ``Parameter`` when the role is not an
+intercept (e.g. a cohort scale or product effect).  When the prior
+carries ``dims``, coordinates are automatically extracted from the dataset
+during ``collect_coords``.
+
+Example: custom gather term
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Copy this into your project as a starting point for cohort / index /
+group gathers:
+
+.. code-block:: python
+
+    @dataclass
+    class Indexed(ModelTerm):
+        base: Any
+        index_var: str
+
+        def get_coords(self, ds):
+            return get_coords(self.base, ds)
+
+        def register_data(self, ds):
+            register_data(self.base, ds=ds)
+            model = pm.modelcontext(None)
+            if self.index_var not in model:
+                pmd.Data(self.index_var, ds[self.index_var], dims=ds[self.index_var].dims)
+
+        def create_variable(self):
+            base_val = build_param(self.base)
+            model = pm.modelcontext(None)
+            idx = model[self.index_var]
+            return base_val[idx]
+
+        def set_data(self, ds, model=None):
+            set_data(self.base, ds=ds, model=model)
+            if self.index_var in ds:
+                pm.set_data({self.index_var: ds[self.index_var].values}, model=model)
+
+Usage (custom + built-ins composed in one expression):
+
+.. code-block:: python
+
+    import pytensor.xtensor as ptx
+    from pymc_extras.prior import Prior
+    from pymc_extras.terms import (
+        Dot,
+        Parameter,
+        Transform,
+        build_param,
+        collect_coords,
+        get_coords,
+        register_data,
+        set_data,
+    )
+
+    mu = Indexed(
+        Parameter("alpha_scale", prior=Prior("HalfNormal", dims="cohort")),
+        "cohort_idx",
+    ) * Transform(
+        -Dot(var_name="covars", name="coef_alpha", prior=Prior("Normal", dims="covar")),
+        ptx.math.exp,
+    )
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        alpha = build_param(mu)
 
 Examples
 --------
+Built-ins cover the common pieces.  The explicit four-step lifecycle
+(``collect_coords`` / ``register_data`` / ``build_param`` / ``set_data``)
+works the same for built-ins and custom terms --- no hidden helpers.
+
 .. code-block:: python
 
     import pymc.dims as pmd
-    import pytensor.xtensor.math as ptx
+    import pytensor.xtensor as ptx
     from pymc_extras.prior import Prior
     from pymc_extras.terms import (
         Dot,
@@ -59,7 +152,7 @@ Examples
     )
 
     mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
-    sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+    sigma = Transform(Intercept(name="sigma"), func=ptx.math.exp)
 
     coords = collect_coords(mu, sigma, ds=ds)
 
@@ -67,6 +160,27 @@ Examples
         register_data(mu, ds=ds)
         register_data(sigma, ds=ds)
         pmd.Normal("y_obs", mu=build_param(mu), sigma=build_param(sigma), observed=ds["y"])
+
+.. code-block:: python
+
+    from pymc_extras.terms import Parameter, Dot, collect_coords, register_data, build_param
+
+    mu = Parameter("baseline", prior=Prior("Normal", dims="product")) + Dot(
+        var_name="x", prior=Prior("Normal", dims="feature")
+    )
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        build_param(mu)
+
+.. code-block:: python
+
+    from pymc_extras.terms import Dot, Intercept, collect_coords, register_data, build_param
+
+    alpha_branch = Dot(var_name="x", name="alpha_coef", prior=Prior("Normal", dims="feature"))
+    beta_branch = Dot(var_name="x", name="beta_coef", prior=Prior("Normal", dims="feature"))
+    mu = alpha_branch + Intercept(name="offset")
+    # beta_branch can be used in a separate expression tree
 
 Gotchas
 -------
@@ -97,46 +211,6 @@ Gotchas
           model = pm.modelcontext(None)
           unique = list(dict.fromkeys(ds[self.data_source].values))
           model.add_coords({self.data_source: unique})
-
-Extending
----------
-``Parameter`` and ``Intercept`` are the same kind of term.  ``Intercept``
-is a convenience alias with ``name`` defaulting to ``"intercept"``; use
-``Parameter`` when the role is not an intercept (e.g. a cohort scale or
-product effect).  When the prior carries ``dims``, coordinates are
-automatically extracted from the dataset during ``collect_coords``.
-
-Custom terms subclass ``ModelTerm`` and implement the five lifecycle
-methods.  Here is an example of a gather / index term that maps a
-cohort-level parameter to customer-level via an index column.  This is
-**not shipped** — copy it into your project as a starting point:
-
-.. code-block:: python
-
-    @dataclass
-    class Indexed(ModelTerm):
-        base: Any  # e.g. Parameter("alpha", prior=Prior(..., dims="cohort"))
-        index_var: str  # e.g. "cohort_idx" (integer codes, dims="customer_id")
-
-        def get_coords(self, ds):
-            return get_coords(self.base, ds)
-
-        def register_data(self, ds):
-            register_data(self.base, ds=ds)
-            model = pm.modelcontext(None)
-            if self.index_var not in model:
-                pmd.Data(self.index_var, ds[self.index_var], dims=ds[self.index_var].dims)
-
-        def create_variable(self):
-            base_val = build_param(self.base)
-            model = pm.modelcontext(None)
-            idx = model[self.index_var]
-            return base_val[idx]
-
-        def set_data(self, ds, model=None):
-            set_data(self.base, ds=ds, model=model)
-            if self.index_var in ds:
-                pm.set_data({self.index_var: ds[self.index_var].values}, model=model)
 """
 
 from __future__ import annotations
@@ -175,8 +249,12 @@ __all__ = [
 class ModelTerm:
     """Base class for composable model terms.
 
-    Subclass and implement the lifecycle methods to define a reusable
-    PyMC subgraph recipe. Terms compose with ``+``, ``*``, and ``-``.
+    Subclass ``ModelTerm`` to define reusable PyMC subgraph recipes.
+    Custom terms compose with the built-ins (``Parameter``, ``Intercept``,
+    ``Dot``, ``Transform``) via ``+``, ``*``, and ``-`` and use the same
+    helpers (``collect_coords``, ``register_data``, ``build_param``,
+    ``set_data``) --- no framework changes required.  See the module
+    docstring **Extending** section for the full contract and an example.
     """
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
@@ -362,6 +440,29 @@ class Parameter(ModelTerm):
         (``Prior``, ``Censored``, ``Scaled``, custom) is accepted.
         When the prior carries ``dims`` (e.g. ``Prior(..., dims="cohort")``),
         ``get_coords`` will extract those coordinates from the dataset.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_extras.terms import (
+            Parameter,
+            Dot,
+            Intercept,
+            collect_coords,
+            register_data,
+            build_param,
+        )
+
+        # scalar
+        mu = Parameter("mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+
+        # dimensional (cohort)
+        alpha = Parameter("alpha_scale", prior=Prior("HalfNormal", dims="cohort"))
+
+        # same concept, GLM sugar
+        intercept = Intercept("intercept")  # defaults to name="intercept"
     """
 
     name: str
@@ -420,6 +521,20 @@ class Dot(ModelTerm):
         Provide a distinct ``name`` to reference the same ``var_name`` from
         multiple terms (e.g. separate alpha and beta coefficient branches)
         without colliding on the coefficient variable name.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        from pymc_extras.prior import Prior
+        from pymc_extras.terms import Dot, Intercept, collect_coords, register_data, build_param
+
+        # basic
+        mu = Intercept("mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+
+        # two branches on the same data, distinct coefficient names
+        alpha_branch = Dot(var_name="x", name="alpha_coef", prior=Prior("Normal", dims="feature"))
+        beta_branch = Dot(var_name="x", name="beta_coef", prior=Prior("Normal", dims="feature"))
     """
 
     var_name: str
@@ -476,9 +591,21 @@ class Transform(ModelTerm):
     --------
     .. code-block:: python
 
-        import pytensor.xtensor.math as ptx
+        import pytensor.xtensor as ptx
 
-        sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+        sigma = Transform(Intercept(name="sigma"), func=ptx.math.exp)
+
+    ``inner`` may be any expression, including custom ``ModelTerm``
+    subclasses and composed trees:
+
+    .. code-block:: python
+
+        from pymc_extras.terms import Dot, Transform
+
+        effect = Transform(
+            Dot(var_name="x", prior=Prior("Normal", dims="feature")),
+            func=ptx.math.softplus,
+        )
     """
 
     inner: Any

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -1,0 +1,571 @@
+#   Copyright 2026 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Composable model terms for building ``pymc.dims`` subgraphs from xarray data.
+
+Terms define reusable recipes for creating PyMC model components from an
+``xarray.Dataset``. They compose with ``+``, ``*``, and ``-`` operators and
+produce coordinates, data registration, tensor construction, and data updating.
+
+The framework is ``pymc.dims``-native. ``create_variable()`` returns an
+``XTensorVariable`` (dimensional tensor). Built-in terms use ``pmd.Data``
+for shared data and ``pmd.Normal`` with ``xdist=True`` for variables.
+Custom terms should use ``pymc.dims`` and ``pytensor.xtensor`` throughout
+to ensure compatibility during composition.
+
+Each term implements five lifecycle methods:
+
+- ``get_coords(ds)`` -- return coordinates from data variables (outside model)
+- ``add_coords(ds)`` -- add coordinates to the model (inside model context)
+- ``register_data(ds)`` -- register ``pmd.Data`` shared variables (inside model)
+- ``create_variable()`` -- build a dimensional tensor **inside** a ``pm.Model`` context
+- ``set_data(ds, model)`` -- update shared variables for prediction
+
+The ``register_data`` helper calls ``add_coords`` before ``register_data``
+on each ``ModelTerm``, so dynamic coordinates are handled automatically.
+Override ``add_coords`` for coordinates that are not discoverable from the
+dataset alone (e.g., unique group labels from a data column).
+
+The ``build_param`` helper accepts any ``VariableFactory`` (``Prior``,
+``Censored``, ``Scaled``, custom), ``ModelTerm``, ``xr.DataArray``,
+or numeric literal. ``Prior.create_variable`` is called with ``xdist=True``
+to produce dimensional output.
+
+Examples
+--------
+.. code-block:: python
+
+    import pymc.dims as pmd
+    import pytensor.xtensor.math as ptx
+    from pymc_extras.prior import Prior
+    from pymc_extras.terms import (
+        Dot,
+        Intercept,
+        Transform,
+        build_param,
+        collect_coords,
+        register_data,
+    )
+
+    mu = Intercept(name="mu") + Dot("x", prior=Prior("Normal", dims="feature"))
+    sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+
+    coords = collect_coords(mu, sigma, ds=ds)
+
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=ds)
+        register_data(sigma, ds=ds)
+        pmd.Normal("y_obs", mu=build_param(mu), sigma=build_param(sigma), observed=ds["y"])
+
+Gotchas
+-------
+- ``create_variable()`` should return a dimensional tensor
+  (via ``pmd.Normal`` with ``xdist=True``, or ``pytensor.xtensor``).
+  Mixing non-xtensor output (e.g., regular ``pm.Normal``) with xtensor
+  output in a ``Sum`` will fail when ``build_param`` composes them.
+- Two ``Dot`` terms referencing the same ``data_var`` will share the
+  ``pmd.Data`` variable automatically (duplicate registration is skipped).
+- Two ``Dot`` terms with the same ``data_var`` will also create identically
+  named beta variables (``{data_var}_beta``), causing a PyMC "already
+  exists" error. Use different ``data_var`` values to avoid this.
+- ``build_param`` is not idempotent --- call it once to create PyMC
+  variables, then sample. Calling it a second time tries to create
+  variables with the same name, causing a PyMC error.
+- Changing the number of observations in ``set_data`` requires rebuilding
+  the model. This is a ``pmd.Data`` constraint (dimensional shared variables
+  have fixed dimension sizes), not a framework limitation.
+- Model-internal coordinates that are not in the dataset can be added
+  by overriding ``add_coords``:
+
+  .. code-block:: python
+
+      def add_coords(self, ds):
+          model = pm.modelcontext(None)
+          unique = list(dict.fromkeys(ds[self.data_source].values))
+          model.add_coords({self.data_source: unique})
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import pymc as pm
+import pymc.dims as pmd
+import pytensor.tensor as pt
+import xarray as xr
+
+from pytensor.xtensor.type import as_xtensor
+
+from pymc_extras.prior import Prior, VariableFactory
+
+__all__ = [
+    "Dot",
+    "Intercept",
+    "ModelTerm",
+    "Product",
+    "Sum",
+    "Transform",
+    "build_param",
+    "collect_coords",
+    "collect_terms",
+    "get_coords",
+    "register_data",
+    "set_data",
+]
+
+
+@dataclass
+class ModelTerm:
+    """Base class for composable model terms.
+
+    Subclass and implement the lifecycle methods to define a reusable
+    PyMC subgraph recipe. Terms compose with ``+``, ``*``, and ``-``.
+    """
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Return coordinates needed for this term."""
+        return {}
+
+    def add_coords(self, ds: xr.Dataset) -> None:
+        """Add coordinates to the model during ``register_data``.
+
+        Called automatically by the ``register_data`` helper. The active
+        model is available via ``pm.modelcontext(None)``. Override this
+        to add coordinates that are not discoverable from the dataset
+        alone (e.g., unique group labels from a data column).
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            Dataset containing the data variables.
+        """
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data variables as ``pmd.Data``."""
+
+    def create_variable(self) -> pt.TensorVariable | None:
+        """Build the term's tensor contribution.
+
+        Must be called within a ``pm.Model`` context. Override this to
+        produce a tensor. Not all terms need to produce a variable —
+        data reference terms may only implement ``register_data`` and
+        ``set_data``.
+
+        Returns
+        -------
+        pt.TensorVariable or None
+        """
+        return None
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data variables for out-of-sample prediction.
+
+        Parameters
+        ----------
+        ds : xr.Dataset
+            New dataset containing updated values.
+        model : pm.Model, optional
+            The PyMC model to update.
+        """
+
+    def __add__(self, other: Any) -> Sum:
+        return Sum([self, other])
+
+    def __radd__(self, other: Any) -> Sum:
+        if isinstance(other, int) and other == 0:
+            return self
+        return Sum([other, self])
+
+    def __mul__(self, other: Any) -> Product:
+        return Product(self, other)
+
+    def __rmul__(self, other: Any) -> Product:
+        return Product(other, self)
+
+    def __sub__(self, other: Any) -> Sum:
+        return Sum([self, -other])
+
+    def __rsub__(self, other: Any) -> Sum:
+        return Sum([other, -self])
+
+    def __neg__(self) -> Product:
+        return Product(-1, self)
+
+
+@dataclass
+class Sum:
+    """Container for additive composition via ``+``.
+
+    Created when terms are composed with the ``+`` operator.
+
+    Parameters
+    ----------
+    terms : list
+        The terms to sum together.
+    """
+
+    terms: list[Any]
+
+    def __add__(self, other: Any) -> Sum:
+        if isinstance(other, Sum):
+            return Sum(self.terms + other.terms)
+        return Sum([*self.terms, other])
+
+    def __radd__(self, other: Any) -> Sum:
+        if isinstance(other, int) and other == 0:
+            return self
+        return Sum([other, *self.terms])
+
+    def __mul__(self, other: Any) -> Product:
+        return Product(self, other)
+
+    def __rmul__(self, other: Any) -> Product:
+        return Product(other, self)
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from all terms."""
+        coords: dict[str, Any] = {}
+        for term in self.terms:
+            if isinstance(term, ModelTerm):
+                coords.update(term.get_coords(ds))
+        return coords
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for all terms.
+
+        Delegates to the module-level ``register_data`` helper which
+        calls ``add_coords`` on each term before registering data.
+        """
+        register_data(self, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for all terms."""
+        for term in self.terms:
+            if isinstance(term, ModelTerm):
+                term.set_data(ds, model=model)
+
+
+@dataclass
+class Product:
+    """Container for multiplicative composition via ``*``.
+
+    Created when terms are composed with the ``*`` operator.
+
+    Parameters
+    ----------
+    left : Any
+        Left operand.
+    right : Any
+        Right operand.
+    """
+
+    left: Any
+    right: Any
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Collect coordinates from both operands."""
+        return {
+            **get_coords(self.left, ds),
+            **get_coords(self.right, ds),
+        }
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register shared data for both operands."""
+        register_data(self, ds=ds)
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update shared data for both operands."""
+        set_data(self.left, ds=ds, model=model)
+        set_data(self.right, ds=ds, model=model)
+
+
+@dataclass
+class Intercept(ModelTerm):
+    """Constant intercept term.
+
+    Each intercept in the same ``pm.Model`` must have a unique ``name``.
+    Two intercepts with the same name (even in different parameter trees,
+    e.g., a ``mu`` expression and a ``sigma`` expression) will clash when
+    ``build_param`` creates the variables.
+
+    Parameters
+    ----------
+    name : str
+        Name for the PyMC variable.
+    prior : VariableFactory
+        Prior distribution for the intercept. Any ``VariableFactory``
+        (``Prior``, ``Censored``, ``Scaled``, custom) is accepted.
+    """
+
+    name: str = "intercept"
+    prior: VariableFactory = field(default_factory=lambda: Prior("Normal"))
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build a scalar intercept variable."""
+        return self.prior.create_variable(self.name, xdist=True)
+
+
+@dataclass
+class Dot(ModelTerm):
+    """Linear predictor term: ``data @ beta``.
+
+    Registers the data variable as ``pmd.Data`` for out-of-sample prediction.
+
+    Parameters
+    ----------
+    data_var : str
+        Name of the data variable in the dataset.
+    prior : VariableFactory
+        Prior for the beta coefficients. Any ``VariableFactory`` is
+        accepted. Must have dims matching the last dimension of the
+        data variable.
+    """
+
+    data_var: str
+    prior: VariableFactory
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        """Extract coordinates from the data variable."""
+        return {k: v.values.tolist() for k, v in ds[self.data_var].coords.items()}
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        """Register the data variable as ``pmd.Data``."""
+        model = pm.modelcontext(None)
+        if self.data_var not in model:
+            pmd.Data(self.data_var, ds[self.data_var])
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        """Update ``pmd.Data`` for prediction."""
+        if self.data_var in ds:
+            da = ds[self.data_var]
+            coords = {dim: ds[dim].values for dim in da.dims if dim in ds.coords}
+            pm.set_data({self.data_var: da.values}, model=model, coords=coords)
+
+    def create_variable(self) -> pt.TensorVariable:
+        """Build ``data @ beta`` tensor."""
+        model = pm.modelcontext(None)
+        data = model[self.data_var]
+        beta = self.prior.create_variable(f"{self.data_var}_beta", xdist=True)
+        return data @ beta
+
+
+@dataclass
+class Transform(ModelTerm):
+    """Apply a pytensor function to a term's output.
+
+    Delegates coordinates, data registration, and data updating to the
+    inner expression. Covers link functions and arbitrary transformations
+    without a separate link system.
+
+    Parameters
+    ----------
+    inner : Any
+        Inner expression accepted by ``build_param``
+        (``ModelTerm``, ``Sum``, ``float``, ``Prior``, etc.).
+    func : Callable
+        A pytensor function applied to ``build_param(inner)``.
+        E.g., ``pytensor.xtensor.math.exp``, ``pt.math.sigmoid``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        import pytensor.xtensor.math as ptx
+
+        sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+    """
+
+    inner: Any
+    func: Callable
+
+    def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
+        return get_coords(self.inner, ds)
+
+    def register_data(self, ds: xr.Dataset) -> None:
+        register_data(self.inner, ds=ds)
+
+    def create_variable(self) -> pt.TensorVariable:
+        return self.func(build_param(self.inner))
+
+    def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
+        set_data(self.inner, ds=ds, model=model)
+
+
+def get_coords(param: Any, ds: xr.Dataset) -> dict[str, Any]:
+    """Extract coordinates from a term or term composition.
+
+    Parameters
+    ----------
+    param : ModelTerm, Sum, Product, int, or float
+        The term(s) to extract coordinates from.
+    ds : xr.Dataset
+        Dataset containing the data variables.
+
+    Returns
+    -------
+    dict[str, Any]
+        Coordinates dict for ``pm.Model`` (or ``pmd`` distributions).
+    """
+    if isinstance(param, (int, float)):
+        return {}
+    if isinstance(param, ModelTerm):
+        return param.get_coords(ds)
+    if isinstance(param, Sum):
+        return param.get_coords(ds)
+    if isinstance(param, Product):
+        return param.get_coords(ds)
+    return {}
+
+
+def register_data(param: Any, *, ds: xr.Dataset) -> None:
+    """Register shared data variables as ``pmd.Data`` in the active model.
+
+    Calls ``add_coords`` before ``register_data`` on each ``ModelTerm``.
+
+    Parameters
+    ----------
+    param : ModelTerm, Sum, Product, int, or float
+        The term(s) containing data variables to register.
+    ds : xr.Dataset
+        Dataset containing the data values.
+    """
+    if isinstance(param, (int, float)):
+        return
+    if isinstance(param, ModelTerm):
+        param.add_coords(ds)
+        param.register_data(ds)
+    if isinstance(param, Sum):
+        for term in param.terms:
+            register_data(term, ds=ds)
+    if isinstance(param, Product):
+        register_data(param.left, ds=ds)
+        register_data(param.right, ds=ds)
+
+
+def build_param(param: Any, name: str = "param") -> pt.TensorVariable | int | float:
+    """Build a tensor parameter from a term, composition, variable factory, or constant.
+
+    Must be called within a ``pm.Model`` context.
+
+    Parameters
+    ----------
+    param : ModelTerm | Sum | Product | VariableFactory | int | float | xr.DataArray
+        The term(s) or variable factory to build into a tensor.
+    name : str
+        Variable name used when building standalone ``VariableFactory``
+        objects. Terms handle their own naming internally.
+
+    Returns
+    -------
+    pt.TensorVariable or float
+        The parameter tensor (``XTensorVariable`` when dimensional).
+    """
+    if isinstance(param, (int, float)):
+        return param
+    if isinstance(param, xr.DataArray):
+        return as_xtensor(param.values, dims=param.dims)
+    if isinstance(param, ModelTerm):
+        return param.create_variable()
+    if isinstance(param, Sum):
+        result: pt.TensorVariable | int = 0
+        for term in param.terms:
+            result = result + build_param(term)
+        return result
+    if isinstance(param, Product):
+        return build_param(param.left) * build_param(param.right)
+    if isinstance(param, VariableFactory):
+        return param.create_variable(name, xdist=True)
+    raise TypeError(f"Cannot build param from {type(param)}")
+
+
+def set_data(param: Any, *, ds: xr.Dataset, model: pm.Model) -> None:
+    """Update shared data variables for out-of-sample prediction.
+
+    Parameters
+    ----------
+    param : ModelTerm, Sum, Product, int, or float
+        The term(s) to update.
+    ds : xr.Dataset
+        New dataset for prediction.
+    model : pm.Model
+        The PyMC model to update.
+    """
+    if isinstance(param, (int, float)):
+        return
+    if isinstance(param, ModelTerm):
+        param.set_data(ds, model=model)
+    if isinstance(param, Sum):
+        param.set_data(ds, model=model)
+    if isinstance(param, Product):
+        param.set_data(ds, model=model)
+
+
+def collect_terms(params: list[Any]) -> list[ModelTerm]:
+    """Collect all ``ModelTerm`` instances from a list of parameter specifications.
+
+    Parameters
+    ----------
+    params : list
+        List of parameter specs (terms, term lists, compositions, constants).
+
+    Returns
+    -------
+    list[ModelTerm]
+        Flattened list of all individual term instances.
+    """
+    result: list[ModelTerm] = []
+    for p in params:
+        if isinstance(p, ModelTerm):
+            result.append(p)
+        elif isinstance(p, Sum):
+            result.extend(collect_terms(p.terms))
+        elif isinstance(p, Product):
+            result.extend(collect_terms([p.left, p.right]))
+    return result
+
+
+def collect_coords(*params: Any, ds: xr.Dataset) -> dict[str, Any]:
+    """Collect coordinates from multiple parameter expressions.
+
+    Convenience wrapper for collecting coordinates from several independent
+    term trees (e.g., a ``mu`` expression and a ``sigma`` expression).
+
+    Parameters
+    ----------
+    *params : Any
+        One or more ``ModelTerm``, ``Sum``, ``Product``, or compositions.
+    ds : xr.Dataset
+        Dataset containing the data variables.
+
+    Returns
+    -------
+    dict[str, Any]
+        Combined coordinates dict for ``pm.Model``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        coords = collect_coords(mu, sigma, ds=ds)
+        coords["obs"] = ds.coords["obs"].values.tolist()
+
+        with pm.Model(coords=coords) as model:
+            ...
+    """
+    coords: dict[str, Any] = {}
+    for param in params:
+        coords.update(get_coords(param, ds))
+    return coords

--- a/pymc_extras/terms.py
+++ b/pymc_extras/terms.py
@@ -78,7 +78,10 @@ Gotchas
   ``pmd.Data`` variable automatically (duplicate registration is skipped).
 - Two ``Dot`` terms with the same ``var_name`` will also create identically
   named beta variables (``{var_name}_beta``), causing a PyMC "already
-  exists" error. Use different ``var_name`` values to avoid this.
+  exists" error. Pass a distinct ``name`` to each ``Dot`` to give the
+  coefficients different variable names while still sharing the same
+  ``pmd.Data`` (e.g. separate alpha and beta coefficient branches on the
+  same covariate matrix).
 - ``build_param`` is not idempotent --- call it once to create PyMC
   variables, then sample. Calling it a second time tries to create
   variables with the same name, causing a PyMC error.
@@ -239,8 +242,7 @@ class Sum:
         """Collect coordinates from all terms."""
         coords: dict[str, Any] = {}
         for term in self.terms:
-            if isinstance(term, ModelTerm):
-                coords.update(term.get_coords(ds))
+            coords.update(get_coords(term, ds))
         return coords
 
     def register_data(self, ds: xr.Dataset) -> None:
@@ -254,8 +256,7 @@ class Sum:
     def set_data(self, ds: xr.Dataset, model: pm.Model | None = None) -> None:
         """Update shared data for all terms."""
         for term in self.terms:
-            if isinstance(term, ModelTerm):
-                term.set_data(ds, model=model)
+            set_data(term, ds=ds, model=model)
 
 
 @dataclass
@@ -338,10 +339,20 @@ class Dot(ModelTerm):
         Prior for the beta coefficients. Any ``VariableFactory`` is
         accepted. Must have dims matching the last dimension of the
         data variable.
+    name : str, optional
+        Name for the coefficient variable. Defaults to ``{var_name}_beta``.
+        Provide a distinct ``name`` to reference the same ``var_name`` from
+        multiple terms (e.g. separate alpha and beta coefficient branches)
+        without colliding on the coefficient variable name.
     """
 
     var_name: str
     prior: VariableFactory
+    name: str | None = None
+
+    def __post_init__(self):
+        if self.name is None:
+            self.name = f"{self.var_name}_beta"
 
     def get_coords(self, ds: xr.Dataset) -> dict[str, Any]:
         """Extract coordinates from the data variable."""
@@ -364,7 +375,7 @@ class Dot(ModelTerm):
         """Build ``data @ beta`` tensor."""
         model = pm.modelcontext(None)
         data = model[self.var_name]
-        beta = self.prior.create_variable(f"{self.var_name}_beta", xdist=True)
+        beta = self.prior.create_variable(self.name, xdist=True)
         return data @ beta
 
 

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -119,7 +119,7 @@ def test_sum_add_sum():
 
 
 def test_sum_add_term():
-    result = Sum([Intercept(name="a")]) + Dot("x", prior=Prior("Normal", dims="feature"))
+    result = Sum([Intercept(name="a")]) + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     assert len(result.terms) == 2
 
 
@@ -140,7 +140,7 @@ def test_sum_mul():
 
 
 def test_sum_get_coords(simple_ds):
-    tl = Sum([Dot("x", prior=Prior("Normal", dims="feature"))])
+    tl = Sum([Dot(var_name="x", prior=Prior("Normal", dims="feature"))])
     coords = tl.get_coords(simple_ds)
     assert "feature" in coords
 
@@ -152,7 +152,7 @@ def test_intercept_create_variable():
 
 
 def test_dot_register_data(simple_ds):
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
     with pm.Model(coords=coords):
         dot.register_data(simple_ds)
@@ -161,7 +161,7 @@ def test_dot_register_data(simple_ds):
 
 
 def test_dot_create_variable(simple_ds):
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
     with pm.Model(coords=coords):
         dot.register_data(simple_ds)
@@ -171,7 +171,7 @@ def test_dot_create_variable(simple_ds):
 
 def test_dot_set_data(simple_ds):
     ds2 = simple_ds.copy()
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
     with pm.Model(coords=coords):
         dot.register_data(simple_ds)
@@ -187,7 +187,7 @@ def test_transform_create_variable():
 
 
 def test_transform_with_dot(simple_ds):
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     transformed = Transform(dot, func=ptx.exp)
     coords = transformed.get_coords(simple_ds)
     with pm.Model(coords=coords):
@@ -219,7 +219,7 @@ def test_build_param_intercept():
 
 
 def test_build_param_dot(simple_ds):
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
     with pm.Model(coords=coords):
         dot.register_data(simple_ds)
@@ -228,7 +228,7 @@ def test_build_param_dot(simple_ds):
 
 
 def test_build_param_sum(simple_ds):
-    terms = Intercept(name="intercept") + Dot("x", prior=Prior("Normal", dims="feature"))
+    terms = Intercept(name="intercept") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = get_coords(terms, simple_ds)
     with pm.Model(coords=coords):
         register_data(terms, ds=simple_ds)
@@ -289,7 +289,7 @@ def test_collect_terms_flat():
 
 
 def test_collect_terms_nested():
-    terms = [Intercept(name="a") + Dot("x", prior=Prior("Normal", dims="feature"))]
+    terms = [Intercept(name="a") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))]
     result = collect_terms(terms)
     assert len(result) == 2
 
@@ -314,7 +314,7 @@ def test_collect_terms_includes_transform():
 
 def test_collect_coords(simple_ds):
     """collect_coords merges coordinates from multiple term trees."""
-    mu = Intercept(name="mu") + Dot("x", prior=Prior("Normal", dims="feature"))
+    mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
     coords = collect_coords(mu, sigma, ds=simple_ds)
     assert "feature" in coords
@@ -322,8 +322,8 @@ def test_collect_coords(simple_ds):
 
 def test_dot_dedup_data(simple_ds):
     """Two Dot terms with same data_var share the pmd.Data."""
-    dot_a = Dot("x", prior=Prior("Normal", dims="feature"))
-    dot_b = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot_a = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    dot_b = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     terms = dot_a + dot_b
     coords = get_coords(terms, simple_ds)
     with pm.Model(coords=coords) as m:
@@ -333,8 +333,8 @@ def test_dot_dedup_data(simple_ds):
 
 def test_dot_duplicate_prior_name_errors(simple_ds):
     """Same data_var AND same prior name clash on variable names."""
-    dot_a = Dot("x", prior=Prior("Normal", dims="feature"))
-    dot_b = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot_a = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    dot_b = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     terms = dot_a + dot_b
     coords = get_coords(terms, simple_ds)
     with pm.Model(coords=coords) as m:
@@ -377,7 +377,7 @@ def test_dot_set_data_renamed_dim(simple_ds):
     ds2 = simple_ds.copy()
     ds2 = ds2.assign_coords(feature=["X", "Y", "Z"])
 
-    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = get_coords(dot, simple_ds)
     with pm.Model(coords=coords):
         dot.register_data(simple_ds)
@@ -398,7 +398,7 @@ def test_collect_terms_deep_nesting(simple_ds):
     """collect_terms flattens deeply nested structures."""
     terms = Product(
         Intercept(name="a"),
-        Sum([Intercept(name="b"), Dot("x", prior=Prior("Normal", dims="feature"))]),
+        Sum([Intercept(name="b"), Dot(var_name="x", prior=Prior("Normal", dims="feature"))]),
     )
     result = collect_terms([terms])
     assert len(result) == 3

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -1,0 +1,425 @@
+#   Copyright 2026 The PyMC Developers
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+"""Tests for pymc_extras.terms."""
+
+from dataclasses import dataclass
+
+import numpy as np
+import pymc as pm
+import pymc.dims as pmd
+import pytensor.tensor as pt
+import pytensor.xtensor.math as ptx
+import pytest
+import xarray as xr
+
+from pytensor.graph.basic import Variable as PTVariable
+
+from pymc_extras.prior import Prior
+from pymc_extras.terms import (
+    Dot,
+    Intercept,
+    ModelTerm,
+    Product,
+    Sum,
+    Transform,
+    build_param,
+    collect_coords,
+    collect_terms,
+    get_coords,
+    register_data,
+)
+
+
+@pytest.fixture
+def simple_ds():
+    """Dataset with a 2D feature variable and a target."""
+    rng = np.random.default_rng(42)
+    return xr.Dataset(
+        {
+            "x": (("obs", "feature"), rng.normal(size=(50, 3))),
+            "y": ("obs", rng.normal(size=50)),
+        },
+        coords={"obs": range(50), "feature": list("ABC")},
+    )
+
+
+def test_modelterm_add():
+    result = Intercept(name="a") + Intercept(name="b")
+    assert isinstance(result, Sum)
+    assert len(result.terms) == 2
+
+
+def test_modelterm_add_int():
+    result = Intercept(name="a") + 5
+    assert isinstance(result, Sum)
+    assert result.terms[0] == Intercept(name="a")
+    assert result.terms[1] == 5
+
+
+def test_modelterm_radd_int():
+    result = 3 + Intercept(name="a")
+    assert isinstance(result, Sum)
+    assert result.terms[0] == 3
+    assert result.terms[1] == Intercept(name="a")
+
+
+def test_modelterm_radd_zero():
+    result = 0 + Intercept(name="a")
+    assert result == Intercept(name="a")
+
+
+def test_modelterm_mul():
+    result = Intercept(name="a") * Intercept(name="b")
+    assert isinstance(result, Product)
+    assert result.left == Intercept(name="a")
+    assert result.right == Intercept(name="b")
+
+
+def test_modelterm_sub():
+    result = Intercept(name="a") - Intercept(name="b")
+    assert isinstance(result, Sum)
+    assert len(result.terms) == 2
+    assert result.terms[0] == Intercept(name="a")
+    assert isinstance(result.terms[1], Product)
+    assert result.terms[1].left == -1
+    assert result.terms[1].right == Intercept(name="b")
+
+
+def test_modelterm_rsub():
+    result = 5 - Intercept(name="a")
+    assert isinstance(result, Sum)
+    assert result.terms[0] == 5
+    assert isinstance(result.terms[1], Product)
+
+
+def test_modelterm_neg():
+    result = -Intercept(name="a")
+    assert isinstance(result, Product)
+    assert result.left == -1
+    assert result.right == Intercept(name="a")
+
+
+def test_sum_add_sum():
+    t1 = Sum([Intercept(name="a")])
+    t2 = Sum([Intercept(name="b")])
+    result = t1 + t2
+    assert len(result.terms) == 2
+
+
+def test_sum_add_term():
+    result = Sum([Intercept(name="a")]) + Dot("x", prior=Prior("Normal", dims="feature"))
+    assert len(result.terms) == 2
+
+
+def test_sum_add_int():
+    result = Sum([Intercept(name="a")]) + 3
+    assert result.terms[-1] == 3
+
+
+def test_sum_radd_zero():
+    result = 0 + Sum([Intercept(name="a")])
+    assert isinstance(result, Sum)
+    assert len(result.terms) == 1
+
+
+def test_sum_mul():
+    result = Sum([Intercept(name="a")]) * Intercept(name="b")
+    assert isinstance(result, Product)
+
+
+def test_sum_get_coords(simple_ds):
+    tl = Sum([Dot("x", prior=Prior("Normal", dims="feature"))])
+    coords = tl.get_coords(simple_ds)
+    assert "feature" in coords
+
+
+def test_intercept_create_variable():
+    with pm.Model():
+        effect = Intercept(name="intercept").create_variable()
+        assert isinstance(effect, PTVariable)
+
+
+def test_dot_register_data(simple_ds):
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = dot.get_coords(simple_ds)
+    with pm.Model(coords=coords):
+        dot.register_data(simple_ds)
+        data = pm.modelcontext(None)["x"]
+        assert data is not None
+
+
+def test_dot_create_variable(simple_ds):
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = dot.get_coords(simple_ds)
+    with pm.Model(coords=coords):
+        dot.register_data(simple_ds)
+        effect = dot.create_variable()
+        assert isinstance(effect, PTVariable)
+
+
+def test_dot_set_data(simple_ds):
+    ds2 = simple_ds.copy()
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = dot.get_coords(simple_ds)
+    with pm.Model(coords=coords):
+        dot.register_data(simple_ds)
+        dot.set_data(ds2)
+
+
+def test_transform_create_variable():
+    with pm.Model():
+        inner = Intercept(name="sigma")
+        transformed = Transform(inner, func=ptx.exp)
+        result = transformed.create_variable()
+        assert isinstance(result, PTVariable)
+
+
+def test_transform_with_dot(simple_ds):
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    transformed = Transform(dot, func=ptx.exp)
+    coords = transformed.get_coords(simple_ds)
+    with pm.Model(coords=coords):
+        transformed.register_data(simple_ds)
+        result = transformed.create_variable()
+        assert isinstance(result, PTVariable)
+
+
+def test_transform_set_data(simple_ds):
+    inner = Intercept(name="sigma")
+    transformed = Transform(inner, func=ptx.exp)
+    ds2 = simple_ds.copy()
+    with pm.Model():
+        transformed.set_data(ds2)
+
+
+def test_build_param_int():
+    assert build_param(5) == 5
+
+
+def test_build_param_float():
+    assert build_param(3.14) == pytest.approx(3.14)
+
+
+def test_build_param_intercept():
+    with pm.Model():
+        result = build_param(Intercept(name="intercept"))
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_dot(simple_ds):
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = dot.get_coords(simple_ds)
+    with pm.Model(coords=coords):
+        dot.register_data(simple_ds)
+        result = build_param(dot)
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_sum(simple_ds):
+    terms = Intercept(name="intercept") + Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = get_coords(terms, simple_ds)
+    with pm.Model(coords=coords):
+        register_data(terms, ds=simple_ds)
+        result = build_param(terms)
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_multiplicative():
+    with pm.Model():
+        result = build_param(Product(Intercept(name="a"), 2.0))
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_prior():
+    with pm.Model():
+        result = build_param(Prior("Normal", mu=0, sigma=1), name="test")
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_transform():
+    with pm.Model():
+        result = build_param(Transform(Intercept(name="sigma"), func=ptx.exp))
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_variable_factory():
+    """Custom VariableFactory is accepted by build_param."""
+
+    class _CustomFactory:
+        dims = None
+
+        def create_variable(self, name, xdist=False):
+            return pt.as_tensor_variable(42.0)
+
+    with pm.Model():
+        result = build_param(_CustomFactory(), name="custom")
+        pt_value = result.eval()
+        assert pt_value == 42.0
+
+
+def test_build_param_dataarray():
+    da = xr.DataArray(np.array([1.0, 2.0, 3.0]), dims="obs")
+    with pm.Model():
+        result = build_param(da)
+        assert isinstance(result, PTVariable)
+
+
+def test_build_param_unknown_raises():
+    with pm.Model():
+        with pytest.raises(TypeError, match="Cannot build param"):
+            build_param("not_a_term")
+
+
+def test_collect_terms_flat():
+    terms = [Intercept(name="a"), Intercept(name="b")]
+    result = collect_terms(terms)
+    assert len(result) == 2
+
+
+def test_collect_terms_nested():
+    terms = [Intercept(name="a") + Dot("x", prior=Prior("Normal", dims="feature"))]
+    result = collect_terms(terms)
+    assert len(result) == 2
+
+
+def test_collect_terms_multiplicative():
+    terms = [Intercept(name="a") * Intercept(name="b")]
+    result = collect_terms(terms)
+    assert len(result) == 2
+
+
+def test_collect_terms_skips_constants():
+    terms = [Intercept(name="a"), 5, 3.0]
+    result = collect_terms(terms)
+    assert len(result) == 1
+
+
+def test_collect_terms_includes_transform():
+    terms = [Transform(Intercept(name="a"), func=ptx.exp)]
+    result = collect_terms(terms)
+    assert len(result) == 1
+
+
+def test_collect_coords(simple_ds):
+    """collect_coords merges coordinates from multiple term trees."""
+    mu = Intercept(name="mu") + Dot("x", prior=Prior("Normal", dims="feature"))
+    sigma = Transform(Intercept(name="sigma"), func=ptx.exp)
+    coords = collect_coords(mu, sigma, ds=simple_ds)
+    assert "feature" in coords
+
+
+def test_dot_dedup_data(simple_ds):
+    """Two Dot terms with same data_var share the pmd.Data."""
+    dot_a = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot_b = Dot("x", prior=Prior("Normal", dims="feature"))
+    terms = dot_a + dot_b
+    coords = get_coords(terms, simple_ds)
+    with pm.Model(coords=coords) as m:
+        register_data(terms, ds=simple_ds)
+        assert "x" in m
+
+
+def test_dot_duplicate_prior_name_errors(simple_ds):
+    """Same data_var AND same prior name clash on variable names."""
+    dot_a = Dot("x", prior=Prior("Normal", dims="feature"))
+    dot_b = Dot("x", prior=Prior("Normal", dims="feature"))
+    terms = dot_a + dot_b
+    coords = get_coords(terms, simple_ds)
+    with pm.Model(coords=coords) as m:
+        register_data(terms, ds=simple_ds)
+        with pytest.raises(ValueError, match="already exists"):
+            build_param(terms)
+
+
+def test_add_coords_dynamic(simple_ds):
+    """Custom term overrides add_coords to add model-internal coords."""
+
+    @dataclass
+    class _GroupTerm(ModelTerm):
+        data_source: str
+
+        def get_coords(self, ds):
+            return {k: v.values.tolist() for k, v in ds[self.data_source].coords.items()}
+
+        def add_coords(self, ds):
+            model = pm.modelcontext(None)
+            unique = list(dict.fromkeys(ds[self.data_source].values))
+            model.add_coords({self.data_source: unique})
+
+        def register_data(self, ds):
+            pmd.Data(f"{self.data_source}_idx", np.arange(len(ds["obs"])), dims="obs")
+
+    ds = xr.Dataset(
+        {"group": ("obs", ["a", "b", "a", "b", "c"] * 10), "y": ("obs", np.arange(50))},
+        coords={"obs": range(50)},
+    )
+    mu = _GroupTerm("group") + Intercept(name="mu")
+    coords = collect_coords(mu, ds=ds)
+    with pm.Model(coords=coords) as m:
+        register_data(mu, ds=ds)
+        assert "group" in m.coords
+
+
+def test_dot_set_data_renamed_dim(simple_ds):
+    """set_data with same shape but renamed coordinate labels."""
+    ds2 = simple_ds.copy()
+    ds2 = ds2.assign_coords(feature=["X", "Y", "Z"])
+
+    dot = Dot("x", prior=Prior("Normal", dims="feature"))
+    coords = get_coords(dot, simple_ds)
+    with pm.Model(coords=coords):
+        dot.register_data(simple_ds)
+        dot.set_data(ds2)
+
+
+def test_build_param_with_subtraction():
+    """Subtraction produces Sum with Product(-1, term)."""
+    terms = Intercept(name="a") - Intercept(name="b")
+    assert isinstance(terms, Sum)
+    assert isinstance(terms.terms[1], Product)
+    with pm.Model():
+        result = build_param(terms)
+        assert isinstance(result, PTVariable)
+
+
+def test_collect_terms_deep_nesting(simple_ds):
+    """collect_terms flattens deeply nested structures."""
+    terms = Product(
+        Intercept(name="a"),
+        Sum([Intercept(name="b"), Dot("x", prior=Prior("Normal", dims="feature"))]),
+    )
+    result = collect_terms([terms])
+    assert len(result) == 3
+
+
+def test_register_data_skips_literals(simple_ds):
+    """register_data ignores int/float terms in a Sum."""
+    terms = Sum([Intercept(name="a"), 5, 3.0])
+    coords = collect_coords(terms, ds=simple_ds)
+    with pm.Model(coords=coords):
+        register_data(terms, ds=simple_ds)  # should not raise
+
+
+def test_custom_term():
+    @dataclass
+    class _Custom(ModelTerm):
+        value: float = 1.0
+
+        def create_variable(self):
+            return pt.as_tensor_variable(self.value)
+
+    with pm.Model():
+        result = build_param(_Custom(42.0))
+        assert isinstance(result, PTVariable)

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -39,6 +39,7 @@ from pymc_extras.terms import (
     collect_terms,
     get_coords,
     register_data,
+    set_data,
 )
 
 
@@ -446,3 +447,93 @@ def test_custom_term():
     with pm.Model():
         result = build_param(_Custom(42.0))
         assert isinstance(result, PTVariable)
+
+
+def test_dot_default_name(simple_ds):
+    """Dot without `name` defaults to `{var_name}_beta` (unchanged behavior)."""
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    assert dot.name == "x_beta"
+
+
+def test_dot_distinct_name_no_collision(simple_ds):
+    """CLV: alpha/beta branches share data but need distinct coef names.
+
+    Two Dot terms referencing the same ``var_name`` with distinct ``name``
+    should build separate coefficient variables without colliding.
+    """
+    dot_a = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    dot_b = Dot(var_name="x", prior=Prior("Normal", dims="feature"), name="x_coef_b")
+    mu = dot_a + dot_b
+    coords = collect_coords(mu, ds=simple_ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=simple_ds)
+        build_param(mu)
+        assert "x_beta" in model.named_vars
+        assert "x_coef_b" in model.named_vars
+
+
+def test_collect_coords_subtraction(simple_ds):
+    """CLV gotcha: `baseline - dot(...)` coordinates must be collected.
+
+    Regression test for `Sum.get_coords` dropping Product children (the
+    Product(-1, Dot) produced by subtraction).
+    """
+    mu = Intercept(name="a") - Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    coords = collect_coords(mu, ds=simple_ds)
+    assert "feature" in coords
+
+
+def test_collect_coords_multiplication(simple_ds):
+    """CLV gotcha: `a + b * c` must collect coordinates from the Product child."""
+    mu = Intercept(name="a") + Dot(var_name="x", prior=Prior("Normal", dims="feature")) * Transform(
+        Intercept(name="scale"), func=ptx.exp
+    )
+    coords = collect_coords(mu, ds=simple_ds)
+    assert "feature" in coords
+
+
+def test_set_data_subtraction(simple_ds):
+    """CLV gotcha: `baseline - dot(...)` must still update the Dot's data on prediction.
+
+    Regression test for `Sum.set_data` dropping Product children, which would
+    silently leave the covariate `pmd.Data` stale during prediction.
+    """
+    mu = Intercept(name="a") - Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    coords = collect_coords(mu, ds=simple_ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=simple_ds)
+        build_param(mu)
+        ds2 = simple_ds.copy()
+        ds2["x"] = xr.DataArray(np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature"))
+        set_data(mu, ds=ds2, model=model)
+        updated = model["x"].get_value()
+    assert np.allclose(updated, ds2["x"].values)
+
+
+def test_set_data_multiplication(simple_ds):
+    """CLV gotcha: `a + b * c` must still update the Dot's data on prediction.
+
+    Mirror of `test_set_data_subtraction` for the `*` trigger (Product child
+    inside a Sum).
+    """
+    mu = Intercept(name="a") + Dot(var_name="x", prior=Prior("Normal", dims="feature")) * Transform(
+        Intercept(name="scale"), func=ptx.exp
+    )
+    coords = collect_coords(mu, ds=simple_ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=simple_ds)
+        build_param(mu)
+        ds2 = simple_ds.copy()
+        ds2["x"] = xr.DataArray(np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature"))
+        set_data(mu, ds=ds2, model=model)
+        updated = model["x"].get_value()
+    assert np.allclose(updated, ds2["x"].values)
+
+
+def test_register_data_subtraction(simple_ds):
+    """`register_data` of `a - b` must register the subtracted Dot's data."""
+    mu = Intercept(name="a") - Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    coords = collect_coords(mu, ds=simple_ds)
+    with pm.Model(coords=coords) as model:
+        register_data(mu, ds=simple_ds)
+        assert "x" in model

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -31,6 +31,7 @@ from pymc_extras.terms import (
     Dot,
     Intercept,
     ModelTerm,
+    Parameter,
     Product,
     Sum,
     Transform,
@@ -155,10 +156,18 @@ def test_intercept_create_variable():
 def test_dot_register_data(simple_ds):
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
-    with pm.Model(coords=coords):
+    with pm.Model(coords=coords) as model:
         dot.register_data(simple_ds)
         data = pm.modelcontext(None)["x"]
         assert data is not None
+        assert "feature" in model.coords
+
+
+def test_dot_get_coords(simple_ds):
+    dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
+    coords = dot.get_coords(simple_ds)
+    assert "feature" in coords
+    assert coords["feature"] == list("ABC")
 
 
 def test_dot_create_variable(simple_ds):
@@ -171,12 +180,14 @@ def test_dot_create_variable(simple_ds):
 
 
 def test_dot_set_data(simple_ds):
-    ds2 = simple_ds.copy()
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = dot.get_coords(simple_ds)
-    with pm.Model(coords=coords):
+    with pm.Model(coords=coords) as model:
         dot.register_data(simple_ds)
+        ds2 = simple_ds.copy()
+        ds2["x"] = xr.DataArray(np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature"))
         dot.set_data(ds2)
+        assert np.allclose(model["x"].get_value(), ds2["x"].values)
 
 
 def test_transform_create_variable():
@@ -198,11 +209,15 @@ def test_transform_with_dot(simple_ds):
 
 
 def test_transform_set_data(simple_ds):
-    inner = Intercept(name="sigma")
+    inner = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     transformed = Transform(inner, func=ptx.exp)
-    ds2 = simple_ds.copy()
-    with pm.Model():
-        transformed.set_data(ds2)
+    coords = transformed.get_coords(simple_ds)
+    with pm.Model(coords=coords) as model:
+        transformed.register_data(simple_ds)
+        ds2 = simple_ds.copy()
+        ds2["x"] = xr.DataArray(np.roll(simple_ds["x"].values, 1, axis=0), dims=("obs", "feature"))
+        transformed.set_data(ds=ds2, model=model)
+        assert np.allclose(model["x"].get_value(), ds2["x"].values)
 
 
 def test_build_param_int():
@@ -380,9 +395,10 @@ def test_dot_set_data_renamed_dim(simple_ds):
 
     dot = Dot(var_name="x", prior=Prior("Normal", dims="feature"))
     coords = get_coords(dot, simple_ds)
-    with pm.Model(coords=coords):
+    with pm.Model(coords=coords) as model:
         dot.register_data(simple_ds)
         dot.set_data(ds2)
+        assert np.allclose(model["x"].get_value(), ds2["x"].values)
 
 
 def test_build_param_with_subtraction():
@@ -409,8 +425,10 @@ def test_register_data_skips_literals(simple_ds):
     """register_data ignores int/float terms in a Sum."""
     terms = Sum([Intercept(name="a"), 5, 3.0])
     coords = collect_coords(terms, ds=simple_ds)
-    with pm.Model(coords=coords):
-        register_data(terms, ds=simple_ds)  # should not raise
+    with pm.Model(coords=coords) as model:
+        register_data(terms, ds=simple_ds)
+        # Literals are skipped; Intercept has no data to register
+        assert len(model.data_vars) == 0
 
 
 def test_product_rmul():
@@ -537,3 +555,79 @@ def test_register_data_subtraction(simple_ds):
     with pm.Model(coords=coords) as model:
         register_data(mu, ds=simple_ds)
         assert "x" in model
+
+
+@pytest.fixture
+def ds_with_dims():
+    """Dataset with an extra non-obs dimension for free-parameter dims."""
+    rng = np.random.default_rng(42)
+    return xr.Dataset(
+        {
+            "x": (("obs", "feature"), rng.normal(size=(20, 3))),
+            "y": ("obs", rng.normal(size=20)),
+        },
+        coords={
+            "obs": range(20),
+            "feature": list("ABC"),
+            "product": ["p1", "p2", "p3"],
+        },
+    )
+
+
+def test_parameter_requires_name():
+    """Parameter without a name raises TypeError."""
+    with pytest.raises(TypeError):
+        Parameter()
+
+
+def test_parameter_get_coords_with_dims(ds_with_dims):
+    """Parameter with prior.dims extracts matching coordinates."""
+    p = Parameter("alpha", prior=Prior("Normal", dims="product"))
+    coords = p.get_coords(ds_with_dims)
+    assert "product" in coords
+    assert coords["product"] == ["p1", "p2", "p3"]
+
+
+def test_parameter_get_coords_no_dims(ds_with_dims):
+    """Parameter without dims returns empty coords."""
+    p = Parameter("mu")
+    coords = p.get_coords(ds_with_dims)
+    assert coords == {}
+
+
+def test_parameter_get_coords_missing_dim():
+    """Parameter with dims not in ds returns empty coords."""
+    ds = xr.Dataset({"x": ("obs", [1, 2])}, coords={"obs": range(2)})
+    p = Parameter("alpha", prior=Prior("Normal", dims="nonexistent"))
+    coords = p.get_coords(ds)
+    assert coords == {}
+
+
+def test_intercept_get_coords_with_dims(ds_with_dims):
+    """Intercept (subclass of Parameter) also extracts prior.dims coords."""
+    p = Intercept("baseline", prior=Prior("Normal", dims="product"))
+    coords = p.get_coords(ds_with_dims)
+    assert "product" in coords
+    assert coords["product"] == ["p1", "p2", "p3"]
+
+
+def test_intercept_default_name():
+    """Intercept defaults name to 'intercept'."""
+    p = Intercept()
+    assert p.name == "intercept"
+
+
+def test_collect_coords_includes_parameter_dims(ds_with_dims):
+    """collect_coords picks up coords from a dimmed Parameter in a Sum."""
+    mu = Intercept("a") + Parameter("alpha", prior=Prior("Normal", dims="product"))
+    coords = collect_coords(mu, ds=ds_with_dims)
+    assert "product" in coords
+
+
+def test_parameter_create_variable():
+    """Parameter create_variable builds a named tensor."""
+    with pm.Model():
+        p = Parameter("alpha", prior=Prior("Normal", dims="product"))
+        with pm.Model(coords={"product": ["p1", "p2", "p3"]}):
+            v = p.create_variable()
+            assert v is not None

--- a/tests/test_terms.py
+++ b/tests/test_terms.py
@@ -412,6 +412,29 @@ def test_register_data_skips_literals(simple_ds):
         register_data(terms, ds=simple_ds)  # should not raise
 
 
+def test_product_rmul():
+    p = Product(Intercept(name="a"), 2.0)
+    result = 3 * p
+    assert isinstance(result, Product)
+
+
+def test_sum_rmul():
+    s = Sum([Intercept(name="a")])
+    result = 3 * s
+    assert isinstance(result, Product)
+
+
+def test_modelterm_set_data_default():
+    t = Intercept(name="x")
+    t.set_data(xr.Dataset(), model=None)  # should not raise
+
+
+def test_modelterm_add_coords_default():
+    t = Intercept(name="x")
+    with pm.Model():
+        t.add_coords(xr.Dataset())  # should not raise
+
+
 def test_custom_term():
     @dataclass
     class _Custom(ModelTerm):


### PR DESCRIPTION
## Summary

`pymc_extras.terms` is a **light, extendable protocol** for composing model terms with `+`, `*`, and `-` into predictors that materialize inside a `pm.Model` from an `xarray.Dataset`.

The goal is **not** to implement every way to specify a model. It's a small contract — subclass `ModelTerm`, implement five lifecycle methods, compose with built-ins — that lets you lump terms into expressions and lets the framework handle coords, `pmd.Data` registration, tensor construction, and prediction data updates. If a term is missing, you write it; that's the intended path.

This leans on `pytensor` / `pymc.dims` / `xtensor` rather than reinventing op-level subgraph machinery. The gap it fills is specifically PyMC's: coordinates with values, syncing data from an `xr.Dataset`, and reusable prediction-time `set_data`. Pure pytensor composition already exists; this layer is the glue between expressions and PyMC's model/dims/xarray stack.

## Built-ins

| Piece | Role |
|-------|------|
| `Parameter` | Named free RV (required `name`); dims via `prior.dims` |
| `Intercept` | Same as `Parameter`, default `name="intercept"` |
| `Dot` | `data @ coef`; optional `name` (default `{var_name}_beta`) |
| `Transform` | `func(inner)` (e.g. `ptx.math.exp`) |
| `Sum` / `Product` | Results of `+` / `*` |

Helpers: `collect_coords`, `register_data`, `build_param`, `set_data`, `collect_terms`. These **are** the API — no one-shot `materialize` helper that hides the lifecycle.

## Quick example

```python
import pymc.dims as pmd
import pytensor.xtensor as ptx
from pymc_extras.prior import Prior
from pymc_extras.terms import (
    Dot, 
    Intercept, 
    Parameter, 
    Transform, 
    build_param, 
    collect_coords, 
    register_data,
)

mu = Intercept(name="mu") + Dot(var_name="x", prior=Prior("Normal", dims="feature"))
sigma = Transform(Intercept(name="sigma"), func=ptx.math.exp)

coords = collect_coords(mu, sigma, ds=ds)
with pm.Model(coords=coords) as model:
    register_data(mu, ds=ds)
    register_data(sigma, ds=ds)
    pmd.Normal("y_obs", mu=build_param(mu), sigma=build_param(sigma), observed=ds["y"])
```

Dimensional free parameters and shared-data dual coefficients:

```python
mu = Parameter("baseline", prior=Prior("Normal", dims="product")) + Dot(var_name="x", name="alpha_coef", prior=Prior("Normal", dims="feature"))
# second branch on the same data matrix:
# Dot(var_name="x", name="beta_coef", prior=Prior("Normal", dims="feature"))
```

## Extending

Custom terms subclass `ModelTerm` and implement the five lifecycle methods (`get_coords`, `add_coords`, `register_data`, `create_variable`, `set_data`). They compose with built-ins the same way — no framework changes.

The module docstring **Extending** section includes a full custom gather / index recipe and shows it composed with `Parameter`, `Dot`, and `Transform`. That pattern is intentional: missing leaves stay in *your* package.

## Design notes

- **Light protocol, not a DSL** — compose with `+` / `*` / `-`; no meta-model language, no one-shot builder.
- **`Parameter` ≡ `Intercept`** — one free-param concept; Intercept is naming sugar for GLM familiarity.
- **`Dot.name`** — two coefficient vectors on one `pmd.Data` without clashes.
- **Composition correctness** — `Sum.get_coords` / `Sum.set_data` recurse into `Product` children so `a - b` and `a + b * c` collect coords and update data.
- **Tests** — composition, naming, dimmed `Parameter`/`Intercept`, dual `Dot` names; see `tests/test_terms.py`.

## Non-goals

- Not every way to specify a model — a light, extendable protocol, not a complete modeling DSL or full hierarchical framework.
- Not reinventing PyTensor ops / subgraph IR — lean on pytensor + `pymc.dims` + xtensor; this layer is coords + `xr.Dataset` data binding.
- No one-shot `materialize` helper — the lifecycle helpers are the API.
- No shipped gather/index term (example only in docs).
- No domain model wrappers (GLM / demand / etc. classes).
- No change to likelihood / sampling APIs.