### PR TITLE
Build post-estimation graphs with the fit's filter settings

### DIFF
--- a/pymc_extras/statespace/core/dummy_graph.py
+++ b/pymc_extras/statespace/core/dummy_graph.py
@@ -123,6 +123,8 @@ def kalman_filter_outputs_from_dummy_graph(
         R,
         H,
         Q,
+        missing_fill_value=ss_mod.missing_fill_value,
+        cov_jitter=ss_mod.cov_jitter,
         time_varying_names=ss_mod.ssm.time_varying_names,
     )
 
@@ -138,6 +140,7 @@ def kalman_filter_outputs_from_dummy_graph(
         Q,
         filtered_states,
         filtered_covariances,
+        cov_jitter=ss_mod.cov_jitter,
         time_varying_names=ss_mod.ssm.time_varying_names,
     )
 

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -505,6 +505,8 @@ def sample_filter_outputs(
             R,
             H,
             Q,
+            missing_fill_value=ss_mod.missing_fill_value,
+            cov_jitter=ss_mod.cov_jitter,
             time_varying_names=ss_mod.ssm.time_varying_names,
         )
 
@@ -514,6 +516,7 @@ def sample_filter_outputs(
             Q,
             filter_outputs[0],
             filter_outputs[3],
+            cov_jitter=ss_mod.cov_jitter,
             time_varying_names=ss_mod.ssm.time_varying_names,
         )
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -125,7 +125,7 @@ class PyMCStateSpace:
     missing_fill_value: float, optional
         Sentinel used to mask missing observations, so PyMC's imputation machinery is not triggered. Set this only
         if your data legitimately contains the default sentinel. Post-estimation graphs are built with this same
-        value. Default -9999.0.
+        value. Default None, which the filter resolves to -9999.0.
 
     Notes
     -----

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -50,6 +50,7 @@ from pymc_extras.statespace.filters.distributions import (
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_DIMS,
     JITTER_DEFAULT,
+    MISSING_FILL,
     OBS_STATE_DIM,
 )
 from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
@@ -125,7 +126,7 @@ class PyMCStateSpace:
     missing_fill_value: float, optional
         Sentinel used to mask missing observations, so PyMC's imputation machinery is not triggered. Set this only
         if your data legitimately contains the default sentinel. Post-estimation graphs are built with this same
-        value. Default None, which the filter resolves to -9999.0.
+        value. Default -9999.0.
 
     Notes
     -----
@@ -251,7 +252,7 @@ class PyMCStateSpace:
         measurement_error: bool = False,
         mode: str | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         self._fit_coords: dict[str, Sequence[str]] | None = None
         self._fit_dims: dict[str, Sequence[str]] | None = None

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -117,6 +117,16 @@ class PyMCStateSpace:
         Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
         to all sampling methods.
 
+    cov_jitter: float, optional
+        Value added to the diagonal of every covariance matrix at each filtering step, for numerical stability.
+        Post-estimation graphs -- ``forecast``, the conditional samplers, ``sample_filter_outputs`` -- are built
+        with this same value. Default 1e-8, or 1e-6 if ``pytensor.config.floatX`` is float32.
+
+    missing_fill_value: float, optional
+        Sentinel used to mask missing observations, so PyMC's imputation machinery is not triggered. Set this only
+        if your data legitimately contains the default sentinel. Post-estimation graphs are built with this same
+        value. Default -9999.0.
+
     Notes
     -----
     Based on the statsmodels statespace implementation https://github.com/statsmodels/statsmodels/blob/main/statsmodels/tsa/statespace/representation.py,
@@ -240,6 +250,8 @@ class PyMCStateSpace:
         verbose: bool = True,
         measurement_error: bool = False,
         mode: str | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         self._fit_coords: dict[str, Sequence[str]] | None = None
         self._fit_dims: dict[str, Sequence[str]] | None = None
@@ -256,6 +268,8 @@ class PyMCStateSpace:
         self.k_posdef = k_posdef
         self.measurement_error = measurement_error
         self.mode = mode
+        self.cov_jitter = cov_jitter
+        self.missing_fill_value = missing_fill_value
 
         self._populate_properties()
 
@@ -926,7 +940,7 @@ class PyMCStateSpace:
         data: np.ndarray | pd.DataFrame | pt.TensorVariable,
         register_data: bool = True,
         missing_fill_value: float | None = None,
-        cov_jitter: float | None = JITTER_DEFAULT,
+        cov_jitter: float | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
         save_kalman_filter_outputs_in_idata: bool = False,
         mode: str | None = None,
@@ -950,7 +964,7 @@ class PyMCStateSpace:
             The Pytensor mode used for the computation graph construction. If None, the default mode will be used.
             Other options include "JAX" and "NUMBA".
 
-        missing_fill_value: float, optional, default=-9999
+        missing_fill_value: float, optional
             A value to mask in missing values. NaN values in the data need to be filled with an arbitrary value to
             avoid triggering PyMC's automatic imputation machinery (missing values are instead filled by treating them
             as hidden states during Kalman filtering).
@@ -959,7 +973,10 @@ class PyMCStateSpace:
             you will need to change the missing_fill_value to something else, to avoid incorrectly mark in
             data as missing.
 
-        cov_jitter: float, default 1e-8 or 1e-6 if pytensor.config.floatX is float32
+            Overrides the value given to the model constructor, which is also what post-estimation graphs use.
+            Default None, meaning the constructor's value is kept.
+
+        cov_jitter: float, optional
             The Kalman filter is known to be numerically unstable, especially at half precision. This value is added to
             the diagonal of every covariance matrix -- predicted, filtered, and smoothed -- at every step, to ensure
             all matrices are strictly positive semi-definite.
@@ -971,6 +988,9 @@ class PyMCStateSpace:
                   error.
 
                 - The Univariate Filter is more robust than other filters, and can tolerate a lower jitter value
+
+            Overrides the value given to the model constructor, which is also what post-estimation graphs use.
+            Default None, meaning the constructor's value is kept.
 
         mvn_method: str, default "svd"
             Method used to invert the covariance matrix when calculating the pdf of a multivariate normal
@@ -1001,6 +1021,12 @@ class PyMCStateSpace:
             )
             self.mode = mode
 
+        # Recorded on the model so post-estimation graphs are filtered the same way the fit was.
+        if cov_jitter is not None:
+            self.cov_jitter = cov_jitter
+        if missing_fill_value is not None:
+            self.missing_fill_value = missing_fill_value
+
         pm_mod = modelcontext(None)
 
         self._insert_random_variables()
@@ -1015,7 +1041,7 @@ class PyMCStateSpace:
             n_obs=self.ssm.k_endog,
             obs_coords=obs_coords,
             register_data=register_data,
-            missing_fill_value=missing_fill_value,
+            missing_fill_value=self.missing_fill_value,
         )
 
         # Order is important here: only call _insert_data_shape_into_n_timesteps after data has been registered.
@@ -1024,8 +1050,8 @@ class PyMCStateSpace:
         filter_outputs = self.kalman_filter.build_graph(
             pt.as_tensor_variable(data),
             *self.unpack_statespace(),
-            missing_fill_value=missing_fill_value,
-            cov_jitter=cov_jitter,
+            missing_fill_value=self.missing_fill_value,
+            cov_jitter=self.cov_jitter,
             time_varying_names=self.ssm.time_varying_names,
         )
 
@@ -1104,7 +1130,7 @@ class PyMCStateSpace:
                 Q,
                 filtered_states,
                 filtered_covariances,
-                cov_jitter=cov_jitter,
+                cov_jitter=self.cov_jitter,
                 time_varying_names=self.ssm.time_varying_names,
             )
             smooth_states.name = "smooth_states"

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -20,6 +20,7 @@ from pymc_extras.statespace.utils.constants import (
     EXOG_STATE_DIM,
     FACTOR_DIM,
     JITTER_DEFAULT,
+    MISSING_FILL,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     TIME_DIM,
@@ -241,7 +242,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         measurement_error: bool = False,
         verbose: bool = True,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         """
         Create a Bayesian Dynamic Factor Model.
@@ -294,7 +295,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         missing_fill_value: float, optional
             Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
+            default sentinel. Post-estimation graphs are built with this same value. Default -9999.0.
         """
 
         validate_names(endog_names, var_name="endog_names", optional=False)

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -19,6 +19,7 @@ from pymc_extras.statespace.utils.constants import (
     ERROR_AR_PARAM_DIM,
     EXOG_STATE_DIM,
     FACTOR_DIM,
+    JITTER_DEFAULT,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     TIME_DIM,
@@ -239,6 +240,8 @@ class BayesianDynamicFactor(PyMCStateSpace):
         error_cov_type: str = "diagonal",
         measurement_error: bool = False,
         verbose: bool = True,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         """
         Create a Bayesian Dynamic Factor Model.
@@ -283,6 +286,15 @@ class BayesianDynamicFactor(PyMCStateSpace):
         verbose: bool, default True
             If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
 
+
+        cov_jitter: float, optional
+            Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
+            stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
+            ``pytensor.config.floatX`` is float32.
+
+        missing_fill_value: float, optional
+            Sentinel used to mask missing observations. Set this only if your data legitimately contains the
+            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
         """
 
         validate_names(endog_names, var_name="endog_names", optional=False)
@@ -335,6 +347,8 @@ class BayesianDynamicFactor(PyMCStateSpace):
             k_posdef=k_posdef,
             verbose=verbose,
             measurement_error=measurement_error,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )
 
     def set_parameters(self) -> Parameter | tuple[Parameter, ...] | None:

--- a/pymc_extras/statespace/models/ETS.py
+++ b/pymc_extras/statespace/models/ETS.py
@@ -20,6 +20,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     ETS_SEASONAL_DIM,
     JITTER_DEFAULT,
+    MISSING_FILL,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
 )
@@ -213,7 +214,7 @@ class BayesianETS(PyMCStateSpace):
 
     missing_fill_value: float, optional
         Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-        default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
+        default sentinel. Post-estimation graphs are built with this same value. Default -9999.0.
 
 
     References
@@ -238,7 +239,7 @@ class BayesianETS(PyMCStateSpace):
         verbose: bool = True,
         mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         if order is not None:
             if len(order) != 3 or any(not isinstance(o, str) for o in order):

--- a/pymc_extras/statespace/models/ETS.py
+++ b/pymc_extras/statespace/models/ETS.py
@@ -19,6 +19,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
     ALL_STATE_DIM,
     ETS_SEASONAL_DIM,
+    JITTER_DEFAULT,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
 )
@@ -205,6 +206,15 @@ class BayesianETS(PyMCStateSpace):
         Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
         to all sampling methods.
 
+    cov_jitter: float, optional
+        Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
+        stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
+        ``pytensor.config.floatX`` is float32.
+
+    missing_fill_value: float, optional
+        Sentinel used to mask missing observations. Set this only if your data legitimately contains the
+        default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
+
 
     References
     ----------
@@ -227,6 +237,8 @@ class BayesianETS(PyMCStateSpace):
         filter_type: str = "standard",
         verbose: bool = True,
         mode: str | Mode | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         if order is not None:
             if len(order) != 3 or any(not isinstance(o, str) for o in order):
@@ -293,6 +305,8 @@ class BayesianETS(PyMCStateSpace):
             verbose=verbose,
             measurement_error=measurement_error,
             mode=mode,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )
 
     def set_parameters(self) -> Parameter | tuple[Parameter, ...] | None:

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -26,6 +26,7 @@ from pymc_extras.statespace.utils.constants import (
     EXOG_STATE_DIM,
     JITTER_DEFAULT,
     MA_PARAM_DIM,
+    MISSING_FILL,
     SARIMAX_STATE_STRUCTURES,
     SEASONAL_AR_PARAM_DIM,
     SEASONAL_MA_PARAM_DIM,
@@ -145,7 +146,7 @@ class BayesianSARIMAX(PyMCStateSpace):
         verbose=True,
         mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         """
         Initialize a BayesianSARIMAX model.
@@ -217,7 +218,7 @@ class BayesianSARIMAX(PyMCStateSpace):
 
         missing_fill_value : float, optional
             Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
+            default sentinel. Post-estimation graphs are built with this same value. Default -9999.0.
         """
         # Model order
         self.p, self.d, self.q = order

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -24,6 +24,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     AR_PARAM_DIM,
     EXOG_STATE_DIM,
+    JITTER_DEFAULT,
     MA_PARAM_DIM,
     SARIMAX_STATE_STRUCTURES,
     SEASONAL_AR_PARAM_DIM,
@@ -143,6 +144,8 @@ class BayesianSARIMAX(PyMCStateSpace):
         measurement_error: bool = False,
         verbose=True,
         mode: str | Mode | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         """
         Initialize a BayesianSARIMAX model.
@@ -206,6 +209,15 @@ class BayesianSARIMAX(PyMCStateSpace):
 
             Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
             to all sampling methods.
+
+        cov_jitter : float, optional
+            Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
+            stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
+            ``pytensor.config.floatX`` is float32.
+
+        missing_fill_value : float, optional
+            Sentinel used to mask missing observations. Set this only if your data legitimately contains the
+            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
         """
         # Model order
         self.p, self.d, self.q = order
@@ -269,6 +281,8 @@ class BayesianSARIMAX(PyMCStateSpace):
             verbose=verbose,
             measurement_error=measurement_error,
             mode=mode,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )
         self._needs_exog_data = self.k_exog > 0
 

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -19,6 +19,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     AR_PARAM_DIM,
     EXOG_STATE_DIM,
+    JITTER_DEFAULT,
     MA_PARAM_DIM,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
@@ -109,6 +110,8 @@ class BayesianVARMAX(PyMCStateSpace):
         measurement_error: bool = False,
         verbose: bool = True,
         mode: str | Mode | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         """
         Create a Bayesian VARMAX model.
@@ -154,6 +157,15 @@ class BayesianVARMAX(PyMCStateSpace):
             Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
             to all sampling methods.
 
+
+        cov_jitter: float, optional
+            Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
+            stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
+            ``pytensor.config.floatX`` is float32.
+
+        missing_fill_value: float, optional
+            Sentinel used to mask missing observations. Set this only if your data legitimately contains the
+            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
         """
 
         validate_names(endog_names, var_name="endog_names", optional=False)
@@ -202,6 +214,8 @@ class BayesianVARMAX(PyMCStateSpace):
             verbose=verbose,
             measurement_error=measurement_error,
             mode=mode,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )
 
         self._needs_exog_data = needs_exog_data

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -21,6 +21,7 @@ from pymc_extras.statespace.utils.constants import (
     EXOG_STATE_DIM,
     JITTER_DEFAULT,
     MA_PARAM_DIM,
+    MISSING_FILL,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     SHOCK_AUX_DIM,
@@ -111,7 +112,7 @@ class BayesianVARMAX(PyMCStateSpace):
         verbose: bool = True,
         mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         """
         Create a Bayesian VARMAX model.
@@ -165,7 +166,7 @@ class BayesianVARMAX(PyMCStateSpace):
 
         missing_fill_value: float, optional
             Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-            default sentinel. Post-estimation graphs are built with this same value. Default None, which the filter resolves to -9999.0.
+            default sentinel. Post-estimation graphs are built with this same value. Default -9999.0.
         """
 
         validate_names(endog_names, var_name="endog_names", optional=False)

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -173,9 +173,10 @@ class StructuralTimeSeries(PyMCStateSpace):
             PyTensor compilation mode.
         cov_jitter : float, optional
             Jitter added to covariance diagonals at each filtering step. Post-estimation graphs use the same
-            value. Default ``JITTER_DEFAULT``.
+            value. Default 1e-8, or 1e-6 if ``pytensor.config.floatX`` is float32.
         missing_fill_value : float, optional
-            Sentinel used to mask missing observations. Post-estimation graphs use the same value. Default None.
+            Sentinel used to mask missing observations. Post-estimation graphs use the same value.
+            Default None, which the filter resolves to -9999.0.
         """
         self._name = name or "StructuralTimeSeries"
         self.measurement_error = measurement_error
@@ -1008,11 +1009,13 @@ class Component:
 
         cov_jitter: float, optional
             Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
-            stability. Post-estimation graphs are built with this same value. Default ``JITTER_DEFAULT``.
+            stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
+            ``pytensor.config.floatX`` is float32.
 
         missing_fill_value: float, optional
             Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-            default sentinel. Post-estimation graphs are built with this same value. Default None.
+            default sentinel. Post-estimation graphs are built with this same value. Default None, which the
+            filter resolves to -9999.0.
 
         Returns
         -------

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -40,6 +40,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     JITTER_DEFAULT,
     LONG_MATRIX_NAMES,
+    MISSING_FILL,
 )
 
 _log = logging.getLogger(__name__)
@@ -134,7 +135,7 @@ class StructuralTimeSeries(PyMCStateSpace):
         filter_type: str = "standard",
         mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         """
         Initialize a StructuralTimeSeries model.
@@ -176,7 +177,7 @@ class StructuralTimeSeries(PyMCStateSpace):
             value. Default 1e-8, or 1e-6 if ``pytensor.config.floatX`` is float32.
         missing_fill_value : float, optional
             Sentinel used to mask missing observations. Post-estimation graphs use the same value.
-            Default None, which the filter resolves to -9999.0.
+            Default -9999.0.
         """
         self._name = name or "StructuralTimeSeries"
         self.measurement_error = measurement_error
@@ -983,7 +984,7 @@ class Component:
         verbose=True,
         mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
-        missing_fill_value: float | None = None,
+        missing_fill_value: float = MISSING_FILL,
     ):
         """
         Build a StructuralTimeSeries statespace model from the current component(s)

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -38,6 +38,7 @@ from pymc_extras.statespace.models.utilities import (
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
     ALL_STATE_DIM,
+    JITTER_DEFAULT,
     LONG_MATRIX_NAMES,
 )
 
@@ -132,6 +133,8 @@ class StructuralTimeSeries(PyMCStateSpace):
         verbose: bool = True,
         filter_type: str = "standard",
         mode: str | Mode | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         """
         Initialize a StructuralTimeSeries model.
@@ -168,6 +171,11 @@ class StructuralTimeSeries(PyMCStateSpace):
             Type of Kalman filter to use.
         mode : str | Mode | None, default None
             PyTensor compilation mode.
+        cov_jitter : float, optional
+            Jitter added to covariance diagonals at each filtering step. Post-estimation graphs use the same
+            value. Default ``JITTER_DEFAULT``.
+        missing_fill_value : float, optional
+            Sentinel used to mask missing observations. Post-estimation graphs use the same value. Default None.
         """
         self._name = name or "StructuralTimeSeries"
         self.measurement_error = measurement_error
@@ -186,6 +194,8 @@ class StructuralTimeSeries(PyMCStateSpace):
             verbose=verbose,
             measurement_error=measurement_error,
             mode=mode,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )
 
         self._tensor_variable_info = tensor_variable_info
@@ -966,7 +976,13 @@ class Component:
         return new_comp
 
     def build(
-        self, name=None, filter_type="standard", verbose=True, mode: str | Mode | None = None
+        self,
+        name=None,
+        filter_type="standard",
+        verbose=True,
+        mode: str | Mode | None = None,
+        cov_jitter: float = JITTER_DEFAULT,
+        missing_fill_value: float | None = None,
     ):
         """
         Build a StructuralTimeSeries statespace model from the current component(s)
@@ -990,6 +1006,14 @@ class Component:
             Regardless of whether a mode is specified, it can always be overwritten via the ``compile_kwargs`` argument
             to all sampling methods.
 
+        cov_jitter: float, optional
+            Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
+            stability. Post-estimation graphs are built with this same value. Default ``JITTER_DEFAULT``.
+
+        missing_fill_value: float, optional
+            Sentinel used to mask missing observations. Set this only if your data legitimately contains the
+            default sentinel. Post-estimation graphs are built with this same value. Default None.
+
         Returns
         -------
         PyMCStateSpace
@@ -1012,4 +1036,6 @@ class Component:
             filter_type=filter_type,
             verbose=verbose,
             mode=mode,
+            cov_jitter=cov_jitter,
+            missing_fill_value=missing_fill_value,
         )

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -11,7 +11,7 @@ from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
 from pymc_extras.statespace.models import structural as st
 from pymc_extras.statespace.models.DFM import BayesianDynamicFactor
-from pymc_extras.statespace.utils.constants import MISSING_FILL
+from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, MISSING_FILL
 from tests.statespace.shared_fixtures import (
     rng,
 )
@@ -151,6 +151,14 @@ def test_missing_fill_value_reaches_post_estimation_graphs(rng):
     filtered_level = conditional["filtered_prior"].values[..., -1, 0]
 
     assert_allclose(filtered_level, MISSING_FILL, rtol=1e-4)
+
+
+def test_filter_config_defaults_to_the_documented_values():
+    """The constructor defaults are the values themselves, not a sentinel resolved further down."""
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)
+
+    assert ss_mod.cov_jitter == JITTER_DEFAULT
+    assert ss_mod.missing_fill_value == MISSING_FILL
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -9,6 +9,7 @@ from pymc.exceptions import ImputationWarning
 
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
 from pymc_extras.statespace.models import structural as st
+from pymc_extras.statespace.utils.constants import MISSING_FILL
 from tests.statespace.shared_fixtures import (
     rng,
 )
@@ -122,3 +123,48 @@ def test_param_dims_coords(ss_mod_multi_component):
             assert i == len(ss_mod_multi_component.coords[s]), (
                 f"Mismatch between shape {i} and dimension {s}"
             )
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_missing_fill_value_reaches_post_estimation_graphs(rng):
+    """Post-estimation graphs must mask missing values with the sentinel the fit used.
+
+    Every observation here is the library's default sentinel but is declared real, via a custom
+    ``missing_fill_value``. A post-estimation graph that fell back to the default would treat the whole
+    series as missing and return the prior rather than states tracking the data.
+    """
+    data = np.full((20, 1), MISSING_FILL, dtype=floatX)
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(
+        verbose=False, missing_fill_value=-1234.0
+    )
+
+    with pm.Model(coords=ss_mod.coords):
+        pm.Normal("initial_trend", mu=0.0, sigma=1.0, shape=(1,))
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX))
+        pm.Exponential("sigma_trend", 1, shape=(1,))
+        ss_mod.build_statespace_graph(data=data)
+        idata = pm.sample_prior_predictive(draws=5, random_seed=rng)
+
+    conditional = ss_mod.sample_conditional_prior(idata, random_seed=rng)
+    filtered_level = conditional["filtered_prior"].values[..., -1, 0]
+
+    assert_allclose(filtered_level, MISSING_FILL, rtol=1e-4)
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_filter_config_is_set_on_the_model_and_overridable_at_build():
+    """Filter settings live on the model; a build-time argument overrides them."""
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(
+        verbose=False, cov_jitter=1e-4, missing_fill_value=-1234.0
+    )
+    assert ss_mod.cov_jitter == 1e-4
+    assert ss_mod.missing_fill_value == -1234.0
+
+    with pm.Model(coords=ss_mod.coords):
+        pm.Normal("initial_trend", shape=(1,))
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX))
+        pm.Exponential("sigma_trend", 1, shape=(1,))
+        ss_mod.build_statespace_graph(data=np.zeros((20, 1), dtype=floatX), cov_jitter=1e-2)
+
+    assert ss_mod.cov_jitter == 1e-2
+    assert ss_mod.missing_fill_value == -1234.0

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -7,8 +7,10 @@ import pytest
 from numpy.testing import assert_allclose
 from pymc.exceptions import ImputationWarning
 
+from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
 from pymc_extras.statespace.models import structural as st
+from pymc_extras.statespace.models.DFM import BayesianDynamicFactor
 from pymc_extras.statespace.utils.constants import MISSING_FILL
 from tests.statespace.shared_fixtures import (
     rng,
@@ -152,13 +154,11 @@ def test_missing_fill_value_reaches_post_estimation_graphs(rng):
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
-def test_filter_config_is_set_on_the_model_and_overridable_at_build():
-    """Filter settings live on the model; a build-time argument overrides them."""
+def test_filter_config_is_overridable_at_build():
+    """A build-time argument overrides the model's filter settings; others are left alone."""
     ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(
         verbose=False, cov_jitter=1e-4, missing_fill_value=-1234.0
     )
-    assert ss_mod.cov_jitter == 1e-4
-    assert ss_mod.missing_fill_value == -1234.0
 
     with pm.Model(coords=ss_mod.coords):
         pm.Normal("initial_trend", shape=(1,))
@@ -168,3 +168,36 @@ def test_filter_config_is_set_on_the_model_and_overridable_at_build():
 
     assert ss_mod.cov_jitter == 1e-2
     assert ss_mod.missing_fill_value == -1234.0
+
+
+@pytest.mark.parametrize(
+    "make_model",
+    [
+        pytest.param(
+            lambda **kw: BayesianSARIMAX(order=(1, 0, 1), stationary_initialization=True, **kw),
+            id="SARIMAX",
+        ),
+        pytest.param(
+            lambda **kw: BayesianVARMAX(order=(1, 0), endog_names=["a", "b"], **kw), id="VARMAX"
+        ),
+        pytest.param(
+            lambda **kw: BayesianETS(order=("A", "N", "N"), endog_names=["a"], **kw), id="ETS"
+        ),
+        pytest.param(
+            lambda **kw: BayesianDynamicFactor(
+                k_factors=1, factor_order=1, endog_names=["a", "b"], **kw
+            ),
+            id="DFM",
+        ),
+        pytest.param(
+            lambda **kw: st.LevelTrend(name="trend", order=1, innovations_order=1).build(**kw),
+            id="structural",
+        ),
+    ],
+)
+def test_shipped_models_accept_filter_config(make_model):
+    """Every shipped model exposes the filter settings its post-estimation graphs will use."""
+    ss_mod = make_model(verbose=False, cov_jitter=1e-3, missing_fill_value=-777.0)
+
+    assert ss_mod.cov_jitter == 1e-3
+    assert ss_mod.missing_fill_value == -777.0


### PR DESCRIPTION
`forecast`, the conditional samplers and `sample_filter_outputs` built their Kalman graphs with the library defaults for `cov_jitter` and `missing_fill_value` instead of whatever the fit used, so a model with a custom `missing_fill_value` treated real observations as missing. Both are now model-level settings that every shipped model accepts in its constructor; the `build_statespace_graph` arguments still work and override.
