### PR TITLE
Clean up dead statespace attributes and fix Representation copy aliasing

### DIFF
--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -306,5 +306,13 @@ class PytensorRepresentation:
 
         raise IndexError("First index must the name of a valid state space matrix.")
 
+    def __copy__(self) -> "PytensorRepresentation":
+        new = self.__class__.__new__(self.__class__)
+        for slot in self.__slots__:
+            setattr(new, slot, getattr(self, slot))
+        new._time_varying_names = set(self._time_varying_names)
+        return new
+
     def copy(self) -> "PytensorRepresentation":
+        """Return a copy sharing this object's matrix graphs but owning its time-varying names."""
         return copy.copy(self)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -50,11 +50,7 @@ from pymc_extras.statespace.filters.distributions import (
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_DIMS,
     JITTER_DEFAULT,
-    MATRIX_DIMS,
-    MATRIX_NAMES,
     OBS_STATE_DIM,
-    SHORT_NAME_TO_LONG,
-    TIME_DIM,
 )
 from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
 
@@ -749,43 +745,6 @@ class PyMCStateSpace:
         """
         raise NotImplementedError("The make_symbolic_statespace method has not been implemented!")
 
-    def _get_matrix_shape_and_dims(self, name: str) -> tuple[tuple[int] | None, tuple[str] | None]:
-        """
-        Get the shape and dimensions of a matrix associated with the specified name.
-
-        This method retrieves the shape and dimensions of a matrix associated with the given name. Importantly,
-        it will only find named dimension if they are the "default" dimension names defined in the
-        statespace.utils.constant.py file.
-
-        Parameters
-        ----------
-        name : str
-            The name of the matrix whose shape and dimensions need to be retrieved.
-
-        Returns
-        -------
-        shape: tuple or None
-            If no named dimension are found, the shape of the requested matrix, otherwise None.
-
-        dims: tuple or None
-            If named dimensions are found, a tuple of strings, otherwise None
-        """
-
-        pm_mod = modelcontext(None)
-        dims = MATRIX_DIMS.get(name, None)
-        dims = dims if all([dim in pm_mod.coords.keys() for dim in dims]) else None
-        data_len = len(self._fit_data)
-
-        if name in self.kalman_filter.seq_names:
-            shape = (data_len, *self.ssm[SHORT_NAME_TO_LONG[name]].type.shape)
-            dims = (TIME_DIM, *dims)
-        else:
-            shape = self.ssm[SHORT_NAME_TO_LONG[name]].type.shape
-
-        shape = shape if dims is None else None
-
-        return shape, dims
-
     def _save_exogenous_data_info(self):
         """
         Store exogenous data required by posterior sampling functions
@@ -935,37 +894,6 @@ class PyMCStateSpace:
 
         replacement_dict = {var: step for var in n_timestep_variables}
         return graph_replace(matrices, replace=replacement_dict, strict=False)
-
-    def _register_matrices_with_pymc_model(self) -> list[pt.TensorVariable]:
-        """
-        Add all statespace matrices to the PyMC model currently on the context stack as pm.Deterministic nodes, and
-        adds named dimensions if they are found.
-
-        Returns
-        -------
-        registered_matrices: list of pt.TensorVariable
-            list of statespace matrices, wrapped in pm.Deterministic
-        """
-
-        pm_mod = modelcontext(None)
-        matrices = self.unpack_statespace()
-        time_varying_names = self.ssm.time_varying_names
-
-        registered_matrices = []
-        for i, (matrix, name) in enumerate(zip(matrices, MATRIX_NAMES)):
-            if not getattr(pm_mod, name, None):
-                shape, dims = self._get_matrix_shape_and_dims(name)
-                has_dims = dims is not None
-
-                if SHORT_NAME_TO_LONG[name] in time_varying_names and has_dims:
-                    dims = (TIME_DIM, *dims)
-
-                x = pm.Deterministic(name, matrix, dims=dims)
-                registered_matrices.append(x)
-            else:
-                registered_matrices.append(matrices[i])
-
-        return registered_matrices
 
     @staticmethod
     def _register_kalman_filter_outputs_with_pymc_model(outputs: tuple[pt.TensorVariable]) -> None:

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -59,7 +59,6 @@ class BaseFilter(ABC):
         self.non_seq_names: list[str] = []
 
         self.n_states = None
-        self.n_posdef = None
         self.n_endog = None
 
         self.missing_fill_value: float | None = None
@@ -203,7 +202,7 @@ class BaseFilter(ABC):
         [R_shape] = constant_fold([R.shape], raise_not_constant=False)
         [Z_shape] = constant_fold([Z.shape], raise_not_constant=False)
 
-        self.n_states, self.n_shocks = R_shape[-2:]
+        self.n_states = R_shape[-2]
         self.n_endog = Z_shape[-2]
 
         data, a0, P0, *params = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)

--- a/tests/statespace/core/test_representation.py
+++ b/tests/statespace/core/test_representation.py
@@ -1,3 +1,4 @@
+import copy
 import unittest
 
 import numpy as np
@@ -165,6 +166,21 @@ class BasicFunctionality(unittest.TestCase):
             ssm["transition"] = T
         msg = str(e.exception)
         self.assertEqual(msg, "Trailing dims of transition are (10, 10), expected (5, 5)")
+
+    def test_copy_does_not_alias_time_varying_names(self):
+        for make_copy in (PytensorRepresentation.copy, copy.copy):
+            with self.subTest(make_copy=make_copy.__qualname__):
+                ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
+                copied = make_copy(ssm)
+
+                copied.declare_time_varying("design")
+
+                self.assertNotIn("design", ssm.time_varying_names)
+                self.assertIn("design", copied.time_varying_names)
+
+                # Everything else is still shared, which is what makes this a shallow copy.
+                self.assertIs(copied.transition, ssm.transition)
+                self.assertEqual(copied.k_states, ssm.k_states)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`PytensorRepresentation.copy()` was `copy.copy` on a `__slots__` object, so a copy shared the original's mutable `_time_varying_names` set — declaring a matrix time-varying on the copy did it on the original too. Latent today since the one caller never declares after copying, but it's a trap.

Everything else is deletion: four methods with no callers anywhere in the package, the tests, the example notebooks, or gEconpy, plus two `BaseFilter` attributes that were written and never read.
