### PR TITLE
Deprecate observed=None on Prior.create_likelihood_variable

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -497,14 +497,25 @@ def sample_prior(
 def _check_observed(observed, xdist: bool) -> None:
     """Refuse a likelihood with nothing to condition on.
 
-    Only on the ``pymc.dims`` path. Without ``xdist`` the value is passed to
-    PyMC untouched, and tightening that would change long-standing behaviour.
+    Raises on the ``pymc.dims`` path. Without ``xdist`` the value has been
+    passed to PyMC untouched since the method arrived, so that path warns
+    first and will raise in a future release.
     """
-    if xdist and observed is None:
-        raise ValueError(
-            "observed cannot be None. A likelihood needs observations; use "
-            "create_variable for a variable without them."
-        )
+    if observed is not None:
+        return
+
+    message = (
+        "observed cannot be None. A likelihood needs observations; use "
+        "create_variable for a variable without them."
+    )
+    if xdist:
+        raise ValueError(message)
+
+    warnings.warn(
+        f"{message} This will become an error in a future release.",
+        FutureWarning,
+        stacklevel=3,
+    )
 
 
 def _param_value_with_dims(param: str, value, dims: Dims | None):

--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -494,6 +494,19 @@ def sample_prior(
     ).prior.dataset
 
 
+def _check_observed(observed, xdist: bool) -> None:
+    """Refuse a likelihood with nothing to condition on.
+
+    Only on the ``pymc.dims`` path. Without ``xdist`` the value is passed to
+    PyMC untouched, and tightening that would change long-standing behaviour.
+    """
+    if xdist and observed is None:
+        raise ValueError(
+            "observed cannot be None. A likelihood needs observations; use "
+            "create_variable for a variable without them."
+        )
+
+
 def _param_value_with_dims(param: str, value, dims: Dims | None):
     """Infer parameter dims positionally.
 
@@ -1398,6 +1411,8 @@ class Prior:
                 dist.create_likelihood_variable("y", mu=mu, observed=observed)
 
         """
+        _check_observed(observed, xdist)
+
         if "mu" not in _get_pymc_parameters(self.pymc_distribution):
             raise UnsupportedDistributionError(
                 f"Likelihood distribution {self.distribution!r} is not supported."
@@ -1642,6 +1657,8 @@ class Censored:
                 dist.create_likelihood_variable("y", mu=mu, observed=observed)
 
         """
+        _check_observed(observed, xdist)
+
         if "mu" not in _get_pymc_parameters(self.distribution.pymc_distribution):
             raise UnsupportedDistributionError(
                 f"Likelihood distribution {self.distribution.distribution!r} is not supported."

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1410,7 +1410,7 @@ class TestXDist:
         assert equivalent_models(obs_m, expected_obs_m)
 
     def test_xdist_likelihood_requires_observed(self):
-        """observed=None is refused on the xdist path, and left alone off it."""
+        """observed=None raises on the xdist path and warns off it."""
 
         coords = {"city": range(3)}
         normal = Prior("Normal", sigma=1, dims=("city",))
@@ -1424,9 +1424,13 @@ class TestXDist:
                     dist.create_likelihood_variable("x", mu=mu, observed=None, xdist=True)
 
         with pm.Model(coords=coords) as legacy:
-            normal.create_likelihood_variable("x", mu=pt.as_tensor([1, 2, 3]), observed=None)
+            mu = pt.as_tensor([1, 2, 3])
+            with pytest.warns(FutureWarning, match=match):
+                normal.create_likelihood_variable("x", mu=mu, observed=None)
+            with pytest.warns(FutureWarning, match=match):
+                censored.create_likelihood_variable("x2", mu=mu, observed=None)
 
-        assert [rv.name for rv in legacy.free_RVs] == ["x"]
+        assert [rv.name for rv in legacy.free_RVs] == ["x", "x2"]
 
     def test_dims(self) -> None:
         assert Prior("Normal").dims is None

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -1412,6 +1412,26 @@ class TestXDist:
 
         assert equivalent_models(obs_m, expected_obs_m)
 
+    def test_xdist_likelihood_requires_observed(self):
+        """observed=None is refused on the xdist path, and left alone off it."""
+        import pymc.dims as pmd
+
+        coords = {"city": range(3)}
+        normal = Prior("Normal", sigma=1, dims=("city",))
+        censored = Censored(normal, lower=0)
+        match = "observed cannot be None"
+
+        with pm.Model(coords=coords):
+            mu = pmd.as_xtensor([1, 2, 3], dims=("city",))
+            for dist in (normal, censored):
+                with pytest.raises(ValueError, match=match):
+                    dist.create_likelihood_variable("x", mu=mu, observed=None, xdist=True)
+
+        with pm.Model(coords=coords) as legacy:
+            normal.create_likelihood_variable("x", mu=pt.as_tensor([1, 2, 3]), observed=None)
+
+        assert [rv.name for rv in legacy.free_RVs] == ["x"]
+
     def test_dims(self) -> None:
         assert Prior("Normal").dims is None
         assert Prior("Normal", dims=()).dims == ()

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -2,6 +2,7 @@ from copy import deepcopy
 
 import numpy as np
 import pymc as pm
+import pymc.dims as pmd
 import pytensor
 import pytensor.tensor as pt
 import pytest
@@ -1273,7 +1274,6 @@ class TestCensored:
         "ignore:The `pymc.dims` module is experimental and may contain critical bugs"
     )
     def test_censored_xdist(self):
-        import pymc.dims as pmd
 
         coords = {
             "batch": range(2),
@@ -1309,7 +1309,6 @@ class TestCensored:
 )
 class TestXDist:
     def test_xdist_serialization(self):
-        import pymc.dims as pmd
 
         mu = pmd.as_xtensor([1, 2, 3], dims=("city",))
         sigma = DataArray([4, 5], dims=("country",))
@@ -1349,7 +1348,6 @@ class TestXDist:
 
     @pytest.mark.parametrize("transform", (None, "exp"))
     def test_xdist_prior(self, transform):
-        import pymc.dims as pmd
 
         mu = pmd.as_xtensor([1, 2, 3], dims=("city",))
         sigma = DataArray([4, 5], dims=("country",))
@@ -1385,7 +1383,6 @@ class TestXDist:
         assert equivalent_models(prior_m, expected_prior_m)
 
     def test_xdist_likelihood(self):
-        import pymc.dims as pmd
 
         mu = pmd.as_xtensor([1, 2, 3], dims=("city",))
         sigma = DataArray([4, 5], dims=("country",))
@@ -1414,7 +1411,6 @@ class TestXDist:
 
     def test_xdist_likelihood_requires_observed(self):
         """observed=None is refused on the xdist path, and left alone off it."""
-        import pymc.dims as pmd
 
         coords = {"city": range(3)}
         normal = Prior("Normal", sigma=1, dims=("city",))
@@ -1481,8 +1477,6 @@ class TestXDist:
                 p_wo_dims.create_variable("v", xdist=True)
 
     def test_core_dims(self):
-        from pymc.dims import ZeroSumNormal
-
         coords = {"country": range(3), "city": range(4)}
 
         prior = Prior("ZeroSumNormal", sigma=np.pi, core_dims=("city",), dims=("country", "city"))
@@ -1490,7 +1484,7 @@ class TestXDist:
             prior.create_variable("x", xdist=True)
 
         with pm.Model(coords=coords) as ref_m:
-            ZeroSumNormal("x", sigma=np.pi, core_dims=("city",), dims=("country", "city"))
+            pmd.ZeroSumNormal("x", sigma=np.pi, core_dims=("city",), dims=("country", "city"))
 
         # This fails because SymbolicRandomVariable (which ZeroSumNormal is), doesn't have `__eq__` implemented
         # assert equivalent_models(m, ref_m)


### PR DESCRIPTION
Closes #731

`Prior.create_likelihood_variable("y", mu=mu, observed=None, xdist=True)` raised `AttributeError: 'NoneType' object has no attribute 'ndim'` out of `_param_value_with_dims`, while `Censored` on both paths and `Prior` with `xdist=False` built an unobserved variable.

With `xdist=True` it now raises `ValueError` pointing at `create_variable`. Without `xdist` it still builds but emits a `FutureWarning`, so that path can start raising after a deprecation period.

One test in `TestXDist` covering `Prior` and `Censored`: both raise with `xdist=True`, both warn and still build without it. `tests/test_prior.py` is 111 passed, 2 skipped.
