### PR TITLE
Fix DFM state metadata and error covariance construction

### DIFF
--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -557,11 +557,13 @@ class BayesianDynamicFactor(PyMCStateSpace):
         names = [
             f"L{lag}.factor_{i}"
             for lag in range(max(self.factor_order, 1))
-            for i in range(self.k_factors)
+            for i in range(1, self.k_factors + 1)
         ]
 
         names.extend(
-            f"L{lag}.error_{i}" for lag in range(self.error_order) for i in range(self.k_endog)
+            f"L{lag}.error_{i}"
+            for lag in range(self.error_order)
+            for i in range(1, self.k_endog + 1)
         )
 
         if self.has_exog:
@@ -582,20 +584,22 @@ class BayesianDynamicFactor(PyMCStateSpace):
         return *hidden_states, *observed_states
 
     def set_shocks(self) -> Shock | tuple[Shock, ...] | None:
-        shock_names = [f"factor_shock_{i}" for i in range(self.k_factors)]
+        shock_names = [f"factor_shock_{i}" for i in range(1, self.k_factors + 1)]
 
         if self.error_order > 0:
-            shock_names.extend(f"error_shock_{i}" for i in range(self.k_endog))
+            shock_names.extend(f"error_shock_{i}" for i in range(1, self.k_endog + 1))
 
         if self.has_exog:
+            # Each exogenous shock drives one coefficient state, so it carries that state's name.
             if self.shared_exog_states:
-                shock_names.extend(f"exog_shock_{i}.shared" for i in range(self.k_exog))
-            else:
-                # Ordered to match the exogenous states in set_states, which are endog-major.
                 shock_names.extend(
-                    f"exog_shock_{i}.endog_{j}"
-                    for j in range(self.k_endog)
-                    for i in range(self.k_exog)
+                    f"exog_shock_{exog_name}[shared]" for exog_name in self.exog_state_names
+                )
+            else:
+                shock_names.extend(
+                    f"exog_shock_{exog_name}[{endog_name}]"
+                    for endog_name in self.endog_names
+                    for exog_name in self.exog_state_names
                 )
 
         return tuple(Shock(name=name) for name in shock_names)

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -18,10 +18,12 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     AR_PARAM_DIM,
     ERROR_AR_PARAM_DIM,
+    EXOG_COEF_STATE_DIM,
     EXOG_STATE_DIM,
     FACTOR_DIM,
     JITTER_DEFAULT,
     MISSING_FILL,
+    NON_EXOG_STATE_DIM,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     TIME_DIM,
@@ -433,8 +435,8 @@ class BayesianDynamicFactor(PyMCStateSpace):
         parameters.append(
             Parameter(
                 name="x0",
-                shape=(k_states,),
-                dims=(ALL_STATE_DIM,),
+                shape=(k_states - self.k_exog_states,),
+                dims=(NON_EXOG_STATE_DIM if self.exog_flag else ALL_STATE_DIM,),
                 constraints=None,
             )
         )
@@ -532,7 +534,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 Parameter(
                     name="beta",
                     shape=(self.k_exog_states,),
-                    dims=(EXOG_STATE_DIM,),
+                    dims=(EXOG_COEF_STATE_DIM,),
                     constraints=None,
                 )
             )
@@ -543,7 +545,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
                     Parameter(
                         name="beta_sigma",
                         shape=(self.k_exog_states,),
-                        dims=(EXOG_STATE_DIM,),
+                        dims=(EXOG_COEF_STATE_DIM,),
                         constraints="Positive",
                     )
                 )
@@ -637,8 +639,14 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         # Exogenous coords
         if self.exog_flag:
-            exog_labels = tuple(range(1, self.k_exog_states + 1))
-            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=exog_labels))
+            k_non_exog_states = self.k_states - self.k_exog_states
+            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=tuple(self.exog_names)))
+            coords.append(
+                Coord(dimension=EXOG_COEF_STATE_DIM, labels=self.state_names[k_non_exog_states:])
+            )
+            coords.append(
+                Coord(dimension=NON_EXOG_STATE_DIM, labels=self.state_names[:k_non_exog_states])
+            )
 
         return tuple(coords)
 

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -386,47 +386,30 @@ class BayesianDynamicFactor(PyMCStateSpace):
         """
 
         validate_names(endog_names, var_name="endog_names", optional=False)
-        k_endog = len(endog_names)
+        validate_names(exog_state_names, var_name="exog_state_names", optional=True)
+
         self.endog_names = tuple(endog_names)
-        self.k_endog = k_endog
+        self.exog_state_names = tuple(exog_state_names) if exog_state_names is not None else ()
+
+        self.k_endog = k_endog = len(self.endog_names)
+        self.k_exog = len(self.exog_state_names)
+        self.has_exog = self.k_exog > 0
+
         self.k_factors = k_factors
         self.factor_order = factor_order
         self.error_order = error_order
         self.error_var = error_var
         self.error_cov_type = error_cov_type
+        self.shared_exog_states = shared_exog_states
+        self.exog_innovations = exog_innovations
 
-        if exog_state_names is not None:
-            self.shared_exog_states = shared_exog_states
-            self.exog_innovations = exog_innovations
-            validate_names(
-                exog_state_names, var_name="exog_state_names", optional=True
-            )  # Not sure if this adds anything
-            k_exog = len(exog_state_names)
-            self.k_exog = k_exog
-            self.exog_state_names = exog_state_names
-        else:
-            self.k_exog = 0
+        self.k_exog_states = self.k_exog if shared_exog_states else self.k_exog * k_endog
 
-        self.k_exog_states = self.k_exog * self.k_endog if not shared_exog_states else self.k_exog
-        self.exog_flag = self.k_exog > 0
+        # A factor_order of 0 still gets one state per factor, it just has no dynamics.
+        k_factor_states = max(factor_order, 1) * k_factors
+        k_error_states = k_endog * error_order
 
-        # Determine the dimension for the latent factor states.
-        # For static factors, one use k_factors.
-        # For dynamic factors with lags, the state include current factors and past lags.
-        # If factor_order is 0, we treat the factor as static (no dynamics),
-        # but it is still included in the state vector with one state per factor. Factor_ar paramter will not exist in this case.
-        k_factor_states = max(self.factor_order, 1) * k_factors
-
-        # Determine the dimension for the error component.
-        # If error_order > 0 then we add additional states for error dynamics, otherwise white noise error.
-        k_error_states = k_endog * error_order if error_order > 0 else 0
-
-        # Total state dimension
         k_states = k_factor_states + k_error_states + self.k_exog_states
-
-        # Number of independent shocks.
-        # Typically, the latent factors introduce k_factors shocks.
-        # If error_order > 0 and errors are modeled jointly or separately, add appropriate count.
         k_posdef = k_factors + (k_endog if error_order > 0 else 0) + self.k_exog_states
 
         super().__init__(
@@ -452,7 +435,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             Parameter(
                 name="x0",
                 shape=(k_states - self.k_exog_states,),
-                dims=(NON_EXOG_STATE_DIM if self.exog_flag else ALL_STATE_DIM,),
+                dims=(NON_EXOG_STATE_DIM if self.has_exog else ALL_STATE_DIM,),
                 constraints=None,
             )
         )
@@ -545,7 +528,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             )
 
         # beta - only if exog_flag
-        if self.exog_flag:
+        if self.has_exog:
             parameters.append(
                 Parameter(
                     name="beta",
@@ -581,7 +564,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             f"L{lag}.error_{i}" for lag in range(self.error_order) for i in range(self.k_endog)
         )
 
-        if self.exog_flag:
+        if self.has_exog:
             if self.shared_exog_states:
                 names.extend([f"beta_{exog_name}[shared]" for exog_name in self.exog_state_names])
             else:
@@ -604,7 +587,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         if self.error_order > 0:
             shock_names.extend(f"error_shock_{i}" for i in range(self.k_endog))
 
-        if self.exog_flag:
+        if self.has_exog:
             if self.shared_exog_states:
                 shock_names.extend(f"exog_shock_{i}.shared" for i in range(self.k_exog))
             else:
@@ -620,7 +603,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
     def set_data_info(self) -> Data | tuple[Data, ...] | None:
         data = []
 
-        if self.exog_flag:
+        if self.has_exog:
             data.append(
                 Data(
                     name="exog_data",
@@ -654,9 +637,9 @@ class BayesianDynamicFactor(PyMCStateSpace):
             coords.append(Coord(dimension=ERROR_AR_PARAM_DIM, labels=error_ar_labels))
 
         # Exogenous coords
-        if self.exog_flag:
+        if self.has_exog:
             k_non_exog_states = self.k_states - self.k_exog_states
-            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=tuple(self.exog_state_names)))
+            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=self.exog_state_names))
             coords.append(
                 Coord(dimension=EXOG_COEF_STATE_DIM, labels=self.state_names[k_non_exog_states:])
             )
@@ -667,7 +650,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         return tuple(coords)
 
     def make_symbolic_graph(self):
-        if self.exog_flag:
+        if self.has_exog:
             # Regression coefficients are states, so their prior is the tail of the initial state.
             initial_factor_states = self.make_and_register_variable(
                 "x0", shape=(self.k_states - self.k_exog_states,), dtype=floatX
@@ -687,7 +670,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         self.ssm["initial_state_cov", :, :] = P0
 
         self.ssm["design"] = self._build_design_matrix()
-        if self.exog_flag:
+        if self.has_exog:
             self.ssm.declare_time_varying("design")
 
         self.ssm["transition", :, :] = pt.linalg.block_diag(*self._build_transition_blocks())
@@ -731,7 +714,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             design_matrix = pt.concatenate(matrix_parts, axis=1)
         design_matrix.name = "design"
 
-        if not self.exog_flag:
+        if not self.has_exog:
             return design_matrix
 
         exog_data = self.make_and_register_data("exog_data", shape=(None, self.k_exog))
@@ -790,7 +773,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         # Exogenous coefficients are constant, or a random walk when exog_innovations is set. Either
         # way the transition is the identity; only the shock loading differs.
-        if self.exog_flag:
+        if self.has_exog:
             blocks.append(pt.eye(self.k_exog_states, dtype=floatX))
 
         return blocks
@@ -806,7 +789,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 col = self.k_factors + i
                 self.ssm["selection", row, col] = 1.0
 
-        if self.exog_flag and self.exog_innovations:
+        if self.has_exog and self.exog_innovations:
             col_start = self.k_factors + (self.k_endog if self.error_order > 0 else 0)
             self.ssm[
                 "selection",
@@ -822,7 +805,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         if self.error_order > 0:
             blocks.append(error_cov)
 
-        if self.exog_flag:
+        if self.has_exog:
             if self.exog_innovations:
                 beta_sigma = self.make_and_register_variable(
                     "beta_sigma", shape=(self.k_exog_states,), dtype=floatX

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 
+import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
@@ -27,6 +28,76 @@ from pymc_extras.statespace.utils.constants import (
 )
 
 floatX = pytensor.config.floatX
+
+
+def _make_var_companion_matrix(ar_coeffs, k_series: int, p: int):
+    r"""
+    Build the VAR(p) companion matrix for a block of jointly modeled series.
+
+    Parameters
+    ----------
+    ar_coeffs : TensorVariable
+        Autoregressive coefficients of shape ``(k_series, p * k_series)``, the horizontal
+        concatenation :math:`[A_1 | A_2 | \cdots | A_p]`.
+    k_series : int
+        Number of series in the block.
+    p : int
+        Lag order.
+
+    Returns
+    -------
+    companion : TensorVariable
+        Companion matrix of shape ``(k_series * p, k_series * p)``, ordered lag-major so the first
+        ``k_series`` rows are the current values of each series.
+    """
+    size = k_series * p
+    companion = pt.zeros((size, size), dtype=floatX)
+    companion = companion[:k_series].set(ar_coeffs)
+
+    if p > 1:
+        companion = companion[k_series:, : k_series * (p - 1)].set(
+            pt.eye(k_series * (p - 1), dtype=floatX)
+        )
+
+    return companion
+
+
+def _make_independent_ar_companion_matrix(ar_coeffs, k_series: int, p: int):
+    r"""
+    Build the companion matrix for ``k_series`` independent AR(p) processes.
+
+    Each series evolves on its own coefficients with no cross-series terms, but the states are
+    interleaved lag-major, matching :func:`_make_var_companion_matrix`.
+
+    Parameters
+    ----------
+    ar_coeffs : TensorVariable
+        Autoregressive coefficients of shape ``(k_series, p)``, one row per series.
+    k_series : int
+        Number of independent series.
+    p : int
+        Lag order.
+
+    Returns
+    -------
+    companion : TensorVariable
+        Companion matrix of shape ``(k_series * p, k_series * p)``.
+    """
+    size = k_series * p
+    companion = pt.zeros((size, size), dtype=floatX)
+
+    # Row j of the first block row carries series j's own coefficients, each placed in the column
+    # holding that lag's copy of series j. Flattened lag-major, those are ar_coeffs.T.ravel().
+    rows = np.tile(np.arange(k_series), p)
+    cols = np.arange(size)
+    companion = companion[rows, cols].set(ar_coeffs.T.ravel())
+
+    if p > 1:
+        companion = companion[k_series:, : k_series * (p - 1)].set(
+            pt.eye(k_series * (p - 1), dtype=floatX)
+        )
+
+    return companion
 
 
 class BayesianDynamicFactor(PyMCStateSpace):
@@ -570,231 +641,33 @@ class BayesianDynamicFactor(PyMCStateSpace):
         return tuple(coords)
 
     def make_symbolic_graph(self):
-        if not self.exog_flag:
-            x0 = self.make_and_register_variable("x0", shape=(self.k_states,), dtype=floatX)
-        else:
-            initial_factor_loadings = self.make_and_register_variable(
+        if self.exog_flag:
+            # Regression coefficients are states, so their prior is the tail of the initial state.
+            initial_factor_states = self.make_and_register_variable(
                 "x0", shape=(self.k_states - self.k_exog_states,), dtype=floatX
             )
             initial_betas = self.make_and_register_variable(
                 "beta", shape=(self.k_exog_states,), dtype=floatX
             )
-            x0 = pt.concatenate([initial_factor_loadings, initial_betas], axis=0)
+            x0 = pt.concatenate([initial_factor_states, initial_betas], axis=0)
+        else:
+            x0 = self.make_and_register_variable("x0", shape=(self.k_states,), dtype=floatX)
 
         self.ssm["initial_state", :] = x0
 
-        # Initial covariance
         P0 = self.make_and_register_variable(
             "P0", shape=(self.k_states, self.k_states), dtype=floatX
         )
         self.ssm["initial_state_cov", :, :] = P0
 
-        # Design matrix (Z)
-        # Construction with block structure:
-        # When factor_order <= 1 and error_order = 0:
-        #   [ A ]               A is the factor loadings matrix with shape (k_endog, k_factors)
-        #
-        # When factor_order > 1, add block of zeros for the factors lags:
-        #   [ A | 0 ]           the zero block has shape (k_endog, k_factors * (factor_order - 1))
-        #
-        # When error_order > 0, add identity matrix and additional zero block for errors lags:
-        #   [ A | 0 | I | 0 ]   I is the identity matrix (k_endog, k_endog) and the final zero block
-        #                       has shape (k_endog, k_endog * (error_order - 1))
-        #
-        # When exog_flag=True, exogenous data (exog_data) is included and the design
-        # matrix becomes 3D with the first dimension indexing time:
-        #   - shared_exog_states=True: exog_data is broadcast across all endogenous series
-        #       → shape (n_timepoints, k_endog, k_exog)
-        #   - shared_exog_states=False: each endogenous series gets its own exog block
-        #       → block-diagonal structure with shape (n_timepoints, k_endog, k_exog * k_endog)
-        # In this case, the base design matrix (factors + errors) is repeated over
-        # time and concatenated with the exogenous block. The final design matrix
-        # has shape (n_timepoints, k_endog, n_columns) and combines all components.
-        factor_loadings = self.make_and_register_variable(
-            "factor_loadings", shape=(self.k_endog, self.k_factors), dtype=floatX
-        )
-        # Add factor loadings (A matrix)
-        matrix_parts = [factor_loadings]
-
-        # Add zero block for the factors lags when factor_order > 1
-        if self.factor_order > 1:
-            matrix_parts.append(
-                pt.zeros((self.k_endog, self.k_factors * (self.factor_order - 1)), dtype=floatX)
-            )
-        # Add identity and zero blocks for error lags when error_order > 0
-        if self.error_order > 0:
-            error_matrix = pt.eye(self.k_endog, dtype=floatX)
-            matrix_parts.append(error_matrix)
-            matrix_parts.append(
-                pt.zeros((self.k_endog, self.k_endog * (self.error_order - 1)), dtype=floatX)
-            )
-        if len(matrix_parts) == 1:
-            design_matrix = factor_loadings * 1.0  # copy to ensure a new PyTensor variable
-            design_matrix.name = "design"
-            # TODO: This is a hack to ensure the design matrix isn't identically equal to the factor_loadings when error_order=0 and factor_order=0
-        else:
-            design_matrix = pt.concatenate(matrix_parts, axis=1)
-            design_matrix.name = "design"
-        # Handle exogenous variables (if any)
-        if self.exog_flag:
-            exog_data = self.make_and_register_data("exog_data", shape=(None, self.k_exog))
-            if self.shared_exog_states:
-                # Shared exogenous states: same exog data is used across all endogenous variables
-                # Shape becomes (n_timepoints, k_endog, k_exog)
-                Z_exog = pt.join(1, *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)])
-            else:
-                # Separate exogenous states: each endogenous variable gets its own exog block
-                # Create block-diagonal structure and reshape to (n_timepoints, k_endog, k_exog * k_endog)
-                Z_exog = pt.linalg.block_diag(
-                    *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)]
-                )
-
-            # Repeat base design_matrix over time dimension to match exogenous time series
-            n_timepoints = Z_exog.shape[0]
-            design_matrix_time = pt.tile(design_matrix, (n_timepoints, 1, 1))
-            # Concatenate the repeated design matrix with exogenous matrix along the last axis
-            # Final shape: (n_timepoints, k_endog, n_columns + n_exog_columns)
-            design_matrix = pt.concatenate([design_matrix_time, Z_exog], axis=2)
-
-        self.ssm["design"] = design_matrix
+        self.ssm["design"] = self._build_design_matrix()
         if self.exog_flag:
             self.ssm.declare_time_varying("design")
 
-        # Transition matrix (T)
-        # Construction with block-diagonal structure:
-        # Each latent component (factors, errors, exogenous states) contributes its own transition block,
-        # and the full transition matrix is assembled with block_diag.
-        #   T = block_diag(A, B, C)
-        #
-        # - Factors (block A):
-        #   If factor_order > 0, the factor AR coefficients are organized into a
-        #   VAR(p) companion matrix of size (k_factors * factor_order, k_factors * factor_order).
-        #   This block shifts lagged factor states and applies AR coefficients.
-        #   If factor_order = 0, a zero matrix is used instead.
-        #
-        # - Errors (block B):
-        #   If error_order > 0:
-        #     * error_var=True → build a full VAR(p) companion matrix (cross-series correlations allowed).
-        #     * error_var=False → build independent AR(p) companion matrices (no cross-series effects).
-        #
-        # - Exogenous states (block C):
-        #   If exog_flag=True, exogenous states are either constant or follow a random walk, modeled with an identity
-        #       transition block of size (k_exog_states, k_exog_states).
-        #
-        # The final transition matrix is block-diagonal, combining all active components:
-        #   Transition = block_diag(Factors, Errors, Exogenous)
+        self.ssm["transition", :, :] = pt.linalg.block_diag(*self._build_transition_blocks())
 
-        # auxiliary functions to build transition matrix block
-        def build_var_block_matrix(ar_coeffs, k_series, p):
-            """
-            Build the VAR(p) companion matrix for the factors.
+        self._build_selection_matrix()
 
-            ar_coeffs: PyTensor matrix of shape (k_series, p * k_series)
-                    [A1 | A2 | ... | Ap] horizontally concatenated.
-            k_series: number of series
-            p: lag order
-            """
-            size = k_series * p
-            block = pt.zeros((size, size), dtype=floatX)
-
-            # First block row: the AR coefficient matrices for each lag
-            block = block[0:k_series, 0 : k_series * p].set(ar_coeffs)
-
-            # Sub-diagonal identity blocks (shift structure)
-            if p > 1:
-                # Create the identity pattern for all sub-diagonal blocks
-                identity_pattern = pt.eye(k_series * (p - 1), dtype=floatX)
-                block = block[k_series:, : k_series * (p - 1)].set(identity_pattern)
-
-            return block
-
-        def build_independent_var_block_matrix(ar_coeffs, k_series, p):
-            """
-            Build a VAR(p)-style companion matrix for independent AR(p) processes
-            with interleaved state ordering:
-            (x1(t), x2(t), ..., x1(t-1), x2(t-1), ...).
-
-            ar_coeffs: PyTensor matrix of shape (k_series, p)
-            k_series: number of independent series
-            p: lag order
-            """
-            size = k_series * p
-            block = pt.zeros((size, size), dtype=floatX)
-
-            # First block row: AR coefficients per series (block diagonal)
-            for j in range(k_series):
-                for lag in range(p):
-                    col_idx = lag * k_series + j
-                    block = pt.set_subtensor(block[j, col_idx], ar_coeffs[j, lag])
-
-            # Sub-diagonal identity blocks (shift)
-            if p > 1:
-                identity_pattern = pt.eye(k_series * (p - 1), dtype=floatX)
-                block = pt.set_subtensor(block[k_series:, : k_series * (p - 1)], identity_pattern)
-            return block
-
-        transition_blocks = []
-        # Block A: Factors
-        if self.factor_order > 0:
-            factor_ar = self.make_and_register_variable(
-                "factor_ar",
-                shape=(self.k_factors, self.factor_order * self.k_factors),
-                dtype=floatX,
-            )
-            transition_blocks.append(
-                build_var_block_matrix(factor_ar, self.k_factors, self.factor_order)
-            )
-        else:
-            transition_blocks.append(pt.zeros((self.k_factors, self.k_factors), dtype=floatX))
-        # Block B: Errors
-        if self.error_order > 0 and self.error_var:
-            error_ar = self.make_and_register_variable(
-                "error_ar", shape=(self.k_endog, self.error_order * self.k_endog), dtype=floatX
-            )
-            transition_blocks.append(
-                build_var_block_matrix(error_ar, self.k_endog, self.error_order)
-            )
-        elif self.error_order > 0 and not self.error_var:
-            error_ar = self.make_and_register_variable(
-                "error_ar", shape=(self.k_endog, self.error_order), dtype=floatX
-            )
-            transition_blocks.append(
-                build_independent_var_block_matrix(error_ar, self.k_endog, self.error_order)
-            )
-        # Block C: Exogenous states
-        if self.exog_flag:
-            transition_blocks.append(pt.eye(self.k_exog_states, dtype=floatX))
-
-        self.ssm["transition", :, :] = pt.linalg.block_diag(*transition_blocks)
-
-        # Selection matrix (R)
-        for i in range(self.k_factors):
-            self.ssm["selection", i, i] = 1.0
-
-        if self.error_order > 0:
-            for i in range(self.k_endog):
-                row = max(self.factor_order, 1) * self.k_factors + i
-                col = self.k_factors + i
-                self.ssm["selection", row, col] = 1.0
-
-        if self.exog_flag and self.exog_innovations:
-            row_start = self.k_states - self.k_exog_states
-            row_end = self.k_states
-
-            if self.error_order > 0:
-                col_start = self.k_factors + self.k_endog
-                col_end = self.k_factors + self.k_endog + self.k_exog_states
-            else:
-                col_start = self.k_factors
-                col_end = self.k_factors + self.k_exog_states
-
-            self.ssm["selection", row_start:row_end, col_start:col_end] = pt.eye(
-                self.k_exog_states, dtype=floatX
-            )
-
-        factor_cov = pt.eye(self.k_factors, dtype=floatX)
-
-        # Handle error_sigma and error_cov depending on error_cov_type
         if self.error_cov_type == "scalar":
             error_sigma = self.make_and_register_variable("error_sigma", shape=(), dtype=floatX)
             error_cov = pt.eye(self.k_endog) * error_sigma
@@ -808,33 +681,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 "error_cov", shape=(self.k_endog, self.k_endog), dtype=floatX
             )
 
-        # State covariance matrix (Q)
-        if self.error_order > 0:
-            if self.exog_flag and self.exog_innovations:
-                # Include AR noise in state vector
-                beta_sigma = self.make_and_register_variable(
-                    "beta_sigma", shape=(self.k_exog_states,), dtype=floatX
-                )
-                exog_cov = pt.diag(beta_sigma)
-                self.ssm["state_cov", :, :] = pt.linalg.block_diag(factor_cov, error_cov, exog_cov)
-            elif self.exog_flag and not self.exog_innovations:
-                exog_cov = pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX)
-                self.ssm["state_cov", :, :] = pt.linalg.block_diag(factor_cov, error_cov, exog_cov)
-            elif not self.exog_flag:
-                self.ssm["state_cov", :, :] = pt.linalg.block_diag(factor_cov, error_cov)
-        else:
-            if self.exog_flag and self.exog_innovations:
-                beta_sigma = self.make_and_register_variable(
-                    "beta_sigma", shape=(self.k_exog_states,), dtype=floatX
-                )
-                exog_cov = pt.diag(beta_sigma)
-                self.ssm["state_cov", :, :] = pt.linalg.block_diag(factor_cov, exog_cov)
-            elif self.exog_flag and not self.exog_innovations:
-                exog_cov = pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX)
-                self.ssm["state_cov", :, :] = pt.linalg.block_diag(factor_cov, exog_cov)
-            elif not self.exog_flag:
-                # Only latent factor in the state
-                self.ssm["state_cov", :, :] = factor_cov
+        self._build_state_cov(error_cov)
 
         # Observation covariance matrix (H)
         if self.error_order > 0:
@@ -856,3 +703,138 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 self.ssm["obs_cov", :, :] = pt.diag(pt.sqrt(total_obs_var))
             else:
                 self.ssm["obs_cov", :, :] = pt.diag(error_sigma)
+
+    def _build_design_matrix(self):
+        r"""
+        Assemble the design matrix :math:`Z`.
+
+        The factor and error components give the block row :math:`[\Lambda | 0 | I | 0]`, where
+        :math:`\Lambda` are the factor loadings, :math:`I` picks out the current error states, and
+        the zero blocks cover lagged states. With exogenous regressors the result gains a leading
+        time axis and the exogenous block is concatenated on the right.
+        """
+        factor_loadings = self.make_and_register_variable(
+            "factor_loadings", shape=(self.k_endog, self.k_factors), dtype=floatX
+        )
+        matrix_parts = [factor_loadings]
+
+        if self.factor_order > 1:
+            matrix_parts.append(
+                pt.zeros((self.k_endog, self.k_factors * (self.factor_order - 1)), dtype=floatX)
+            )
+
+        if self.error_order > 0:
+            matrix_parts.append(pt.eye(self.k_endog, dtype=floatX))
+            matrix_parts.append(
+                pt.zeros((self.k_endog, self.k_endog * (self.error_order - 1)), dtype=floatX)
+            )
+
+        if len(matrix_parts) == 1:
+            # Copy so the design matrix is its own node rather than an alias of the registered
+            # factor_loadings variable, which the matrix substitution machinery relies on.
+            design_matrix = factor_loadings.copy()
+        else:
+            design_matrix = pt.concatenate(matrix_parts, axis=1)
+        design_matrix.name = "design"
+
+        if not self.exog_flag:
+            return design_matrix
+
+        exog_data = self.make_and_register_data("exog_data", shape=(None, self.k_exog))
+        if self.shared_exog_states:
+            # One set of coefficients seen by every observed series: (time, k_endog, k_exog).
+            Z_exog = pt.join(1, *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)])
+        else:
+            # Each observed series gets its own block of coefficients, laid out endog-major:
+            # (time, k_endog, k_exog * k_endog).
+            Z_exog = pt.linalg.block_diag(
+                *[pt.expand_dims(exog_data, 1) for _ in range(self.k_endog)]
+            )
+
+        design_matrix_time = pt.tile(design_matrix, (Z_exog.shape[0], 1, 1))
+        design_matrix = pt.concatenate([design_matrix_time, Z_exog], axis=2)
+        design_matrix.name = "design"
+
+        return design_matrix
+
+    def _build_transition_blocks(self) -> list[pt.TensorVariable]:
+        r"""
+        Build the per-component blocks of the transition matrix :math:`T`.
+
+        Returns
+        -------
+        blocks : list of TensorVariable
+            Companion matrices for the factor and error components and, when exogenous regressors
+            are present, an identity block for the coefficient states. Assembling these with
+            :func:`pytensor.tensor.linalg.block_diag` gives :math:`T`.
+        """
+        blocks = []
+
+        if self.factor_order > 0:
+            factor_ar = self.make_and_register_variable(
+                "factor_ar",
+                shape=(self.k_factors, self.factor_order * self.k_factors),
+                dtype=floatX,
+            )
+            blocks.append(_make_var_companion_matrix(factor_ar, self.k_factors, self.factor_order))
+        else:
+            blocks.append(pt.zeros((self.k_factors, self.k_factors), dtype=floatX))
+
+        if self.error_order > 0:
+            if self.error_var:
+                error_ar = self.make_and_register_variable(
+                    "error_ar", shape=(self.k_endog, self.error_order * self.k_endog), dtype=floatX
+                )
+                blocks.append(_make_var_companion_matrix(error_ar, self.k_endog, self.error_order))
+            else:
+                error_ar = self.make_and_register_variable(
+                    "error_ar", shape=(self.k_endog, self.error_order), dtype=floatX
+                )
+                blocks.append(
+                    _make_independent_ar_companion_matrix(error_ar, self.k_endog, self.error_order)
+                )
+
+        # Exogenous coefficients are constant, or a random walk when exog_innovations is set. Either
+        # way the transition is the identity; only the shock loading differs.
+        if self.exog_flag:
+            blocks.append(pt.eye(self.k_exog_states, dtype=floatX))
+
+        return blocks
+
+    def _build_selection_matrix(self) -> None:
+        """Wire each shock into the state it enters, in the order the shocks are declared."""
+        for i in range(self.k_factors):
+            self.ssm["selection", i, i] = 1.0
+
+        if self.error_order > 0:
+            for i in range(self.k_endog):
+                row = max(self.factor_order, 1) * self.k_factors + i
+                col = self.k_factors + i
+                self.ssm["selection", row, col] = 1.0
+
+        if self.exog_flag and self.exog_innovations:
+            col_start = self.k_factors + (self.k_endog if self.error_order > 0 else 0)
+            self.ssm[
+                "selection",
+                self.k_states - self.k_exog_states : self.k_states,
+                col_start : col_start + self.k_exog_states,
+            ] = pt.eye(self.k_exog_states, dtype=floatX)
+
+    def _build_state_cov(self, error_cov) -> None:
+        r"""Build the state covariance :math:`Q` from the blocks the model actually has."""
+        # Factor innovations are standardized to identity in order to identify the factors.
+        blocks = [pt.eye(self.k_factors, dtype=floatX)]
+
+        if self.error_order > 0:
+            blocks.append(error_cov)
+
+        if self.exog_flag:
+            if self.exog_innovations:
+                beta_sigma = self.make_and_register_variable(
+                    "beta_sigma", shape=(self.k_exog_states,), dtype=floatX
+                )
+                blocks.append(pt.diag(beta_sigma))
+            else:
+                blocks.append(pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX))
+
+        self.ssm["state_cov", :, :] = pt.linalg.block_diag(*blocks)

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
+from pytensor.compile.mode import Mode
+
 from pymc_extras.statespace.core.properties import (
     Coord,
     Data,
@@ -312,8 +314,10 @@ class BayesianDynamicFactor(PyMCStateSpace):
         error_order: int = 0,
         error_var: bool = False,
         error_cov_type: str = "diagonal",
+        filter_type: str = "standard",
         measurement_error: bool = False,
         verbose: bool = True,
+        mode: str | Mode | None = None,
         cov_jitter: float = JITTER_DEFAULT,
         missing_fill_value: float = MISSING_FILL,
     ):
@@ -354,11 +358,21 @@ class BayesianDynamicFactor(PyMCStateSpace):
         error_cov_type : {'scalar', 'diagonal', 'unstructured'}, optional
             Structure of the covariance matrix of the observation errors.
 
+        filter_type : str, optional
+            The type of Kalman Filter to use. Options are "standard", "univariate", and "cholesky".
+            See the docs for kalman filters for more details. Default "standard".
+
         measurement_error: bool, default True
             If true, a measurement error term is added to the model.
 
         verbose: bool, default True
             If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
+
+        mode : str or Mode, optional
+            Pytensor compile mode, used in auxiliary sampling methods such as
+            ``sample_conditional_posterior`` and ``forecast``. The mode does **not** effect calls to
+            ``pm.sample``. Regardless of whether a mode is specified, it can always be overwritten
+            via the ``compile_kwargs`` argument to all sampling methods. Default None.
 
 
         cov_jitter: float, optional
@@ -419,8 +433,10 @@ class BayesianDynamicFactor(PyMCStateSpace):
             k_endog=k_endog,
             k_states=k_states,
             k_posdef=k_posdef,
+            filter_type=filter_type,
             verbose=verbose,
             measurement_error=measurement_error,
+            mode=mode,
             cov_jitter=cov_jitter,
             missing_fill_value=missing_fill_value,
         )

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -106,200 +106,123 @@ def _make_independent_ar_companion_matrix(ar_coeffs, k_series: int, p: int):
 
 class BayesianDynamicFactor(PyMCStateSpace):
     r"""
-    Dynamic Factor Models
+    Dynamic Factor Model
 
     Notes
     -----
-    The Dynamic Factor Model (DFM) is a multivariate state-space model used to represent high-dimensional time series
-    as being driven by a smaller set of unobserved dynamic factors.
+    The Dynamic Factor Model (DFM) is a multivariate state-space model that represents a
+    high-dimensional time series as being driven by a smaller set of unobserved dynamic factors.
 
-    Given a set of observed time series :math:`\{y_t\}_{t=0}^T`, where
+    Given observed series :math:`\{y_t\}_{t=0}^T`, where
 
     .. math::
         y_t = \begin{bmatrix} y_{1,t} & y_{2,t} & \cdots & y_{k_{\text{endog}},t} \end{bmatrix}^T,
 
-    the DFM assumes that each series is a linear combination of a few latent factors and (optionally) autoregressive errors.
-
-    Let:
-    - :math:`k` be the number of dynamic factors (k_factors),
-    - :math:`p` be the order of the latent factor process (factor_order),
-    - :math:`q` be the order of the observation error process (error_order).
-
-    The model equations are in reduced form is:
+    the DFM treats each series as a linear combination of a few latent factors and, optionally,
+    autoregressive errors. Writing :math:`k` for the number of factors (``k_factors``), :math:`p`
+    for the order of the factor process (``factor_order``), and :math:`q` for the order of the error
+    process (``error_order``), the model in reduced form is
 
     .. math::
         y_t &= \Lambda f_t + B x_t + u_t + \eta_t \\
         f_t &= A_1 f_{t-1} + \cdots + A_p f_{t-p} + \varepsilon_{f,t} \\
         u_t &= C_1 u_{t-1} + \cdots + C_q u_{t-q} + \varepsilon_{u,t}
 
-    Where:
-    - :math:`f_t` is the vector of latent dynamic factors (size :math:`k`),
-    - :math:`x_t` is an optional vector of exogenous variables
-    - :math:`u_t` is a vector of autoregressive observation errors (if `error_var=True` with a VAR(q) structure, else treated as independent AR processes),
-    - :math:`\eta_t \sim \mathcal{N}(0, H_t)` is an optional measurement error (if `measurement_error=True`),
-    - :math:`\varepsilon_{f,t} \sim \mathcal{N}(0, I)` and :math:`\varepsilon_{u,t} \sim \mathcal{N}(0, \Sigma_u)` are independent noise terms.
-        To identify the factors, the innovations to the factor process are standardized with identity covariance.
+    where :math:`f_t` is the vector of latent dynamic factors of size :math:`k`, :math:`x_t` is an
+    optional vector of exogenous variables, :math:`u_t` is a vector of autoregressive observation
+    errors following a VAR(q) if ``error_var=True`` and independent AR(q) processes otherwise, and
+    :math:`\eta_t \sim \mathcal{N}(0, H_t)` is an optional measurement error, included when
+    ``measurement_error=True``. The innovations satisfy
+    :math:`\varepsilon_{f,t} \sim \mathcal{N}(0, I)` and
+    :math:`\varepsilon_{u,t} \sim \mathcal{N}(0, \Sigma_u)`. Factor innovations are standardized to
+    an identity covariance in order to identify the factors.
 
-    Internally, the model is represented in state-space form by stacking all current and lagged latent factors and (if present)
-    AR observation errors into a single state vector of dimension:  :math:: k_{\text{states}} = k \cdot p + k_{\text{endog}} \cdot q,
-    where :math:`k_{\text{endog}}` is the number of observed time series.
-
-    The state vector is defined as:
+    Internally the model stacks all current and lagged latent factors and, when present, the AR
+    observation errors into a single state vector of dimension
+    :math:`k_{\text{states}} = k \cdot p + k_{\text{endog}} \cdot q`, where
+    :math:`k_{\text{endog}}` is the number of observed series. States are ordered lag-major: the
+    current value of every factor comes first, then the first lag of every factor, and so on, with
+    the error states laid out the same way.
 
     .. math::
         s_t = \begin{bmatrix}
-            f_t(1) \\
-            \vdots \\
-            f_t(k) \\
-            f_{t-p+1}(1) \\
-            \vdots \\
-            f_{t-p+1}(k) \\
-            u_t(1) \\
-            \vdots \\
-            u_t(k_{\text{endog}}) \\
-            \vdots \\
-            u_{t-q+1}(1) \\
-            \vdots \\
-            u_{t-q+1}(k_{\text{endog}})
-        \end{bmatrix}
+            f_t(1) & \cdots & f_t(k) &
+            f_{t-1}(1) & \cdots & f_{t-1}(k) & \cdots &
+            u_t(1) & \cdots & u_t(k_{\text{endog}}) & \cdots
+        \end{bmatrix}^T
         \in \mathbb{R}^{k_{\text{states}}}
 
-    The transition equation is given by:
+    The transition equation is :math:`s_{t+1} = T s_t + R \epsilon_t`, where :math:`T` is
+    block-diagonal in the factor, error, and exogenous components. Each block is a companion matrix:
+    its first block row holds the autoregressive coefficients and its subdiagonal holds an identity
+    that shifts each lag forward. :math:`\epsilon_t` collects the independent shocks,
 
     .. math::
-        s_{t+1} = T s_t + R \epsilon_t
+        \epsilon_t = \begin{bmatrix} \epsilon_{f,t} \\ \epsilon_{u,t} \end{bmatrix}
+        \in \mathbb{R}^{k + k_{\text{endog}}},
 
-    Where:
-    - :math:`T` is the state transition matrix, composed of:
-        - VAR coefficients :math:`A_1, \dots, A_{p*k_factors}` for the factors,
-        - (if enabled) AR coefficients :math:`C_1, \dots, C_q` for the observation errors.
-        .. math::
-            T = \begin{bmatrix}
-            A_{1,1}  &   A_{1,2}  &   \cdots  &   A_{1,p}  &   0       &   0       &   \cdots  &   0 \\
-            A_{2,1}  &   A_{2,2}  &   \cdots  &   A_{2,p}  &   0       &   0       &   \cdots  &   0 \\
-            1       &   0       &   \cdots  &   0          &   0       &   0       &   \cdots  &   0 \\
-            0       &   1       &   \cdots  &   0          &   0       &   0       &   \cdots  &   0 \\
-            \vdots  &   \vdots  &   \ddots  &   \vdots     &   \vdots  &   \vdots  &   \ddots  &   \vdots \\
-            \hline
-            0       &   0       &   \cdots  &   0       &   C_{1,1}  &  \cdots  &    C_{1,2} &   C_{1,q} \\
-            0       &   0       &   \cdots  &   0       &   1       &   0       &   \cdots  &   0 \\
-            0       &   0       &   \cdots  &   0       &   0       &   1       &   \cdots  &   0 \\
-            \vdots  &   \vdots  &           &   \vdots  &   \vdots  &   \vdots  &   \ddots  &   \vdots
-            \end{bmatrix}
-            \in \mathbb{R}^{k_{\text{states}} \times k_{\text{states}}}
+    and :math:`R` selects which states each shock enters.
 
-    - :math:`\epsilon_t` contains the independent shocks (innovations) and has dimension :math:`k + k_{\text{endog}}` if AR errors are included.
-        .. math::
-            \epsilon_t = \begin{bmatrix}
-            \epsilon_{f,t} \\
-            \epsilon_{u,t}
-            \end{bmatrix}
-            \in \mathbb{R}^{k +  k_{\text{endog}}}
-
-    - :math:`R` is a selection matrix mapping shocks to state transitions.
-        .. math::
-            R = \begin{bmatrix}
-            1       &   0       &   \cdots  &   0       &   0       &   0       &   \cdots  &   0 \\
-            0       &   1       &   \cdots  &   0       &   0       &   0       &   \cdots  &   0 \\
-            \vdots  &   \vdots  &   \ddots  &   \vdots  &   \vdots  &   \vdots  &   \ddots  &   \vdots \\
-            0       &   0       &   \cdots  &   1       &   0       &   0       &   \cdots  &   0 \\
-            0       &   0       &   \cdots  &   0       &   1       &   0       &   \cdots  &   0 \\
-            0       &   0       &   \cdots  &   0       &   0       &   1       &   \cdots  &   0 \\
-            \vdots  &   \vdots  &   \ddots  &   \vdots  &   \vdots  &   \vdots  &   \ddots  &   \vdots \\
-            \end{bmatrix}
-            \in \mathbb{R}^{k_{\text{states}} \times (k + k_{\text{endog}})}
-
-    The observation equation is given by:
+    The observation equation is :math:`y_t = Z s_t + \eta_t`, with design matrix
 
     .. math::
+        Z = \begin{bmatrix} \Lambda & 0 & I & 0 \end{bmatrix}
+        \in \mathbb{R}^{k_{\text{endog}} \times k_{\text{states}}}
 
-        y_t = Z s_t + \eta_t
+    where :math:`\Lambda` holds the factor loadings, the identity block picks out the current error
+    states when :math:`q > 0`, and the zero blocks cover the lagged states, which do not enter the
+    observation equation directly.
 
-    where
-
-    - :math:`y_t` is the vector of observed variables at time :math:`t`
-
-    - :math:`Z` is the design matrix of the state space representation
-        .. math::
-            Z = \begin{bmatrix}
-            \lambda_{1,1}       &   \lambda_{1,k}   &   \vdots    &   1   &   0   &   \cdots  &   0   &   0   &   \cdots  &   0 \\
-            \lambda_{2,1}       &   \lambda_{2,k}   &   \vdots    &   0   &   1   &   \cdots   &   0   &   \cdots  &   0 \\
-            \vdots              &   \vdots          &   \vdots  &   \vdots  &   \ddots  &   \vdots  &   \vdots  &   \ddots  &   \vdots \\
-            \lambda_{k_{\text{endog}},1}  &   \cdots  &   \lambda_{k_{\text{endog}},k}  &   0   &   0   &   \cdots  &   1   &   0   &   \cdots  &   0 \\
-            \end{bmatrix}
-            \in \mathbb{R}^{k_{\text{endog}} \times k_{\text{states}}}
-
-    - :math:`\eta_t` is the vector of observation errors at time :math:`t`
-
-    When exogenous variables :math:`x_t` are present, the implementation follows `pymc_extras/statespace/models/structural/components/regression.py`.
-    In this case, the state vector is extended to include the beta parameters, and the design matrix is modified accordingly,
-    becoming 3-dimensional to handle time-varying exogenous regressors.
-    This approach provides greater flexibility, controlled by the boolean flags `shared_exog_state` and `exog_innovations`.
-    Unlike Statsmodels, where exogenous variables are included only in the observation equation, here they are fully integrated into the state-space
-    representation.
+    When exogenous variables :math:`x_t` are present, the implementation follows
+    :mod:`pymc_extras.statespace.models.structural.components.regression`: the state vector is
+    extended with the regression coefficients and :math:`Z` becomes three-dimensional, with the
+    leading axis indexing time. Unlike statsmodels, which places exogenous variables only in the
+    observation equation, they are fully integrated into the state-space representation here, which
+    is what allows time-varying coefficients via ``exog_innovations``.
 
     .. warning::
 
-        Identification can be an issue, particularly when many observed series load onto only a few latent factors.
-        These models are only identified up to a sign flip in the factor loadings. Proper prior specification is crucial
-        for good estimation and inference.
+        Identification can be an issue, particularly when many observed series load onto only a few
+        latent factors. These models are identified only up to a sign flip in the factor loadings.
+        Proper prior specification is crucial for good estimation and inference.
 
     Examples
     --------
-    The following code snippet estimates a dynamic factor model with 1 latent factors,
-    a AR(2) structure on the factor and a AR(1) structure on the errors:
+    Estimate a dynamic factor model with one latent factor following an AR(2), and AR(1) errors:
 
     .. code:: python
 
-        import pymc_extras.statespace as pmss
         import pymc as pm
+        import pytensor.tensor as pt
 
-        # Create DFM Statespace Model
+        import pymc_extras.statespace as pmss
+
+        # data is a wide DataFrame of observed series indexed by time
         dfm_mod = pmss.BayesianDynamicFactor(
-                k_factors=1,                # Number of latent dynamic factors
-                factor_order=2,             # Number of lags for the latent factor process
-                endog_names=data.columns,   # Names of the observed time series (endogenous variables) (we could also use k_endog = len(data.columns))
-                error_order=1,              # Order of the autoregressive process for the observation noise (i.e., AR(q) error, here q=1)
-                error_var=False,            # If False, models errors as separate AR processes
-                error_cov_type="diagonal",  # Structure of the observation error covariance matrix: uncorrelated noise across series
-                measurement_error=True,     # Whether to include a measurement error term in the model
-                verbose=True
-            )
+            k_factors=1,
+            factor_order=2,
+            endog_names=data.columns,
+            error_order=1,
+            error_var=False,
+            error_cov_type="diagonal",
+            measurement_error=True,
+        )
 
-        # Unpack coords
-        coords = dfm_mod.coords
+        with pm.Model(coords=dfm_mod.coords) as pymc_mod:
+            x0 = pm.Normal("x0", dims=["state"])
 
+            P0_diag = pm.HalfNormal("P0_diag", dims=["state"])
+            P0 = pm.Deterministic("P0", pt.diag(P0_diag), dims=["state", "state_aux"])
 
-        with pm.Model(coords=coords) as pymc_mod:
-            # Priors for the initial state mean and covariance
-            x0 = pm.Normal("x0", dims=["state_dim"])
-            P0 = pm.HalfNormal("P0", dims=["state_dim", "state_dim"])
+            factor_loadings = pm.Normal("factor_loadings", dims=["observed_state", "factor"])
+            factor_ar = pm.Normal("factor_ar", dims=["factor", "lag_ar"])
+            error_ar = pm.Normal("error_ar", dims=["observed_state", "error_lag_ar"])
 
-            # Factor loadings: shape (k_endog, k_factors)
-            factor_loadings = pm.Normal("factor_loadings", sigma=1, dims=["k_endog", "k_factors"])
+            error_sigma = pm.HalfNormal("error_sigma", dims=["observed_state"])
+            sigma_obs = pm.HalfNormal("sigma_obs", dims=["observed_state"])
 
-            # AR coefficients for factor dynamics: shape (k_factors, factor_order)
-            factor_ar = pm.Normal("factor_ar", sigma=1, dims=["k_factors", "k_factors" * "factor_order"])
-
-            # AR coefficients for observation noise: shape (k_endog, error_order)
-            error_ar = pm.Normal("error_ar", sigma=1, dims=["k_endog", "error_order"])
-
-            # Std devs for observation noise: shape (k_endog,)
-            error_sigma = pm.HalfNormal("error_sigma", dims=["k_endog"])
-
-            # Observation noise covariance matrix
-            obs_sigma = pm.HalfNormal("sigma_obs", dims=["k_endog"])
-
-            # Build the symbolic graph and attach it to the model
             dfm_mod.build_statespace_graph(data=data)
-
-            # Sampling
-            idata = pm.sample(
-                draws=500,
-                chains=2,
-                nuts_sampler="nutpie",
-                nuts_sampler_kwargs={"backend": "jax", "gradient_backend": "jax"},
-            )
+            idata = pm.sample()
 
     """
 
@@ -321,70 +244,59 @@ class BayesianDynamicFactor(PyMCStateSpace):
         cov_jitter: float = JITTER_DEFAULT,
         missing_fill_value: float = MISSING_FILL,
     ):
-        """
+        r"""
         Create a Bayesian Dynamic Factor Model.
 
         Parameters
         ----------
         k_factors : int
             Number of latent factors.
-
         factor_order : int
-            Order of the VAR process for the latent factors. If set to 0, the factors have no autoregressive dynamics
-            and are modeled as a white noise process, i.e., :math:`f_t = \varepsilon_{f,t}`.
-            Therefore, the state vector will include one state per factor and "factor_ar" will not exist.
-
-        endog_names : Sequence of str, optional
+            Order of the VAR process for the latent factors. If 0, the factors have no
+            autoregressive dynamics and are modeled as white noise, :math:`f_t = \varepsilon_{f,t}`.
+            The state vector still carries one state per factor, but ``factor_ar`` does not exist.
+        endog_names : sequence of str
             Names of the observed time series.
-
-        exog_state_names : Sequence of str, optional
-            Names of the exogenous variables.
-
-        shared_exog_states: bool, optional
-            Whether exogenous latent states are shared across the observed states. If True, there will be only one set of exogenous latent
-            states, which are observed by all observed states. If False, each observed state has its own set of exogenous latent states.
-
+        exog_state_names : sequence of str, optional
+            Names of the exogenous variables. Default None, for a model with no exogenous
+            regressors.
+        shared_exog_states : bool, optional
+            Whether the exogenous latent states are shared across the observed states. If True there
+            is a single set of exogenous states seen by every observed state; if False each observed
+            state gets its own set. Default False.
         exog_innovations : bool, optional
-            Whether to allow time-varying regression coefficients. If True, coefficients follow a random walk.
-
+            Whether to allow time-varying regression coefficients. If True, the coefficients follow
+            a random walk. Default False.
         error_order : int, optional
-            Order of the AR process for the observation error component.
-            Default is 0, corresponding to white noise errors.
-
+            Order of the AR process for the observation error component. Default 0, corresponding to
+            white noise errors.
         error_var : bool, optional
-            If True, errors are modeled jointly via a VAR process;
-            otherwise, each error is modeled separately.
-
+            If True, the errors are modeled jointly as a VAR process; otherwise each error is an
+            independent AR process. Default False.
         error_cov_type : {'scalar', 'diagonal', 'unstructured'}, optional
-            Structure of the covariance matrix of the observation errors.
-
+            Structure of the covariance matrix of the observation errors. Default 'diagonal'.
         filter_type : str, optional
             The type of Kalman Filter to use. Options are "standard", "univariate", and "cholesky".
             See the docs for kalman filters for more details. Default "standard".
-
-        measurement_error: bool, default True
-            If true, a measurement error term is added to the model.
-
-        verbose: bool, default True
-            If true, a message will be logged to the terminal explaining the variable names, dimensions, and supports.
-
+        measurement_error : bool, optional
+            If True, a measurement error term is added to the model. Default False.
+        verbose : bool, optional
+            If True, a message will be logged to the terminal explaining the variable names,
+            dimensions, and supports. Default True.
         mode : str or Mode, optional
             Pytensor compile mode, used in auxiliary sampling methods such as
             ``sample_conditional_posterior`` and ``forecast``. The mode does **not** effect calls to
             ``pm.sample``. Regardless of whether a mode is specified, it can always be overwritten
             via the ``compile_kwargs`` argument to all sampling methods. Default None.
-
-
-        cov_jitter: float, optional
-            Jitter added to the diagonal of every covariance matrix at each filtering step, for numerical
-            stability. Post-estimation graphs are built with this same value. Default 1e-8, or 1e-6 if
-            ``pytensor.config.floatX`` is float32.
-
-        missing_fill_value: float, optional
-            Sentinel used to mask missing observations. Set this only if your data legitimately contains the
-            default sentinel. Post-estimation graphs are built with this same value. Default -9999.0.
+        cov_jitter : float, optional
+            Jitter added to the diagonal of every covariance matrix at each filtering step, for
+            numerical stability. Post-estimation graphs are built with this same value. Default
+            1e-8, or 1e-6 if ``pytensor.config.floatX`` is float32.
+        missing_fill_value : float, optional
+            Sentinel used to mask missing observations. Set this only if your data legitimately
+            contains the default sentinel. Post-estimation graphs are built with this same value.
+            Default -9999.0.
         """
-
         validate_names(endog_names, var_name="endog_names", optional=False)
         validate_names(exog_state_names, var_name="exog_state_names", optional=True)
 
@@ -430,7 +342,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
         k_endog = self.k_endog
         k_states = self.k_states
 
-        # x0 - initial state
         parameters.append(
             Parameter(
                 name="x0",
@@ -440,7 +351,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
             )
         )
 
-        # P0 - initial covariance
         parameters.append(
             Parameter(
                 name="P0",
@@ -450,7 +360,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
             )
         )
 
-        # factor_loadings
         parameters.append(
             Parameter(
                 name="factor_loadings",
@@ -460,7 +369,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
             )
         )
 
-        # factor_ar - only if factor_order > 0
         if self.factor_order > 0:
             parameters.append(
                 Parameter(
@@ -471,7 +379,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 )
             )
 
-        # error_ar - only if error_order > 0
         if self.error_order > 0:
             error_ar_shape = (
                 (k_endog, self.error_order * k_endog)
@@ -487,7 +394,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 )
             )
 
-        # error_sigma or error_cov depending on error_cov_type
         if self.error_cov_type == "scalar":
             parameters.append(
                 Parameter(
@@ -516,7 +422,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 )
             )
 
-        # sigma_obs - only if measurement_error
         if self.measurement_error:
             parameters.append(
                 Parameter(
@@ -527,7 +432,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 )
             )
 
-        # beta - only if exog_flag
         if self.has_exog:
             parameters.append(
                 Parameter(
@@ -538,7 +442,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 )
             )
 
-            # beta_sigma - only if exog_innovations
             if self.exog_innovations:
                 parameters.append(
                     Parameter(
@@ -568,7 +471,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         if self.has_exog:
             if self.shared_exog_states:
-                names.extend([f"beta_{exog_name}[shared]" for exog_name in self.exog_state_names])
+                names.extend(f"beta_{exog_name}[shared]" for exog_name in self.exog_state_names)
             else:
                 names.extend(
                     f"beta_{exog_name}[{endog_name}]"
@@ -620,27 +523,22 @@ class BayesianDynamicFactor(PyMCStateSpace):
         return tuple(data)
 
     def set_coords(self) -> Coord | tuple[Coord, ...] | None:
-        k_endog = self.k_endog
         coords = list(self.default_coords())
 
-        # Factor coords
         factor_labels = tuple(f"factor_{i + 1}" for i in range(self.k_factors))
         coords.append(Coord(dimension=FACTOR_DIM, labels=factor_labels))
 
-        # AR param coords for factors
         if self.factor_order > 0:
             ar_labels = tuple(range(1, (self.factor_order * self.k_factors) + 1))
             coords.append(Coord(dimension=AR_PARAM_DIM, labels=ar_labels))
 
-        # AR param coords for errors
         if self.error_order > 0:
             if self.error_var:
-                error_ar_labels = tuple(range(1, (self.error_order * k_endog) + 1))
+                error_ar_labels = tuple(range(1, (self.error_order * self.k_endog) + 1))
             else:
                 error_ar_labels = tuple(range(1, self.error_order + 1))
             coords.append(Coord(dimension=ERROR_AR_PARAM_DIM, labels=error_ar_labels))
 
-        # Exogenous coords
         if self.has_exog:
             k_non_exog_states = self.k_states - self.k_exog_states
             coords.append(Coord(dimension=EXOG_STATE_DIM, labels=self.exog_state_names))
@@ -801,25 +699,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 col_start : col_start + self.k_exog_states,
             ] = pt.eye(self.k_exog_states, dtype=floatX)
 
-    def _build_state_cov(self, error_cov) -> None:
-        r"""Build the state covariance :math:`Q` from the blocks the model actually has."""
-        # Factor innovations are standardized to identity in order to identify the factors.
-        blocks = [pt.eye(self.k_factors, dtype=floatX)]
-
-        if self.error_order > 0:
-            blocks.append(error_cov)
-
-        if self.has_exog:
-            if self.exog_innovations:
-                beta_sigma = self.make_and_register_variable(
-                    "beta_sigma", shape=(self.k_exog_states,), dtype=floatX
-                )
-                blocks.append(pt.diag(beta_sigma))
-            else:
-                blocks.append(pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX))
-
-        self.ssm["state_cov", :, :] = pt.linalg.block_diag(*blocks)
-
     def _build_error_cov(self):
         """Build the covariance of the idiosyncratic observation errors."""
         if self.error_cov_type == "scalar":
@@ -839,6 +718,25 @@ class BayesianDynamicFactor(PyMCStateSpace):
             "error_cov_type must be one of 'scalar', 'diagonal', or 'unstructured', got "
             f"{self.error_cov_type!r}"
         )
+
+    def _build_state_cov(self, error_cov) -> None:
+        r"""Build the state covariance :math:`Q` from the blocks the model actually has."""
+        # Factor innovations are standardized to identity in order to identify the factors.
+        blocks = [pt.eye(self.k_factors, dtype=floatX)]
+
+        if self.error_order > 0:
+            blocks.append(error_cov)
+
+        if self.has_exog:
+            if self.exog_innovations:
+                beta_sigma = self.make_and_register_variable(
+                    "beta_sigma", shape=(self.k_exog_states,), dtype=floatX
+                )
+                blocks.append(pt.diag(beta_sigma))
+            else:
+                blocks.append(pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX))
+
+        self.ssm["state_cov", :, :] = pt.linalg.block_diag(*blocks)
 
     def _build_obs_cov(self, error_cov) -> None:
         r"""Build the observation covariance :math:`H`."""

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -551,16 +551,17 @@ class BayesianDynamicFactor(PyMCStateSpace):
         return tuple(parameters)
 
     def set_states(self) -> State | tuple[State, ...] | None:
+        # States are laid out lag-major to match the companion matrices built in
+        # make_symbolic_graph: every series at lag 0, then every series at lag 1, and so on.
         names = [
             f"L{lag}.factor_{i}"
-            for i in range(self.k_factors)
             for lag in range(max(self.factor_order, 1))
+            for i in range(self.k_factors)
         ]
 
-        if self.error_order > 0:
-            names.extend(
-                f"L{lag}.error_{i}" for i in range(self.k_endog) for lag in range(self.error_order)
-            )
+        names.extend(
+            f"L{lag}.error_{i}" for lag in range(self.error_order) for i in range(self.k_endog)
+        )
 
         if self.exog_flag:
             if self.shared_exog_states:
@@ -568,8 +569,8 @@ class BayesianDynamicFactor(PyMCStateSpace):
             else:
                 names.extend(
                     f"beta_{exog_name}[{endog_name}]"
-                    for exog_name in self.exog_names
                     for endog_name in self.endog_names
+                    for exog_name in self.exog_names
                 )
 
         hidden_states = [State(name=name, observed=False, shared=False) for name in names]
@@ -589,10 +590,11 @@ class BayesianDynamicFactor(PyMCStateSpace):
             if self.shared_exog_states:
                 shock_names.extend(f"exog_shock_{i}.shared" for i in range(self.k_exog))
             else:
+                # Ordered to match the exogenous states in set_states, which are endog-major.
                 shock_names.extend(
                     f"exog_shock_{i}.endog_{j}"
-                    for i in range(self.k_exog)
                     for j in range(self.k_endog)
+                    for i in range(self.k_exog)
                 )
 
         return tuple(Shock(name=name) for name in shock_names)

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -308,7 +308,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         k_factors: int,
         factor_order: int,
         endog_names: Sequence[str] | None = None,
-        exog_names: Sequence[str] | None = None,
+        exog_state_names: Sequence[str] | None = None,
         shared_exog_states: bool = False,
         exog_innovations: bool = False,
         error_order: int = 0,
@@ -337,7 +337,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         endog_names : Sequence of str, optional
             Names of the observed time series.
 
-        exog_names : Sequence of str, optional
+        exog_state_names : Sequence of str, optional
             Names of the exogenous variables.
 
         shared_exog_states: bool, optional
@@ -395,15 +395,15 @@ class BayesianDynamicFactor(PyMCStateSpace):
         self.error_var = error_var
         self.error_cov_type = error_cov_type
 
-        if exog_names is not None:
+        if exog_state_names is not None:
             self.shared_exog_states = shared_exog_states
             self.exog_innovations = exog_innovations
             validate_names(
-                exog_names, var_name="exog_names", optional=True
+                exog_state_names, var_name="exog_state_names", optional=True
             )  # Not sure if this adds anything
-            k_exog = len(exog_names)
+            k_exog = len(exog_state_names)
             self.k_exog = k_exog
-            self.exog_names = exog_names
+            self.exog_state_names = exog_state_names
         else:
             self.k_exog = 0
 
@@ -583,12 +583,12 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         if self.exog_flag:
             if self.shared_exog_states:
-                names.extend([f"beta_{exog_name}[shared]" for exog_name in self.exog_names])
+                names.extend([f"beta_{exog_name}[shared]" for exog_name in self.exog_state_names])
             else:
                 names.extend(
                     f"beta_{exog_name}[{endog_name}]"
                     for endog_name in self.endog_names
-                    for exog_name in self.exog_names
+                    for exog_name in self.exog_state_names
                 )
 
         hidden_states = [State(name=name, observed=False, shared=False) for name in names]
@@ -656,7 +656,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
         # Exogenous coords
         if self.exog_flag:
             k_non_exog_states = self.k_states - self.k_exog_states
-            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=tuple(self.exog_names)))
+            coords.append(Coord(dimension=EXOG_STATE_DIM, labels=tuple(self.exog_state_names)))
             coords.append(
                 Coord(dimension=EXOG_COEF_STATE_DIM, labels=self.state_names[k_non_exog_states:])
             )

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -670,41 +670,9 @@ class BayesianDynamicFactor(PyMCStateSpace):
 
         self._build_selection_matrix()
 
-        if self.error_cov_type == "scalar":
-            error_sigma = self.make_and_register_variable("error_sigma", shape=(), dtype=floatX)
-            error_cov = pt.eye(self.k_endog) * error_sigma
-        elif self.error_cov_type == "diagonal":
-            error_sigma = self.make_and_register_variable(
-                "error_sigma", shape=(self.k_endog,), dtype=floatX
-            )
-            error_cov = pt.diag(error_sigma)
-        elif self.error_cov_type == "unstructured":
-            error_cov = self.make_and_register_variable(
-                "error_cov", shape=(self.k_endog, self.k_endog), dtype=floatX
-            )
-
+        error_cov = self._build_error_cov()
         self._build_state_cov(error_cov)
-
-        # Observation covariance matrix (H)
-        if self.error_order > 0:
-            if self.measurement_error:
-                sigma_obs = self.make_and_register_variable(
-                    "sigma_obs", shape=(self.k_endog,), dtype=floatX
-                )
-                self.ssm["obs_cov", :, :] = pt.diag(sigma_obs)
-            # else: obs_cov remains zero (no measurement noise and idiosyncratic noise captured in state)
-        else:
-            if self.measurement_error:
-                # TODO: check this decision
-                # in this case error_order = 0, so there is no error term in the state, so the sigma error could not be added there
-                # Idiosyncratic + measurement error
-                sigma_obs = self.make_and_register_variable(
-                    "sigma_obs", shape=(self.k_endog,), dtype=floatX
-                )
-                total_obs_var = error_sigma**2 + sigma_obs**2
-                self.ssm["obs_cov", :, :] = pt.diag(pt.sqrt(total_obs_var))
-            else:
-                self.ssm["obs_cov", :, :] = pt.diag(error_sigma)
+        self._build_obs_cov(error_cov)
 
     def _build_design_matrix(self):
         r"""
@@ -840,3 +808,39 @@ class BayesianDynamicFactor(PyMCStateSpace):
                 blocks.append(pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX))
 
         self.ssm["state_cov", :, :] = pt.linalg.block_diag(*blocks)
+
+    def _build_error_cov(self):
+        """Build the covariance of the idiosyncratic observation errors."""
+        if self.error_cov_type == "scalar":
+            error_sigma = self.make_and_register_variable("error_sigma", shape=(), dtype=floatX)
+            return pt.eye(self.k_endog, dtype=floatX) * error_sigma
+        elif self.error_cov_type == "diagonal":
+            error_sigma = self.make_and_register_variable(
+                "error_sigma", shape=(self.k_endog,), dtype=floatX
+            )
+            return pt.diag(error_sigma)
+        elif self.error_cov_type == "unstructured":
+            return self.make_and_register_variable(
+                "error_cov", shape=(self.k_endog, self.k_endog), dtype=floatX
+            )
+
+        raise ValueError(
+            "error_cov_type must be one of 'scalar', 'diagonal', or 'unstructured', got "
+            f"{self.error_cov_type!r}"
+        )
+
+    def _build_obs_cov(self, error_cov) -> None:
+        r"""Build the observation covariance :math:`H`."""
+        obs_cov = pt.zeros((self.k_endog, self.k_endog), dtype=floatX)
+
+        # Without error states the idiosyncratic error is not in the state vector, so it lands here.
+        if self.error_order == 0:
+            obs_cov = obs_cov + error_cov
+
+        if self.measurement_error:
+            sigma_obs = self.make_and_register_variable(
+                "sigma_obs", shape=(self.k_endog,), dtype=floatX
+            )
+            obs_cov = obs_cov + pt.diag(sigma_obs)
+
+        self.ssm["obs_cov", :, :] = obs_cov

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -703,12 +703,12 @@ class BayesianDynamicFactor(PyMCStateSpace):
         """Build the covariance of the idiosyncratic observation errors."""
         if self.error_cov_type == "scalar":
             error_sigma = self.make_and_register_variable("error_sigma", shape=(), dtype=floatX)
-            return pt.eye(self.k_endog, dtype=floatX) * error_sigma
+            return pt.eye(self.k_endog, dtype=floatX) * error_sigma**2
         elif self.error_cov_type == "diagonal":
             error_sigma = self.make_and_register_variable(
                 "error_sigma", shape=(self.k_endog,), dtype=floatX
             )
-            return pt.diag(error_sigma)
+            return pt.diag(error_sigma**2)
         elif self.error_cov_type == "unstructured":
             return self.make_and_register_variable(
                 "error_cov", shape=(self.k_endog, self.k_endog), dtype=floatX
@@ -750,6 +750,6 @@ class BayesianDynamicFactor(PyMCStateSpace):
             sigma_obs = self.make_and_register_variable(
                 "sigma_obs", shape=(self.k_endog,), dtype=floatX
             )
-            obs_cov = obs_cov + pt.diag(sigma_obs)
+            obs_cov = obs_cov + pt.diag(sigma_obs**2)
 
         self.ssm["obs_cov", :, :] = obs_cov

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -15,6 +15,8 @@ ETS_SEASONAL_DIM = "seasonal_lag"
 FACTOR_DIM = "factor"
 ERROR_AR_PARAM_DIM = "error_lag_ar"
 EXOG_STATE_DIM = "exogenous"
+EXOG_COEF_STATE_DIM = "exogenous_coefficient"
+NON_EXOG_STATE_DIM = "non_exogenous_state"
 
 MISSING_FILL = -9999.0
 JITTER_DEFAULT = 1e-8 if pytensor.config.floatX.endswith("64") else 1e-6

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -216,45 +216,37 @@ def unpack_symbolic_matrices_with_params(mod, param_dict, data_dict=None, mode="
     return f_matrices(**param_dict, **data_dict)
 
 
-def simulate_from_numpy_model(
-    mod, rng, param_dict, data_dict=None, steps=100, state_shocks=None, measurement_shocks=None
-):
-    x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(mod, param_dict, data_dict)
-    k_endog = mod.k_endog
-    k_states = mod.k_states
-    k_posdef = mod.k_posdef
+def simulate_from_matrices(matrices, rng, steps=100):
+    x0, P0, c, d, T, Z, R, H, Q = matrices
+    k_states, k_posdef = R.shape
+    k_endog = Z.shape[-2]
+    has_measurement_error = not np.allclose(H, 0)
 
     x = np.zeros((steps, k_states))
     y = np.zeros((steps, k_endog))
 
+    def measurement_error():
+        if not has_measurement_error:
+            return 0
+        return rng.multivariate_normal(mean=np.zeros(k_endog), cov=H).squeeze()
+
     x[0] = x0
     y[0] = (Z @ x0).squeeze() if Z.ndim == 2 else (Z[0] @ x0).squeeze()
-
-    if not np.allclose(H, 0):
-        y[0] += rng.multivariate_normal(mean=np.zeros(1), cov=H).squeeze()
+    y[0] += measurement_error()
 
     for t in range(1, steps):
-        if k_posdef > 0:
-            innov = R @ rng.multivariate_normal(mean=np.zeros(k_posdef), cov=Q)
-        else:
-            innov = 0
-
-        if not np.allclose(H, 0):
-            error = measurement_shocks[t - 1]
-        else:
-            error = 0
+        innov = R @ rng.multivariate_normal(mean=np.zeros(k_posdef), cov=Q) if k_posdef > 0 else 0
 
         x[t] = c + T @ x[t - 1] + innov
-        if Z.ndim == 2:
-            y[t] = (d + Z @ x[t] + error).squeeze()
-        else:
-            y[t] = (d + Z[t] @ x[t] + error).squeeze()
+        design = Z if Z.ndim == 2 else Z[t]
+        y[t] = (d + design @ x[t] + measurement_error()).squeeze()
 
     return x, y.squeeze()
 
 
 @pytest.mark.parametrize("n_obs,n_runs", [(100, 200)])
-def test_DFM_exog_betas_random_walk(n_obs, n_runs):
+def test_exog_coefficient_random_walk_variance_grows_linearly(n_obs, n_runs):
+    """With exog_innovations the coefficients random walk, so Var(beta_t) = t * diag(Q)."""
     rng = np.random.default_rng(123)
     dfm_mod = BayesianDynamicFactor(
         k_factors=1,
@@ -267,51 +259,40 @@ def test_DFM_exog_betas_random_walk(n_obs, n_runs):
         exog_innovations=True,
         error_cov_type="diagonal",
         measurement_error=False,
+        verbose=False,
     )
 
-    # Arbitrary Parameters
+    beta_variances = np.array([1.0, 2.0, 3.0, 4.0])
     param_dict = {
         "factor_loadings": np.array([[0.9], [0.8]]),
         "factor_ar": np.array([[0.5]]),
         "error_ar": np.array([[0.4], [0.3]]),
         "error_sigma": np.array([0.1, 0.2]),
         "P0": np.eye(dfm_mod.k_states),
-        "x0": np.zeros(dfm_mod.k_states - dfm_mod.k_exog * dfm_mod.k_endog),
-        "beta": np.array([0.3, 0.5, 1, 2]),
-        "beta_sigma": np.array([1, 2, 3, 4]) ** 0.5,
+        "x0": np.zeros(dfm_mod.k_states - dfm_mod.k_exog_states),
+        "beta": np.array([0.3, 0.5, 1.0, 2.0]),
+        "beta_sigma": beta_variances,
     }
-    data_dict = {"exog_data": np.random.normal(size=(n_obs, 2))}
-
-    # Run multiple sims
-    betas_t1, betas_t100 = [], []
-    k_exog_states = dfm_mod.k_exog * dfm_mod.k_endog
-
-    for _ in range(n_runs):
-        x_traj, _ = simulate_from_numpy_model(dfm_mod, rng, param_dict, data_dict, steps=n_obs)
-        beta_traj = x_traj[:, -k_exog_states:]
-        betas_t1.append(beta_traj[1, :])
-        betas_t100.append(beta_traj[-1, :])
-
-    betas_t1 = np.array(betas_t1)
-    betas_t100 = np.array(betas_t100)
-
-    var_t1 = betas_t1.var(axis=0)
-    var_t100 = betas_t100.var(axis=0)
-
-    assert np.all(var_t100 > var_t1), (
-        f"Expected variance at T=100 > T=1, got {var_t1} vs {var_t100}"
+    matrices = unpack_symbolic_matrices_with_params(
+        dfm_mod, param_dict, {"exog_data": rng.normal(size=(n_obs, 2))}
     )
 
+    first_exog_state = dfm_mod.k_states - dfm_mod.k_exog_states
+    coefficient_paths = np.array(
+        [
+            simulate_from_matrices(matrices, rng, steps=n_obs)[0][:, first_exog_state:]
+            for _ in range(n_runs)
+        ]
+    )
 
-@pytest.mark.parametrize("shared", [True, False])
-def test_DFM_exog_shared_vs_not(shared):
+    assert_allclose(coefficient_paths[:, 1].var(axis=0), beta_variances, rtol=0.3)
+    assert_allclose(coefficient_paths[:, -1].var(axis=0), (n_obs - 1) * beta_variances, rtol=0.3)
+
+
+@pytest.mark.parametrize("shared", [True, False], ids=["shared", "per_series"])
+def test_exog_contribution_is_shared_across_series_only_when_requested(shared):
     rng = np.random.default_rng(123)
-
-    n_obs = 50
-    k_exog = 2
-    k_endog = 2
-
-    # Dummy exogenous data
+    n_obs, k_exog, k_endog = 50, 2, 2
     exog = rng.normal(size=(n_obs, k_exog))
 
     dfm_mod = BayesianDynamicFactor(
@@ -324,64 +305,37 @@ def test_DFM_exog_shared_vs_not(shared):
         exog_innovations=False,
         error_cov_type="diagonal",
         measurement_error=False,
+        verbose=False,
     )
 
-    k_exog_states = dfm_mod.k_exog * dfm_mod.k_endog if not shared else dfm_mod.k_exog
-
-    if shared:
-        beta = np.array([0.3, 0.5])
-    else:
-        beta = np.array([0.3, 0.5, 1.0, 2.0])
-
+    beta = np.array([0.3, 0.5]) if shared else np.array([0.3, 0.5, 1.0, 2.0])
     param_dict = {
         "factor_loadings": np.array([[0.9], [0.8]]),
         "factor_ar": np.array([[0.5]]),
         "error_ar": np.array([[0.4], [0.3]]),
         "error_sigma": np.array([0.1, 0.2]),
         "P0": np.eye(dfm_mod.k_states),
-        "x0": np.zeros(dfm_mod.k_states - k_exog_states),
+        "x0": np.zeros(dfm_mod.k_states - dfm_mod.k_exog_states),
         "beta": beta,
     }
 
-    data_dict = {"exog_data": exog}
+    matrices = unpack_symbolic_matrices_with_params(dfm_mod, param_dict, {"exog_data": exog})
+    x_traj, _ = simulate_from_matrices(matrices, rng, steps=n_obs)
+    Z = dict(zip(MATRIX_NAMES, matrices))["Z"]
 
-    # Simulate trajectory
-    x_traj, y_traj = simulate_from_numpy_model(dfm_mod, rng, param_dict, data_dict, steps=n_obs)
-
-    # Test 1: Check hidden states
-    # Extract exogenous hidden states at time t=10
     t = 10
-    exog_states_start = dfm_mod.k_states - k_exog_states
-    exog_states_end = dfm_mod.k_states
-    exog_hidden_states = x_traj[t, exog_states_start:exog_states_end]
+    first_exog_state = dfm_mod.k_states - dfm_mod.k_exog_states
 
+    # Without innovations the coefficients never move off their initial value.
+    assert_allclose(x_traj[t, first_exog_state:], beta)
+
+    exog_contribution = Z[t][:, first_exog_state:] @ x_traj[t, first_exog_state:]
     if shared:
-        # When shared=True, there should be k_exog states total
-        assert len(exog_hidden_states) == k_exog
+        expected = np.full(k_endog, beta @ exog[t])
     else:
-        # When shared=False, there should be k_exog * k_endog states
-        assert len(exog_hidden_states) == k_exog * k_endog
-        # Each endogenous variable has its own set of exogenous states
-        exog_states_reshaped = exog_hidden_states.reshape(k_endog, k_exog)
-        assert not np.allclose(exog_states_reshaped[0], exog_states_reshaped[1])
+        expected = beta.reshape(k_endog, k_exog) @ exog[t]
 
-    # Test 2: Check observed contributions
-    exog_t = exog[t]
-
-    if shared:
-        # All endogenous variables get the same beta * data contribution
-        contributions = [beta @ exog_t for _ in range(k_endog)]
-        assert np.allclose(contributions[0], contributions[1]), (
-            "Expected same contribution for all endog when shared=True"
-        )
-    else:
-        # Each endogenous variable gets different beta * data
-        beta_reshaped = beta.reshape(k_endog, k_exog)
-        contributions = [beta_reshaped[i] @ exog_t for i in range(k_endog)]
-        # Check that contributions are different
-        assert not np.allclose(contributions[0], contributions[1]), (
-            f"Expected different contributions, got {contributions}"
-        )
+    assert_allclose(exog_contribution, expected)
 
 
 class TestDFMConfiguration:
@@ -950,6 +904,21 @@ def test_dfm_rejects_unknown_error_cov_type():
         )
 
 
+@pytest.mark.parametrize("filter_type", ["standard", "univariate", "cholesky"])
+def test_dfm_accepts_filter_type_and_mode(filter_type):
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1"],
+        filter_type=filter_type,
+        mode="FAST_COMPILE",
+        verbose=False,
+    )
+
+    assert isinstance(mod.kalman_filter, FILTER_FACTORY[filter_type])
+    assert mod.mode == "FAST_COMPILE"
+
+
 @pytest.mark.parametrize("shared_exog_states", [True, False], ids=["shared", "per_series"])
 def test_exog_model_builds_from_advertised_dims(shared_exog_states, rng):
     """Every parameter's advertised dims must be as long as the variable it stands for."""
@@ -983,21 +952,6 @@ def test_exog_model_builds_from_advertised_dims(shared_exog_states, rng):
         mod.build_statespace_graph(data)
 
     assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))
-
-
-@pytest.mark.parametrize("filter_type", ["standard", "univariate", "cholesky"])
-def test_dfm_accepts_filter_type_and_mode(filter_type):
-    mod = BayesianDynamicFactor(
-        k_factors=1,
-        factor_order=1,
-        endog_names=["y0", "y1"],
-        filter_type=filter_type,
-        mode="FAST_COMPILE",
-        verbose=False,
-    )
-
-    assert isinstance(mod.kalman_filter, FILTER_FACTORY[filter_type])
-    assert mod.mode == "FAST_COMPILE"
 
 
 @pytest.mark.parametrize("shared_exog_states", [True, False], ids=["shared", "per_series"])

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -454,8 +454,8 @@ class TestDFMConfiguration:
             OBS_STATE_DIM: ("y0", "y1", "y2"),
             ALL_STATE_DIM: (
                 "L0.factor_0",
-                "L1.factor_0",
                 "L0.factor_1",
+                "L1.factor_0",
                 "L1.factor_1",
                 "L0.error_0",
                 "L0.error_1",
@@ -463,8 +463,8 @@ class TestDFMConfiguration:
             ),
             ALL_STATE_AUX_DIM: (
                 "L0.factor_0",
-                "L1.factor_0",
                 "L0.factor_1",
+                "L1.factor_0",
                 "L1.factor_1",
                 "L0.error_0",
                 "L0.error_1",
@@ -524,19 +524,19 @@ class TestDFMConfiguration:
             ALL_STATE_DIM: (
                 "L0.factor_0",
                 "L0.error_0",
-                "L1.error_0",
                 "L0.error_1",
-                "L1.error_1",
                 "L0.error_2",
+                "L1.error_0",
+                "L1.error_1",
                 "L1.error_2",
             ),
             ALL_STATE_AUX_DIM: (
                 "L0.factor_0",
                 "L0.error_0",
-                "L1.error_0",
                 "L0.error_1",
-                "L1.error_1",
                 "L0.error_2",
+                "L1.error_0",
+                "L1.error_1",
                 "L1.error_2",
             ),
             FACTOR_DIM: ("factor_1",),
@@ -768,3 +768,84 @@ def test_dfm_workflow(rng, mock_sample):
     irf = ss_mod.impulse_response_function(idata, n_steps=10, random_seed=rng)
     assert "irf" in irf
     assert np.isfinite(irf.irf.values).all()
+
+
+def evaluate_matrices(mod, param_values, data_dict=None):
+    matrices = unpack_symbolic_matrices_with_params(mod, param_values, data_dict=data_dict)
+    return dict(zip(MATRIX_NAMES, matrices))
+
+
+def random_param_values(mod, rng):
+    return {
+        name: rng.normal(size=variable.type.shape).astype(floatX)
+        for name, variable in mod._name_to_variable.items()
+    }
+
+
+@pytest.mark.parametrize(
+    "k_factors, factor_order, error_order, error_var",
+    [(2, 3, 0, False), (1, 1, 2, False), (2, 2, 2, False), (1, 1, 2, True), (2, 2, 2, True)],
+    ids=["factor_lags", "error_lags", "both", "error_lags_var", "both_var"],
+)
+def test_lagged_state_names_match_transition_shifts(
+    k_factors, factor_order, error_order, error_var, rng
+):
+    """A state called ``L{lag}.X`` has to be the previous step's ``L{lag - 1}.X``."""
+    mod = BayesianDynamicFactor(
+        k_factors=k_factors,
+        factor_order=factor_order,
+        endog_names=["y0", "y1", "y2"],
+        error_order=error_order,
+        error_var=error_var,
+        verbose=False,
+    )
+    T = evaluate_matrices(mod, random_param_values(mod, rng))["T"]
+    name_to_index = {name: i for i, name in enumerate(mod.state_names)}
+
+    lagged_states = [
+        (i, name) for i, name in enumerate(mod.state_names) if name.startswith(("L1.", "L2."))
+    ]
+    assert lagged_states, "this configuration has no lagged states to check"
+
+    for index, name in lagged_states:
+        lag, component = name.split(".", 1)
+        expected = np.zeros(mod.k_states)
+        expected[name_to_index[f"L{int(lag[1:]) - 1}.{component}"]] = 1.0
+
+        assert_allclose(T[index], expected, err_msg=f"state {name!r} does not shift from its lag")
+
+
+@pytest.mark.parametrize("shared_exog_states", [True, False], ids=["shared", "per_series"])
+def test_exog_state_names_match_design_columns(shared_exog_states, rng):
+    """A state called ``beta_x[y]`` has to be the column of Z carrying x onto series y."""
+    endog_names = ["y0", "y1", "y2"]
+    exog_names = ["a", "b"]
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=endog_names,
+        exog_names=exog_names,
+        shared_exog_states=shared_exog_states,
+        verbose=False,
+    )
+
+    exog_data = np.array([[2.0, 5.0]], dtype=floatX)
+    Z = evaluate_matrices(mod, random_param_values(mod, rng), data_dict={"exog_data": exog_data})[
+        "Z"
+    ][0]
+    exog_values = dict(zip(exog_names, exog_data[0]))
+
+    beta_states = [(i, name) for i, name in enumerate(mod.state_names) if name.startswith("beta_")]
+    assert len(beta_states) == mod.k_exog_states
+
+    for column, name in beta_states:
+        exog_name, endog_name = name.removeprefix("beta_").rstrip("]").split("[")
+        value = exog_values[exog_name]
+
+        if endog_name == "shared":
+            expected = np.full(len(endog_names), value)
+        else:
+            expected = np.zeros(len(endog_names))
+            expected[endog_names.index(endog_name)] = value
+
+        assert_allclose(Z[:, column], expected, err_msg=f"state {name!r} loads the wrong series")

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -476,16 +476,13 @@ class TestDFMConfiguration:
             ),
             FACTOR_DIM: ("factor_1", "factor_2"),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
-            ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
-            if error_var
-            else tuple(range(1, error_order + 1)),
+            ERROR_AR_PARAM_DIM: tuple(range(1, error_order + 1)),
         }
 
         assert mod.param_names == expected_param_names
         assert mod.param_dims == expected_param_dims
         for k, v in expected_coords.items():
             assert mod.coords[k] == v
-        assert len(mod.state_names) == k_factors * max(factor_order, 1) + k_endog * error_order
         assert mod.observed_states == ("y0", "y1", "y2")
         assert len(mod.shock_names) == k_factors + k_endog
 
@@ -545,16 +542,13 @@ class TestDFMConfiguration:
             ),
             FACTOR_DIM: ("factor_1",),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
-            ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
-            if error_var
-            else tuple(range(1, error_order + 1)),
+            ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1)),
         }
 
         assert mod.param_names == expected_param_names
         assert mod.param_dims == expected_param_dims
         for k, v in expected_coords.items():
             assert mod.coords[k] == v
-        assert len(mod.state_names) == k_factors * max(factor_order, 1) + k_endog * error_order
         assert mod.observed_states == ("y0", "y1", "y2")
         assert len(mod.shock_names) == k_factors + k_endog
 
@@ -623,9 +617,7 @@ class TestDFMConfiguration:
             ),
             FACTOR_DIM: ("factor_1", "factor_2"),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
-            ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
-            if error_var
-            else tuple(range(1, error_order + 1)),
+            ERROR_AR_PARAM_DIM: tuple(range(1, error_order + 1)),
             EXOG_STATE_DIM: ("x0", "x1"),
             EXOG_COEF_STATE_DIM: ("beta_x0[shared]", "beta_x1[shared]"),
             NON_EXOG_STATE_DIM: (
@@ -641,12 +633,15 @@ class TestDFMConfiguration:
         assert mod.param_dims == expected_param_dims
         for k, v in expected_coords.items():
             assert mod.coords[k] == v
-        assert len(mod.state_names) == k_factors * max(factor_order, 1) + k_endog * error_order + (
-            k_exog if shared_exog_states else k_exog * k_endog
-        )
         assert mod.observed_states == ("y0", "y1", "y2")
-        assert len(mod.shock_names) == k_factors + k_endog + (
-            k_exog if shared_exog_states else k_exog * k_endog
+        assert mod.shock_names == (
+            "factor_shock_1",
+            "factor_shock_2",
+            "error_shock_1",
+            "error_shock_2",
+            "error_shock_3",
+            "exog_shock_x0[shared]",
+            "exog_shock_x1[shared]",
         )
 
     def test_exog_not_shared_no_exog_innovations(self):
@@ -712,9 +707,7 @@ class TestDFMConfiguration:
             ),
             FACTOR_DIM: ("factor_1",),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
-            ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
-            if error_var
-            else tuple(range(1, error_order + 1)),
+            ERROR_AR_PARAM_DIM: tuple(range(1, error_order + 1)),
             EXOG_STATE_DIM: ("x0",),
             EXOG_COEF_STATE_DIM: ("beta_x0[y0]", "beta_x0[y1]", "beta_x0[y2]"),
             NON_EXOG_STATE_DIM: (
@@ -730,12 +723,15 @@ class TestDFMConfiguration:
         assert mod.param_dims == expected_param_dims
         for k, v in expected_coords.items():
             assert mod.coords[k] == v
-        assert len(mod.state_names) == k_factors * max(factor_order, 1) + k_endog * error_order + (
-            k_exog if shared_exog_states else k_exog * k_endog
-        )
         assert mod.observed_states == ("y0", "y1", "y2")
-        assert len(mod.shock_names) == k_factors + k_endog + (
-            k_exog if shared_exog_states else k_exog * k_endog
+        assert mod.shock_names == (
+            "factor_shock_1",
+            "error_shock_1",
+            "error_shock_2",
+            "error_shock_3",
+            "exog_shock_x0[y0]",
+            "exog_shock_x0[y1]",
+            "exog_shock_x0[y2]",
         )
 
 

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -406,8 +406,8 @@ class TestDFMConfiguration:
         }
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
-            ALL_STATE_DIM: ("L0.factor_0",),
-            ALL_STATE_AUX_DIM: ("L0.factor_0",),
+            ALL_STATE_DIM: ("L0.factor_1",),
+            ALL_STATE_AUX_DIM: ("L0.factor_1",),
             FACTOR_DIM: ("factor_1",),
         }
 
@@ -415,9 +415,9 @@ class TestDFMConfiguration:
         assert mod.param_dims == expected_param_dims
         for k, v in expected_coords.items():
             assert mod.coords[k] == v
-        assert mod.state_names == ("L0.factor_0",)
+        assert mod.state_names == ("L0.factor_1",)
         assert mod.observed_states == ("y0", "y1", "y2")
-        assert mod.shock_names == ("factor_shock_0",)
+        assert mod.shock_names == ("factor_shock_1",)
 
     def test_dynamic_factor_ar1_error_diagonal_error(self):
         k_factors = 2
@@ -457,22 +457,22 @@ class TestDFMConfiguration:
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
             ALL_STATE_DIM: (
-                "L0.factor_0",
                 "L0.factor_1",
-                "L1.factor_0",
+                "L0.factor_2",
                 "L1.factor_1",
-                "L0.error_0",
+                "L1.factor_2",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
             ),
             ALL_STATE_AUX_DIM: (
-                "L0.factor_0",
                 "L0.factor_1",
-                "L1.factor_0",
+                "L0.factor_2",
                 "L1.factor_1",
-                "L0.error_0",
+                "L1.factor_2",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
             ),
             FACTOR_DIM: ("factor_1", "factor_2"),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
@@ -526,22 +526,22 @@ class TestDFMConfiguration:
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
             ALL_STATE_DIM: (
-                "L0.factor_0",
-                "L0.error_0",
+                "L0.factor_1",
                 "L0.error_1",
                 "L0.error_2",
-                "L1.error_0",
+                "L0.error_3",
                 "L1.error_1",
                 "L1.error_2",
+                "L1.error_3",
             ),
             ALL_STATE_AUX_DIM: (
-                "L0.factor_0",
-                "L0.error_0",
+                "L0.factor_1",
                 "L0.error_1",
                 "L0.error_2",
-                "L1.error_0",
+                "L0.error_3",
                 "L1.error_1",
                 "L1.error_2",
+                "L1.error_3",
             ),
             FACTOR_DIM: ("factor_1",),
             AR_PARAM_DIM: tuple(range(1, k_factors * max(factor_order, 1) + 1)),
@@ -604,20 +604,20 @@ class TestDFMConfiguration:
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
             ALL_STATE_DIM: (
-                "L0.factor_0",
                 "L0.factor_1",
-                "L0.error_0",
+                "L0.factor_2",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
                 "beta_x0[shared]",
                 "beta_x1[shared]",
             ),
             ALL_STATE_AUX_DIM: (
-                "L0.factor_0",
                 "L0.factor_1",
-                "L0.error_0",
+                "L0.factor_2",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
                 "beta_x0[shared]",
                 "beta_x1[shared]",
             ),
@@ -629,11 +629,11 @@ class TestDFMConfiguration:
             EXOG_STATE_DIM: ("x0", "x1"),
             EXOG_COEF_STATE_DIM: ("beta_x0[shared]", "beta_x1[shared]"),
             NON_EXOG_STATE_DIM: (
-                "L0.factor_0",
                 "L0.factor_1",
-                "L0.error_0",
+                "L0.factor_2",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
             ),
         }
 
@@ -691,21 +691,21 @@ class TestDFMConfiguration:
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
             ALL_STATE_DIM: (
-                "L0.factor_0",
-                "L1.factor_0",
-                "L0.error_0",
+                "L0.factor_1",
+                "L1.factor_1",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
                 "beta_x0[y0]",
                 "beta_x0[y1]",
                 "beta_x0[y2]",
             ),
             ALL_STATE_AUX_DIM: (
-                "L0.factor_0",
-                "L1.factor_0",
-                "L0.error_0",
+                "L0.factor_1",
+                "L1.factor_1",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
                 "beta_x0[y0]",
                 "beta_x0[y1]",
                 "beta_x0[y2]",
@@ -718,11 +718,11 @@ class TestDFMConfiguration:
             EXOG_STATE_DIM: ("x0",),
             EXOG_COEF_STATE_DIM: ("beta_x0[y0]", "beta_x0[y1]", "beta_x0[y2]"),
             NON_EXOG_STATE_DIM: (
-                "L0.factor_0",
-                "L1.factor_0",
-                "L0.error_0",
+                "L0.factor_1",
+                "L1.factor_1",
                 "L0.error_1",
                 "L0.error_2",
+                "L0.error_3",
             ),
         }
 
@@ -1002,3 +1002,32 @@ def test_dfm_accepts_filter_type_and_mode(filter_type):
 
     assert isinstance(mod.kalman_filter, FILTER_FACTORY[filter_type])
     assert mod.mode == "FAST_COMPILE"
+
+
+@pytest.mark.parametrize("shared_exog_states", [True, False], ids=["shared", "per_series"])
+def test_exog_shock_names_match_the_states_they_drive(shared_exog_states, rng):
+    """An exogenous shock is named for the coefficient state its column of R feeds."""
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1", "y2"],
+        exog_state_names=["a", "b"],
+        shared_exog_states=shared_exog_states,
+        exog_innovations=True,
+        verbose=False,
+    )
+    R = evaluate_matrices(
+        mod,
+        random_param_values(mod, rng),
+        data_dict={"exog_data": np.zeros((1, 2), dtype=floatX)},
+    )["R"]
+
+    exog_shocks = [(i, n) for i, n in enumerate(mod.shock_names) if n.startswith("exog_shock_")]
+    assert len(exog_shocks) == mod.k_exog_states
+
+    for shock_index, shock_name in exog_shocks:
+        driven_states = np.flatnonzero(R[:, shock_index])
+        assert len(driven_states) == 1, f"{shock_name!r} does not drive exactly one state"
+
+        state_name = mod.state_names[driven_states[0]]
+        assert shock_name == state_name.replace("beta_", "exog_shock_", 1)

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -849,3 +849,90 @@ def test_exog_state_names_match_design_columns(shared_exog_states, rng):
             expected[endog_names.index(endog_name)] = value
 
         assert_allclose(Z[:, column], expected, err_msg=f"state {name!r} loads the wrong series")
+
+
+def test_unstructured_error_cov_without_error_states():
+    """With error_order=0 the idiosyncratic error has no state, so it is observation noise."""
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1", "y2"],
+        error_order=0,
+        error_cov_type="unstructured",
+        verbose=False,
+    )
+    error_cov = np.array([[1.0, 0.2, 0.0], [0.2, 1.5, 0.1], [0.0, 0.1, 2.0]], dtype=floatX)
+    matrices = evaluate_matrices(
+        mod,
+        {
+            "x0": np.zeros(mod.k_states, dtype=floatX),
+            "P0": np.eye(mod.k_states, dtype=floatX),
+            "factor_loadings": np.ones((3, 1), dtype=floatX),
+            "factor_ar": np.array([[0.5]], dtype=floatX),
+            "error_cov": error_cov,
+        },
+    )
+
+    assert_allclose(matrices["H"], error_cov)
+    assert_allclose(matrices["Q"], np.eye(1))
+
+
+def test_scalar_error_cov_without_error_states():
+    """A scalar error variance spreads over the observation covariance diagonal."""
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1", "y2"],
+        error_order=0,
+        error_cov_type="scalar",
+        verbose=False,
+    )
+    matrices = evaluate_matrices(
+        mod,
+        {
+            "x0": np.zeros(mod.k_states, dtype=floatX),
+            "P0": np.eye(mod.k_states, dtype=floatX),
+            "factor_loadings": np.ones((3, 1), dtype=floatX),
+            "factor_ar": np.array([[0.5]], dtype=floatX),
+            "error_sigma": np.array(0.75, dtype=floatX),
+        },
+    )
+
+    assert_allclose(matrices["H"], np.eye(3) * 0.75)
+
+
+def test_measurement_error_adds_to_idiosyncratic_error():
+    """error_sigma and sigma_obs are both variances, so H is their sum on the diagonal."""
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1", "y2"],
+        error_order=0,
+        error_cov_type="diagonal",
+        measurement_error=True,
+        verbose=False,
+    )
+    matrices = evaluate_matrices(
+        mod,
+        {
+            "x0": np.zeros(mod.k_states, dtype=floatX),
+            "P0": np.eye(mod.k_states, dtype=floatX),
+            "factor_loadings": np.ones((3, 1), dtype=floatX),
+            "factor_ar": np.array([[0.5]], dtype=floatX),
+            "error_sigma": np.array([1.0, 2.0, 3.0], dtype=floatX),
+            "sigma_obs": np.array([0.5, 0.25, 0.125], dtype=floatX),
+        },
+    )
+
+    assert_allclose(matrices["H"], np.diag([1.5, 2.25, 3.125]))
+
+
+def test_dfm_rejects_unknown_error_cov_type():
+    with pytest.raises(ValueError, match="error_cov_type must be one of"):
+        BayesianDynamicFactor(
+            k_factors=1,
+            factor_order=1,
+            endog_names=["y0", "y1"],
+            error_cov_type="diagnoal",
+            verbose=False,
+        )

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -19,13 +19,16 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     AR_PARAM_DIM,
     ERROR_AR_PARAM_DIM,
+    EXOG_COEF_STATE_DIM,
     EXOG_STATE_DIM,
     FACTOR_DIM,
     LONG_MATRIX_NAMES,
     MATRIX_NAMES,
+    NON_EXOG_STATE_DIM,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     SHORT_NAME_TO_LONG,
+    TIME_DIM,
 )
 from tests.statespace.shared_fixtures import rng
 
@@ -587,15 +590,15 @@ class TestDFMConfiguration:
             "beta_sigma",
         )
         expected_param_dims = {
-            "x0": (ALL_STATE_DIM,),
+            "x0": (NON_EXOG_STATE_DIM,),
             "P0": (ALL_STATE_DIM, ALL_STATE_AUX_DIM),
             "factor_loadings": (OBS_STATE_DIM, FACTOR_DIM),
             "factor_ar": (FACTOR_DIM, AR_PARAM_DIM),
             "error_ar": (OBS_STATE_DIM, ERROR_AR_PARAM_DIM),
             "error_sigma": (OBS_STATE_DIM,),
             "sigma_obs": (OBS_STATE_DIM,),
-            "beta": (EXOG_STATE_DIM,),
-            "beta_sigma": (EXOG_STATE_DIM,),
+            "beta": (EXOG_COEF_STATE_DIM,),
+            "beta_sigma": (EXOG_COEF_STATE_DIM,),
         }
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
@@ -622,9 +625,15 @@ class TestDFMConfiguration:
             ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
             if error_var
             else tuple(range(1, error_order + 1)),
-            EXOG_STATE_DIM: tuple(range(1, k_exog + 1))
-            if shared_exog_states
-            else tuple(range(1, k_exog * k_endog + 1)),
+            EXOG_STATE_DIM: ("x0", "x1"),
+            EXOG_COEF_STATE_DIM: ("beta_x0[shared]", "beta_x1[shared]"),
+            NON_EXOG_STATE_DIM: (
+                "L0.factor_0",
+                "L0.factor_1",
+                "L0.error_0",
+                "L0.error_1",
+                "L0.error_2",
+            ),
         }
 
         assert mod.param_names == expected_param_names
@@ -670,13 +679,13 @@ class TestDFMConfiguration:
             "beta",
         )
         expected_param_dims = {
-            "x0": (ALL_STATE_DIM,),
+            "x0": (NON_EXOG_STATE_DIM,),
             "P0": (ALL_STATE_DIM, ALL_STATE_AUX_DIM),
             "factor_loadings": (OBS_STATE_DIM, FACTOR_DIM),
             "factor_ar": (FACTOR_DIM, AR_PARAM_DIM),
             "error_ar": (OBS_STATE_DIM, ERROR_AR_PARAM_DIM),
             "error_sigma": (),
-            "beta": (EXOG_STATE_DIM,),
+            "beta": (EXOG_COEF_STATE_DIM,),
         }
         expected_coords = {
             OBS_STATE_DIM: ("y0", "y1", "y2"),
@@ -705,9 +714,15 @@ class TestDFMConfiguration:
             ERROR_AR_PARAM_DIM: tuple(range(1, (error_order * k_endog) + 1))
             if error_var
             else tuple(range(1, error_order + 1)),
-            EXOG_STATE_DIM: tuple(range(1, k_exog + 1))
-            if shared_exog_states
-            else tuple(range(1, k_exog * k_endog + 1)),
+            EXOG_STATE_DIM: ("x0",),
+            EXOG_COEF_STATE_DIM: ("beta_x0[y0]", "beta_x0[y1]", "beta_x0[y2]"),
+            NON_EXOG_STATE_DIM: (
+                "L0.factor_0",
+                "L1.factor_0",
+                "L0.error_0",
+                "L0.error_1",
+                "L0.error_2",
+            ),
         }
 
         assert mod.param_names == expected_param_names
@@ -936,3 +951,38 @@ def test_dfm_rejects_unknown_error_cov_type():
             error_cov_type="diagnoal",
             verbose=False,
         )
+
+
+@pytest.mark.parametrize("shared_exog_states", [True, False], ids=["shared", "per_series"])
+def test_exog_model_builds_from_advertised_dims(shared_exog_states, rng):
+    """Every parameter's advertised dims must be as long as the variable it stands for."""
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1", "y2"],
+        exog_names=["a", "b"],
+        shared_exog_states=shared_exog_states,
+        exog_innovations=True,
+        verbose=False,
+    )
+
+    index = pd.date_range("2020-01-01", periods=20, freq="D")
+    data = pd.DataFrame(rng.normal(size=(20, 3)), columns=["y0", "y1", "y2"], index=index)
+    exog = rng.normal(size=(20, 2))
+
+    assert len(mod.coords[EXOG_STATE_DIM]) == exog.shape[1]
+
+    with pm.Model(coords=mod.coords) as pymc_mod:
+        pm.Data("exog_data", exog, dims=[TIME_DIM, EXOG_STATE_DIM])
+        pm.Normal("x0", dims=mod.param_dims["x0"])
+        P0_diag = pm.Exponential("P0_diag", 1, dims=[ALL_STATE_DIM])
+        pm.Deterministic("P0", pt.diag(P0_diag), dims=[ALL_STATE_DIM, ALL_STATE_AUX_DIM])
+        pm.Normal("factor_loadings", dims=mod.param_dims["factor_loadings"])
+        pm.Normal("factor_ar", dims=mod.param_dims["factor_ar"])
+        pm.Exponential("error_sigma", 1, dims=mod.param_dims["error_sigma"])
+        pm.Normal("beta", dims=mod.param_dims["beta"])
+        pm.Exponential("beta_sigma", 1, dims=mod.param_dims["beta_sigma"])
+
+        mod.build_statespace_graph(data)
+
+    assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -262,7 +262,7 @@ def test_DFM_exog_betas_random_walk(n_obs, n_runs):
         endog_names=["endogenous_0", "endogenous_1"],
         error_order=1,
         error_var=False,
-        exog_names=["exogenous_0", "exogenous_1"],
+        exog_state_names=["exogenous_0", "exogenous_1"],
         shared_exog_states=False,
         exog_innovations=True,
         error_cov_type="diagonal",
@@ -319,7 +319,7 @@ def test_DFM_exog_shared_vs_not(shared):
         factor_order=1,
         endog_names=["endogenous_0", "endogenous_1"],
         error_order=1,
-        exog_names=["exogenous_0", "exogenous_1"],
+        exog_state_names=["exogenous_0", "exogenous_1"],
         shared_exog_states=shared,
         exog_innovations=False,
         error_cov_type="diagonal",
@@ -572,7 +572,7 @@ class TestDFMConfiguration:
             endog_names=["y0", "y1", "y2"],
             error_order=error_order,
             error_var=error_var,
-            exog_names=["x0", "x1"],
+            exog_state_names=["x0", "x1"],
             shared_exog_states=shared_exog_states,
             exog_innovations=True,
             error_cov_type="diagonal",
@@ -663,7 +663,7 @@ class TestDFMConfiguration:
             endog_names=["y0", "y1", "y2"],
             error_order=error_order,
             error_var=error_var,
-            exog_names=["x0"],
+            exog_state_names=["x0"],
             shared_exog_states=shared_exog_states,
             exog_innovations=False,
             error_cov_type="scalar",
@@ -835,12 +835,12 @@ def test_lagged_state_names_match_transition_shifts(
 def test_exog_state_names_match_design_columns(shared_exog_states, rng):
     """A state called ``beta_x[y]`` has to be the column of Z carrying x onto series y."""
     endog_names = ["y0", "y1", "y2"]
-    exog_names = ["a", "b"]
+    exog_state_names = ["a", "b"]
     mod = BayesianDynamicFactor(
         k_factors=1,
         factor_order=1,
         endog_names=endog_names,
-        exog_names=exog_names,
+        exog_state_names=exog_state_names,
         shared_exog_states=shared_exog_states,
         verbose=False,
     )
@@ -849,7 +849,7 @@ def test_exog_state_names_match_design_columns(shared_exog_states, rng):
     Z = evaluate_matrices(mod, random_param_values(mod, rng), data_dict={"exog_data": exog_data})[
         "Z"
     ][0]
-    exog_values = dict(zip(exog_names, exog_data[0]))
+    exog_values = dict(zip(exog_state_names, exog_data[0]))
 
     beta_states = [(i, name) for i, name in enumerate(mod.state_names) if name.startswith("beta_")]
     assert len(beta_states) == mod.k_exog_states
@@ -961,7 +961,7 @@ def test_exog_model_builds_from_advertised_dims(shared_exog_states, rng):
         k_factors=1,
         factor_order=1,
         endog_names=["y0", "y1", "y2"],
-        exog_names=["a", "b"],
+        exog_state_names=["a", "b"],
         shared_exog_states=shared_exog_states,
         exog_innovations=True,
         verbose=False,

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -13,6 +13,7 @@ from pymc.testing import mock_sample_setup_and_teardown
 from pytensor.graph.traversal import explicit_graph_inputs
 from statsmodels.tsa.statespace.dynamic_factor import DynamicFactor
 
+from pymc_extras.statespace.core.statespace import FILTER_FACTORY
 from pymc_extras.statespace.models.DFM import BayesianDynamicFactor
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
@@ -986,3 +987,18 @@ def test_exog_model_builds_from_advertised_dims(shared_exog_states, rng):
         mod.build_statespace_graph(data)
 
     assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))
+
+
+@pytest.mark.parametrize("filter_type", ["standard", "univariate", "cholesky"])
+def test_dfm_accepts_filter_type_and_mode(filter_type):
+    mod = BayesianDynamicFactor(
+        k_factors=1,
+        factor_order=1,
+        endog_names=["y0", "y1"],
+        filter_type=filter_type,
+        mode="FAST_COMPILE",
+        verbose=False,
+    )
+
+    assert isinstance(mod.kalman_filter, FILTER_FACTORY[filter_type])
+    assert mod.mode == "FAST_COMPILE"

--- a/tests/statespace/models/test_DFM.py
+++ b/tests/statespace/models/test_DFM.py
@@ -109,12 +109,12 @@ def create_sm_test_values_mapping(
             }
         )
 
-    # Observation error variances:
+    # statsmodels parameterizes the observation error by its variance, not its standard deviation.
     if "error_sigma" in test_values:
         error_sigma = test_values["error_sigma"]
         sm_test_values.update(
             {
-                f"sigma2.{endog_name}": error_sigma[endog_idx]
+                f"sigma2.{endog_name}": error_sigma[endog_idx] ** 2
                 for endog_idx, endog_name in enumerate(data.columns)
             }
         )
@@ -844,7 +844,7 @@ def test_unstructured_error_cov_without_error_states():
 
 
 def test_scalar_error_cov_without_error_states():
-    """A scalar error variance spreads over the observation covariance diagonal."""
+    """A scalar error standard deviation spreads its variance over the observation covariance."""
     mod = BayesianDynamicFactor(
         k_factors=1,
         factor_order=1,
@@ -864,11 +864,11 @@ def test_scalar_error_cov_without_error_states():
         },
     )
 
-    assert_allclose(matrices["H"], np.eye(3) * 0.75)
+    assert_allclose(matrices["H"], np.eye(3) * 0.75**2)
 
 
 def test_measurement_error_adds_to_idiosyncratic_error():
-    """error_sigma and sigma_obs are both variances, so H is their sum on the diagonal."""
+    """error_sigma and sigma_obs are standard deviations, so H sums their variances."""
     mod = BayesianDynamicFactor(
         k_factors=1,
         factor_order=1,
@@ -890,7 +890,7 @@ def test_measurement_error_adds_to_idiosyncratic_error():
         },
     )
 
-    assert_allclose(matrices["H"], np.diag([1.5, 2.25, 3.125]))
+    assert_allclose(matrices["H"], np.diag([1.0**2 + 0.5**2, 2.0**2 + 0.25**2, 3.0**2 + 0.125**2]))
 
 
 def test_dfm_rejects_unknown_error_cov_type():


### PR DESCRIPTION
DFM's declared metadata disagreed with the graph it actually built: state and shock names were ordered differently from the matrices they label, and with exogenous regressors the advertised `x0` dims were the wrong length, so a model built from `mod.param_dims` never produced a valid logp. Separately, `error_cov_type` of `"scalar"` or `"unstructured"` crashed whenever `error_order=0`.

Coord labels change as a result, and `exog_names` is now `exog_state_names` to match the other models. The first commit is pure code movement.

`error_sigma` and `sigma_obs` were used directly as variances, so they're squared now and a prior on either means something different than it did — `sigma_*` is a standard deviation, `*_cov` is a covariance, same as SARIMAX. Old symptom of this in #295 and #327.
