### PR TITLE
Fix sample_statespace_matrices and give it tests

### DIFF
--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -463,11 +463,11 @@ def sample_filter_outputs(
     if filter_output_names is None:
         filter_output_names = list(FILTER_OUTPUT_DIMS.keys())
     else:
-        unknown_filter_output_names = np.setdiff1d(
-            filter_output_names, list(FILTER_OUTPUT_DIMS.keys())
-        )
-        if unknown_filter_output_names.size > 0:
-            raise ValueError(f"{unknown_filter_output_names} not a valid filter output name!")
+        unknown_filter_output_names = set(filter_output_names).difference(FILTER_OUTPUT_DIMS)
+        if unknown_filter_output_names:
+            raise ValueError(
+                f"{sorted(unknown_filter_output_names)} not a valid filter output name!"
+            )
         filter_output_names = [x for x in FILTER_OUTPUT_DIMS.keys() if x in filter_output_names]
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -19,6 +19,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     FILTER_OUTPUT_DIMS,
     FILTER_OUTPUT_TYPES,
+    LONG_MATRIX_NAMES,
     MATRIX_DIMS,
     MATRIX_NAMES,
     OBS_STATE_DIM,
@@ -403,7 +404,7 @@ def sample_unconditional_posterior(
 def sample_statespace_matrices(
     ss_mod: "PyMCStateSpace",
     idata,
-    matrix_names: str | list[str] | None,
+    matrix_names: str | list[str] | None = None,
     group: str = "posterior",
     **kwargs,
 ):
@@ -413,7 +414,8 @@ def sample_statespace_matrices(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     if matrix_names is None:
-        matrix_names = MATRIX_NAMES
+        # Not the short names: x0 and P0 collide with parameters most models declare.
+        matrix_names = LONG_MATRIX_NAMES
     elif isinstance(matrix_names, str):
         matrix_names = [matrix_names]
 

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -422,15 +422,19 @@ def sample_statespace_matrices(
         ss_mod._insert_random_variables()
 
         for name in ss_mod.data_names:
-            pm.Data(**ss_mod.data_info[name])
+            pm.Data(**ss_mod._fit_exog_data[name])
 
         ss_mod._insert_data_variables()
         matrices = ss_mod.unpack_statespace()
-        for short_name, matrix in zip(MATRIX_NAMES, matrices):
+        for short_name, matrix in zip(MATRIX_NAMES, matrices, strict=True):
             long_name = SHORT_NAME_TO_LONG[short_name]
             if (long_name in matrix_names) or (short_name in matrix_names):
                 name = long_name if long_name in matrix_names else short_name
-                dims = [x if x in ss_mod._fit_coords else None for x in MATRIX_DIMS[short_name]]
+                matrix_dims = MATRIX_DIMS[short_name]
+                if matrix.ndim == len(matrix_dims) + 1:
+                    # A time-varying matrix carries a leading time axis its static dims do not name.
+                    matrix_dims = (TIME_DIM, *matrix_dims)
+                dims = [x if x in ss_mod._fit_coords else None for x in matrix_dims]
                 pm.Deterministic(name, matrix, dims=dims)
 
     # TODO: Remove this after pm.Flat has its initial_value fixed

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -413,11 +413,16 @@ def sample_statespace_matrices(
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
+    if isinstance(matrix_names, str):
+        matrix_names = [matrix_names]
+
     if matrix_names is None:
         # Not the short names: x0 and P0 collide with parameters most models declare.
         matrix_names = LONG_MATRIX_NAMES
-    elif isinstance(matrix_names, str):
-        matrix_names = [matrix_names]
+    else:
+        unknown_matrix_names = set(matrix_names).difference(MATRIX_NAMES, LONG_MATRIX_NAMES)
+        if unknown_matrix_names:
+            raise ValueError(f"{sorted(unknown_matrix_names)} not a valid statespace matrix name!")
 
     with pm.Model(coords=ss_mod._fit_coords) as forward_model:
         dummy_graph.build_dummy_graph(ss_mod)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1289,26 +1289,33 @@ class PyMCStateSpace:
         **kwargs,
     ):
         """
-        Draw samples of requested statespace matrices from provided idata
+        Draw samples of the statespace matrices implied by a model's parameter draws.
 
         Parameters
         ----------
-        matrix_names: str, list[str], optional
-            Statespace matrices to be sampled. Valid names are short names: x0, P0, c, d, T, Z, R, H, Q, or
-             "formal" names: initial_state, initial_state_cov, state_intercept, obs_intercept, transition, design,
-                             selection, obs_cov, state_cov
-        idata: DataTree
-            DataTree from which to sample
-
-        group: str, one of "posterior" or "prior"
-            Whether to sample from priors or posteriors
-
-        kwargs:
-            Additional keyword arguments are passed to ``pymc.sample_posterior_predictive``
+        idata : DataTree
+            Sampling results holding the parameter draws the matrices are built from.
+        matrix_names : str or list of str, optional
+            Matrices to sample, as short names (``x0``, ``P0``, ``c``, ``d``, ``T``, ``Z``, ``R``, ``H``, ``Q``)
+            or long names (``initial_state``, ``initial_state_cov``, ``state_intercept``, ``obs_intercept``,
+            ``transition``, ``design``, ``selection``, ``obs_cov``, ``state_cov``). Each sampled matrix takes the
+            name it was requested by, so short names can collide with model parameters called ``x0`` or ``P0``.
+            Default None, which samples every matrix under its long name.
+        group : str, optional
+            Which group of ``idata`` to draw from, ``"posterior"`` or ``"prior"``. Default "posterior".
+        **kwargs
+            Additional keyword arguments are passed to :func:`pymc.sample_posterior_predictive`.
 
         Returns
         -------
-        idata_matrices: az.InterenceData
+        idata_matrices : DataTree
+            Sampled matrices, in the ``posterior_predictive`` group. A time-varying matrix carries a leading
+            time dimension; the others carry only the dimensions declared for them.
+
+        Raises
+        ------
+        ValueError
+            If any requested name is neither a short nor a long statespace matrix name.
         """
         return forward_sampling.sample_statespace_matrices(
             self, idata, matrix_names=matrix_names, group=group, **kwargs
@@ -1321,6 +1328,27 @@ class PyMCStateSpace:
         group: str = "posterior",
         **kwargs,
     ):
+        """
+        Draw samples of the Kalman filter and smoother outputs from a model's parameter draws.
+
+        Parameters
+        ----------
+        idata : DataTree
+            Sampling results holding the parameter draws the outputs are computed from.
+        filter_output_names : str or list of str, optional
+            Which outputs to sample: ``filtered_states``, ``predicted_states``, ``smoothed_states``, each of
+            their ``_covariances`` counterparts, and ``predicted_observed_states`` with
+            ``predicted_observed_covariances``. Default None, which samples all of them.
+        group : str, optional
+            Which group of ``idata`` to draw from, ``"posterior"`` or ``"prior"``. Default "posterior".
+        **kwargs
+            Additional keyword arguments are passed to :func:`pymc.sample_posterior_predictive`.
+
+        Returns
+        -------
+        idata_filter_outputs : DataTree
+            Sampled outputs, in the ``posterior_predictive`` group.
+        """
         return forward_sampling.sample_filter_outputs(
             self,
             idata,

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1282,7 +1282,11 @@ class PyMCStateSpace:
         )
 
     def sample_statespace_matrices(
-        self, idata, matrix_names: str | list[str] | None, group: str = "posterior", **kwargs
+        self,
+        idata,
+        matrix_names: str | list[str] | None = None,
+        group: str = "posterior",
+        **kwargs,
     ):
         """
         Draw samples of requested statespace matrices from provided idata

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -243,3 +243,15 @@ def test_sample_statespace_matrices_defaults_to_every_matrix(mod_name, idata_nam
     ).posterior_predictive
 
     assert set(sampled.data_vars) == set(LONG_MATRIX_NAMES)
+
+
+def test_sample_statespace_matrices_rejects_unknown_names(ss_mod, idata):
+    """A mistyped name fails naming itself, rather than as a KeyError from inside pymc."""
+    with pytest.raises(ValueError, match="not a valid statespace matrix name"):
+        ss_mod.sample_statespace_matrices(idata, matrix_names="tranistion", group="prior")
+
+    # A valid name alongside an invalid one must not mask the mistake.
+    with pytest.raises(ValueError, match="not a valid statespace matrix name"):
+        ss_mod.sample_statespace_matrices(
+            idata, matrix_names=["transition", "bogus"], group="prior"
+        )

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -224,3 +224,22 @@ def test_sample_statespace_matrices_keeps_its_dims(exog_ss_mod, idata_exog):
 
         assert sampled[long_name].dims == expected, f"{long_name} lost its dims"
         assert np.all(np.isfinite(sampled[long_name].values)), f"{long_name} is not finite"
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values")
+@pytest.mark.filterwarnings("ignore:No frequency was specific on the data's DateTimeIndex.")
+@pytest.mark.parametrize(
+    "mod_name, idata_name",
+    [("ss_mod", "idata"), ("exog_ss_mod", "idata_exog")],
+    ids=["no_exog", "with_exog"],
+)
+def test_sample_statespace_matrices_defaults_to_every_matrix(mod_name, idata_name, request):
+    """The default names must not collide with the x0 and P0 parameters models declare."""
+    ss_mod = request.getfixturevalue(mod_name)
+    idata = request.getfixturevalue(idata_name)
+
+    sampled = ss_mod.sample_statespace_matrices(
+        idata, matrix_names=None, group="prior"
+    ).posterior_predictive
+
+    assert set(sampled.data_vars) == set(LONG_MATRIX_NAMES)

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -119,7 +119,7 @@ def test_sample_filter_outputs(rng, exog_ss_mod, idata_exog):
 
     assert missing_outputs.size == 0
 
-    msg = "['filter_covariances' 'filter_states'] not a valid filter output name!"
+    msg = "['filter_covariances', 'filter_states'] not a valid filter output name!"
     incorrect_outputs = ["filter_states", "filter_covariances"]
     with pytest.raises(ValueError, match=re.escape(msg)):
         exog_ss_mod.sample_filter_outputs(idata_exog, filter_output_names=incorrect_outputs)

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -8,7 +8,13 @@ import pytest
 from numpy.testing import assert_allclose
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
-from pymc_extras.statespace.utils.constants import MATRIX_NAMES
+from pymc_extras.statespace.utils.constants import (
+    LONG_MATRIX_NAMES,
+    MATRIX_DIMS,
+    MATRIX_NAMES,
+    SHORT_NAME_TO_LONG,
+    TIME_DIM,
+)
 
 
 @pytest.mark.parametrize("group", ["posterior", "prior"])
@@ -195,3 +201,26 @@ class TestTimeVaryingTransition:
         assert "irf" in result
         assert result["irf"].shape[2] == 20
         assert not np.any(np.isnan(result["irf"].values))
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values")
+@pytest.mark.filterwarnings("ignore:No frequency was specific on the data's DateTimeIndex.")
+def test_sample_statespace_matrices_keeps_its_dims(exog_ss_mod, idata_exog):
+    """Every sampled matrix carries the dims MATRIX_DIMS declares for it.
+
+    The dims are looked up against the fit coords and silently become ``None`` for any coord that is
+    missing, so a coord regression would degrade the output rather than fail.
+    """
+    matrix_idata = exog_ss_mod.sample_statespace_matrices(
+        idata_exog, matrix_names=LONG_MATRIX_NAMES, group="prior"
+    )
+    sampled = matrix_idata.posterior_predictive
+
+    for short_name in MATRIX_NAMES:
+        long_name = SHORT_NAME_TO_LONG[short_name]
+        expected = ("chain", "draw", *MATRIX_DIMS[short_name])
+        if long_name in exog_ss_mod.ssm.time_varying_names:
+            expected = ("chain", "draw", TIME_DIM, *MATRIX_DIMS[short_name])
+
+        assert sampled[long_name].dims == expected, f"{long_name} lost its dims"
+        assert np.all(np.isfinite(sampled[long_name].values)), f"{long_name} is not finite"


### PR DESCRIPTION
`sample_statespace_matrices` had no tests, and it turned out to raise in three separate configurations: exogenous models, time-varying matrices, and the default argument — which registered `x0` and `P0`, colliding with the parameters most models declare. The default is now the long names, so `mod.sample_statespace_matrices(idata)` works.

Unknown names raised a bare `KeyError` from inside `sample_posterior_predictive`; now a `ValueError` naming them, matching `sample_filter_outputs` right below.
