### PR TITLE
Build the shared-states design matrix explicitly

### DIFF
--- a/pymc_extras/statespace/models/structural/components/cycle.py
+++ b/pymc_extras/statespace/models/structural/components/cycle.py
@@ -306,8 +306,11 @@ class Cycle(Component):
         k_endog_effective = 1 if self.share_states else k_endog
 
         Z = np.array([1.0, 0.0]).reshape((1, -1))
-        design_matrix = block_diag(*[Z for _ in range(k_endog_effective)])
-        self.ssm["design", :, :] = pt.as_tensor_variable(design_matrix)
+        if self.share_states:
+            # Shared states: every series observes the same cycle.
+            self.ssm["design"] = pt.join(0, *[Z for _ in range(k_endog)])
+        else:
+            self.ssm["design"] = block_diag(*[Z for _ in range(k_endog_effective)])
 
         # selection matrix R defines structure of innovations (always identity for cycle components)
         # when innovations=False, state cov Q=0, hence R @ Q @ R.T = 0

--- a/pymc_extras/statespace/models/structural/components/level_trend.py
+++ b/pymc_extras/statespace/models/structural/components/level_trend.py
@@ -306,9 +306,9 @@ class LevelTrend(Component):
         Z = np.array([1.0] + [0.0] * (k_states - 1)).reshape((1, -1))
 
         if self.share_states:
-            self.ssm["design", :, :] = pt.join(0, *[Z for _ in range(k_endog)])
+            self.ssm["design"] = pt.join(0, *[Z for _ in range(k_endog)])
         else:
-            self.ssm["design", :, :] = pt.linalg.block_diag(*[Z for _ in range(k_endog)])
+            self.ssm["design"] = pt.linalg.block_diag(*[Z for _ in range(k_endog)])
 
         if k_posdef > 0:
             sigma_trend = self.make_and_register_variable(

--- a/pymc_extras/statespace/models/structural/components/seasonality.py
+++ b/pymc_extras/statespace/models/structural/components/seasonality.py
@@ -484,6 +484,9 @@ class TimeSeasonality(Component):
         k_states = self._k_states_per_endog()
         k_endog_effective = self._k_endog_effective()
         Z = pt.zeros((1, k_states))[0, 0].set(1)
+        if self.share_states:
+            # Shared states: every series observes the same seasonal states.
+            return pt.join(0, *[Z for _ in range(self.k_endog)])
         return pt.linalg.block_diag(*[Z for _ in range(k_endog_effective)])
 
     def _build_initial_state_dk(self, initial_params: TensorVariable) -> TensorVariable:
@@ -595,7 +598,7 @@ class TimeSeasonality(Component):
             self.ssm["transition", :, :] = T
 
         # Design matrix
-        self.ssm["design", :, :] = self._build_design_matrix()
+        self.ssm["design"] = self._build_design_matrix()
 
         # Initial state parameters
         initial_params = self.make_and_register_variable(
@@ -817,7 +820,11 @@ class FrequencySeasonality(Component):
 
         Z = pt.zeros((1, k_states))[0, slice(0, k_states, 2)].set(1.0)
 
-        self.ssm["design", :, :] = pt.linalg.block_diag(*[Z for _ in range(k_endog_effective)])
+        if self.share_states:
+            # Shared states: every series observes the same frequency states.
+            self.ssm["design"] = pt.join(0, *[Z for _ in range(k_endog)])
+        else:
+            self.ssm["design"] = pt.linalg.block_diag(*[Z for _ in range(k_endog_effective)])
 
         init_state = self.make_and_register_variable(
             f"params_{self.name}", shape=(n_coefs,) if k_endog == 1 else (k_endog, n_coefs)


### PR DESCRIPTION
With shared states, `Cycle`, `TimeSeasonality` and `FrequencySeasonality` built a single `(1, k_states)` design row and let `set_subtensor` broadcast it across the observed series. They build the full matrix now, so the design can be assigned whole and actually gets shape-checked.
