### PR TITLE
Untangle PytensorRepresentation and assign matrices whole

### DIFF
--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -300,7 +300,8 @@ class PytensorRepresentation:
             self._validate_name(name)
             existing = getattr(self, name)
             updated = pt.set_subtensor(existing[tuple(idx)], value)
-            updated.name = name
+            updated.name = existing.name
+            updated.tag = copy.copy(existing.tag)
             setattr(self, name, updated)
             return
 

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -239,8 +239,12 @@ class PytensorRepresentation:
         elif isinstance(value, int | float):
             tensor = pt.as_tensor_variable(np.asarray(value, dtype=floatX), name=name)
         else:
-            tensor = pt.as_tensor_variable(value)
-            tensor.name = name
+            # Name a derived variable, never the caller's own: model parameters are looked up by
+            # name, so renaming one here would quietly break that lookup. ``copy`` drops tags, so
+            # carry them across by hand.
+            given = pt.as_tensor_variable(value)
+            tensor = given.copy(name=name)
+            tensor.tag = copy.copy(given.tag)
 
         if tensor.ndim < core_ndim:
             raise ValueError(

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -310,14 +310,3 @@ class PytensorRepresentation:
             return
 
         raise IndexError("First index must the name of a valid state space matrix.")
-
-    def __copy__(self) -> "PytensorRepresentation":
-        new = self.__class__.__new__(self.__class__)
-        for slot in self.__slots__:
-            setattr(new, slot, getattr(self, slot))
-        new._time_varying_names = set(self._time_varying_names)
-        return new
-
-    def copy(self) -> "PytensorRepresentation":
-        """Return a copy sharing this object's matrix graphs but owning its time-varying names."""
-        return copy.copy(self)

--- a/pymc_extras/statespace/models/DFM.py
+++ b/pymc_extras/statespace/models/DFM.py
@@ -564,18 +564,18 @@ class BayesianDynamicFactor(PyMCStateSpace):
         else:
             x0 = self.make_and_register_variable("x0", shape=(self.k_states,), dtype=floatX)
 
-        self.ssm["initial_state", :] = x0
+        self.ssm["initial_state"] = x0
 
         P0 = self.make_and_register_variable(
             "P0", shape=(self.k_states, self.k_states), dtype=floatX
         )
-        self.ssm["initial_state_cov", :, :] = P0
+        self.ssm["initial_state_cov"] = P0
 
         self.ssm["design"] = self._build_design_matrix()
         if self.has_exog:
             self.ssm.declare_time_varying("design")
 
-        self.ssm["transition", :, :] = pt.linalg.block_diag(*self._build_transition_blocks())
+        self.ssm["transition"] = pt.linalg.block_diag(*self._build_transition_blocks())
 
         self._build_selection_matrix()
 
@@ -736,7 +736,7 @@ class BayesianDynamicFactor(PyMCStateSpace):
             else:
                 blocks.append(pt.zeros((self.k_exog_states, self.k_exog_states), dtype=floatX))
 
-        self.ssm["state_cov", :, :] = pt.linalg.block_diag(*blocks)
+        self.ssm["state_cov"] = pt.linalg.block_diag(*blocks)
 
     def _build_obs_cov(self, error_cov) -> None:
         r"""Build the observation covariance :math:`H`."""
@@ -752,4 +752,4 @@ class BayesianDynamicFactor(PyMCStateSpace):
             )
             obs_cov = obs_cov + pt.diag(sigma_obs**2)
 
-        self.ssm["obs_cov", :, :] = obs_cov
+        self.ssm["obs_cov"] = obs_cov

--- a/pymc_extras/statespace/models/ETS.py
+++ b/pymc_extras/statespace/models/ETS.py
@@ -684,18 +684,16 @@ class BayesianETS(PyMCStateSpace):
             self.ssm["state_cov"] = state_cov
 
         else:
-            state_cov_idx = ("state_cov", *np.diag_indices(self.k_posdef))
-            state_cov = self.make_and_register_variable(
+            sigma_state = self.make_and_register_variable(
                 "sigma_state", shape=() if self.k_posdef == 1 else (self.k_posdef,), dtype=floatX
             )
-            self.ssm[state_cov_idx] = state_cov**2
+            self.ssm["state_cov"] = pt.diag(pt.atleast_1d(sigma_state**2))
 
         if self.measurement_error:
-            obs_cov_idx = ("obs_cov", *np.diag_indices(self.k_endog))
-            obs_cov = self.make_and_register_variable(
+            sigma_obs = self.make_and_register_variable(
                 "sigma_obs", shape=() if self.k_endog == 1 else (self.k_endog,), dtype=floatX
             )
-            self.ssm[obs_cov_idx] = obs_cov**2
+            self.ssm["obs_cov"] = pt.diag(pt.atleast_1d(sigma_obs**2))
 
         if self.stationary_initialization:
             T_stationary = graph_replace(T, {stationary_dampening: self.initialization_dampening})

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -507,7 +507,7 @@ class BayesianSARIMAX(PyMCStateSpace):
                 "P0", shape=(self.k_states, self.k_states), dtype=floatX
             )
 
-            self.ssm["initial_state", :] = x0
+            self.ssm["initial_state"] = x0
             self.ssm["initial_state_cov"] = P0
 
         # Design matrix has no RVs
@@ -646,5 +646,5 @@ class BayesianSARIMAX(PyMCStateSpace):
         # on c, T, R and Q
         if self.stationary_initialization:
             x0, P0 = self._stationary_initialization()
-            self.ssm["initial_state", :] = x0
-            self.ssm["initial_state_cov", :, :] = P0
+            self.ssm["initial_state"] = x0
+            self.ssm["initial_state_cov"] = P0

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -34,6 +34,49 @@ from pymc_extras.statespace.utils.constants import (
 )
 
 
+def _fill_axis(
+    base: np.ndarray,
+    index: int,
+    positions: Sequence[np.ndarray],
+    values: Sequence[pt.TensorVariable],
+    axis: int,
+) -> pt.TensorVariable:
+    """
+    Write ``values`` into one row or column of ``base``, in a single assignment.
+
+    Parameters
+    ----------
+    base : ndarray
+        Constant matrix the parameters are written into.
+    index : int
+        Row (``axis=0``) or column (``axis=1``) receiving the values.
+    positions : sequence of ndarray
+        Index arrays giving the offsets along the other axis, one per block of values.
+    values : sequence of TensorVariable
+        Parameter blocks, aligned with ``positions``.
+    axis : int
+        0 to fill a row, 1 to fill a column.
+
+    Returns
+    -------
+    filled : TensorVariable
+        ``base`` with the parameters written in.
+    """
+    base = pt.as_tensor_variable(base)
+    if not values:
+        return base
+
+    offsets = np.concatenate(positions)
+    # Blocks write to disjoint lags -- ``_verify_order`` rejects the orders that would overlap --
+    # so one assignment is equivalent to writing each block in turn.
+    assert len(np.unique(offsets)) == len(offsets), "parameter blocks overlap"
+
+    block = pt.concatenate([pt.atleast_1d(value) for value in values])
+    key = (index, offsets) if axis == 0 else (offsets, index)
+
+    return pt.set_subtensor(base[key], block)
+
+
 def _verify_order(p, d, q, P, D, Q, S):
     for name, terms in zip(["AR", "MA"], [(p, P), (q, Q)]):
         a, A = terms
@@ -480,112 +523,99 @@ class BayesianSARIMAX(PyMCStateSpace):
                 [0] * self._k_diffs, [1.0], np.zeros(self.k_states - self._k_diffs - 1)
             ][:, None]
 
-            ar_param_idx = np.s_[
-                "transition", self._k_diffs : self._k_diffs + self.p, self._k_diffs
-            ]
-            ma_param_idx = np.s_["selection", 1 + self._k_diffs : 1 + self._k_diffs + self.q, 0]
-
-            self.ssm["transition"] = transition
-            self.ssm["selection"] = selection
+            ar_rows, ar_values = [], []
+            ma_rows, ma_values = [], []
 
             if p > 0:
                 ar_params = self.make_and_register_variable("ar_params", shape=(p,), dtype=floatX)
-                self.ssm[ar_param_idx] = ar_params
+                ar_rows.append(np.arange(self._k_diffs, self._k_diffs + p))
+                ar_values.append(ar_params)
 
             if P > 0:
                 seasonal_ar_params = self.make_and_register_variable(
                     "seasonal_ar_params", shape=(P,), dtype=floatX
                 )
                 idx_rows = self._k_diffs + (np.arange(1, P + 1) * S) - 1
-                S_ar_param_idx = np.s_["transition", idx_rows, self._k_diffs]
-                self.ssm[S_ar_param_idx] = seasonal_ar_params
+                ar_rows.append(idx_rows)
+                ar_values.append(seasonal_ar_params)
 
                 if p > 0:
-                    cross_term_idx = np.s_[
-                        "transition",
-                        idx_rows.repeat(p) + np.tile(np.arange(p), P) + 1,
-                        self._k_diffs,
-                    ]
-                    self.ssm[cross_term_idx] = -pt.repeat(seasonal_ar_params, p) * pt.tile(
-                        ar_params, P
-                    )
+                    ar_rows.append(idx_rows.repeat(p) + np.tile(np.arange(p), P) + 1)
+                    ar_values.append(-pt.repeat(seasonal_ar_params, p) * pt.tile(ar_params, P))
 
             if q > 0:
                 ma_params = self.make_and_register_variable("ma_params", shape=(q,), dtype=floatX)
-                self.ssm[ma_param_idx] = ma_params
+                ma_rows.append(np.arange(1 + self._k_diffs, 1 + self._k_diffs + q))
+                ma_values.append(ma_params)
 
             if Q > 0:
                 seasonal_ma_params = self.make_and_register_variable(
                     "seasonal_ma_params", shape=(Q,), dtype=floatX
                 )
                 idx_rows = self._k_diffs + np.arange(1, Q + 1) * S
-                S_ma_param_idx = np.s_["selection", idx_rows, 0]
-                self.ssm[S_ma_param_idx] = seasonal_ma_params
+                ma_rows.append(idx_rows)
+                ma_values.append(seasonal_ma_params)
 
                 if q > 0:
-                    cross_term_idx = np.s_[
-                        "selection", idx_rows.repeat(q) + np.tile(np.arange(q), Q) + 1, 0
-                    ]
-                    self.ssm[cross_term_idx] = pt.repeat(seasonal_ma_params, q) * pt.tile(
-                        ma_params, Q
-                    )
+                    ma_rows.append(idx_rows.repeat(q) + np.tile(np.arange(q), Q) + 1)
+                    ma_values.append(pt.repeat(seasonal_ma_params, q) * pt.tile(ma_params, Q))
+
+            # Every AR term lands in one column of T, and every MA term in one column of R.
+            self.ssm["transition"] = _fill_axis(
+                transition, self._k_diffs, ar_rows, ar_values, axis=1
+            )
+            self.ssm["selection"] = _fill_axis(selection, 0, ma_rows, ma_values, axis=1)
 
         elif self.state_structure == "interpretable":
-            ar_param_idx = np.s_["transition", 0, : max(1, p)]
-            ma_param_idx = np.s_["transition", 0, self._p_max : self._p_max + max(1, q)]
-
             transition = np.eye(self.k_states, k=-1)
             transition[-self._q_max, self._p_max - 1] = 0
 
             selection = np.r_[[1.0], np.zeros(self.k_states - 1)][:, None]
             selection[-self._q_max, 0] = 1
 
-            self.ssm["transition"] = transition
-            self.ssm["selection"] = selection
+            param_cols, param_values = [], []
 
             if self.p > 0:
                 ar_params = self.make_and_register_variable(
                     "ar_params", shape=(self.p,), dtype=floatX
                 )
-                self.ssm[ar_param_idx] = ar_params
+                param_cols.append(np.arange(max(1, p)))
+                param_values.append(ar_params)
 
             if self.P > 0:
                 seasonal_ar_params = self.make_and_register_variable(
                     "seasonal_ar_params", shape=(P,), dtype=floatX
                 )
                 idx_cols = np.arange(1, P + 1) * S - 1
-                S_ar_param_idx = np.s_["transition", 0, idx_cols]
-                self.ssm[S_ar_param_idx] = seasonal_ar_params
+                param_cols.append(idx_cols)
+                param_values.append(seasonal_ar_params)
 
                 if p > 0:
-                    cross_term_idx = np.s_[
-                        "transition", 0, idx_cols.repeat(p) + np.tile(np.arange(p), P) + 1
-                    ]
-                    self.ssm[cross_term_idx] = -pt.repeat(seasonal_ar_params, p) * pt.tile(
-                        ar_params, P
-                    )
+                    param_cols.append(idx_cols.repeat(p) + np.tile(np.arange(p), P) + 1)
+                    param_values.append(-pt.repeat(seasonal_ar_params, p) * pt.tile(ar_params, P))
 
             if self.q > 0:
                 ma_params = self.make_and_register_variable(
                     "ma_params", shape=(self.q,), dtype=floatX
                 )
-                self.ssm[ma_param_idx] = ma_params
+                param_cols.append(np.arange(self._p_max, self._p_max + max(1, q)))
+                param_values.append(ma_params)
 
             if Q > 0:
                 seasonal_ma_params = self.make_and_register_variable(
                     "seasonal_ma_params", shape=(Q,), dtype=floatX
                 )
                 idx_cols = self._p_max + np.arange(1, Q + 1) * S - 1
-                S_ma_param_idx = np.s_["transition", 0, idx_cols]
-                self.ssm[S_ma_param_idx] = seasonal_ma_params
+                param_cols.append(idx_cols)
+                param_values.append(seasonal_ma_params)
 
                 if q > 0:
-                    cross_term_idx = np.s_[
-                        "transition", 0, idx_cols.repeat(q) + np.tile(np.arange(q), Q) + 1
-                    ]
-                    self.ssm[cross_term_idx] = pt.repeat(seasonal_ma_params, q) * pt.tile(
-                        ma_params, Q
-                    )
+                    param_cols.append(idx_cols.repeat(q) + np.tile(np.arange(q), Q) + 1)
+                    param_values.append(pt.repeat(seasonal_ma_params, q) * pt.tile(ma_params, Q))
+
+            # In this parameterization every AR and MA term lands in the first row of T.
+            self.ssm["transition"] = _fill_axis(transition, 0, param_cols, param_values, axis=0)
+            self.ssm["selection"] = selection
 
         # If exogenous regressors are present, register them as data and include a regression term
         # in the observation intercept
@@ -601,18 +631,16 @@ class BayesianSARIMAX(PyMCStateSpace):
             self.ssm.declare_time_varying("obs_intercept")
 
         # Set up the state covariance matrix
-        state_cov_idx = ("state_cov", *np.diag_indices(self.k_posdef))
         state_cov = self.make_and_register_variable(
             "sigma_state", shape=() if self.k_posdef == 1 else (self.k_posdef,), dtype=floatX
         )
-        self.ssm[state_cov_idx] = state_cov**2
+        self.ssm["state_cov"] = pt.diag(pt.atleast_1d(state_cov**2))
 
         if self.measurement_error:
-            obs_cov_idx = ("obs_cov", *np.diag_indices(self.k_endog))
             obs_cov = self.make_and_register_variable(
                 "sigma_obs", shape=() if self.k_endog == 1 else (self.k_endog,), dtype=floatX
             )
-            self.ssm[obs_cov_idx] = obs_cov**2
+            self.ssm["obs_cov"] = pt.diag(pt.atleast_1d(obs_cov**2))
 
         # The initial conditions have to be done last in the case of stationary initialization, because it will depend
         # on c, T, R and Q

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -465,7 +465,7 @@ class BayesianVARMAX(PyMCStateSpace):
             sigma_obs = self.make_and_register_variable(
                 "sigma_obs", shape=(self.k_endog,), dtype=floatX
             )
-            self.ssm["obs_cov"] = pt.diag(sigma_obs)
+            self.ssm["obs_cov"] = pt.diag(sigma_obs**2)
 
         state_cov = self.make_and_register_variable(
             "state_cov", shape=(self.k_posdef, self.k_posdef), dtype=floatX

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -405,7 +405,8 @@ class BayesianVARMAX(PyMCStateSpace):
             )
             self.ssm["initial_state_cov", :, :] = P0
 
-        # Design matrix is a truncated identity (first k_obs states observed)
+        # Design matrix is a truncated identity (first k_obs states observed). Written as an
+        # indexed update rather than a whole matrix because of #736.
         self.ssm[("design", *np.diag_indices(self.k_endog))] = 1
 
         # Transition matrix has 4 blocks:
@@ -413,24 +414,20 @@ class BayesianVARMAX(PyMCStateSpace):
         # Upper right: MA coefs (k_obs, k_obs * q)
         # Lower left: Truncated identity (k_obs * min(p, 1), k_obs * min(p, 1))
         # Lower right: Shifted identity (k_obs * p, k_obs * q)
-        self.ssm["transition"] = np.zeros((self.k_states, self.k_states))
+        transition = np.zeros((self.k_states, self.k_states))
         if self.p > 1:
-            idx = (
-                slice(self.k_endog, self.k_endog * self.p),
-                slice(0, self.k_endog * (self.p - 1)),
+            transition[self.k_endog : self.k_endog * self.p, : self.k_endog * (self.p - 1)] = (
+                np.eye(self.k_endog * (self.p - 1))
             )
-            self.ssm[("transition", *idx)] = np.eye(self.k_endog * (self.p - 1))
 
         if self.q > 1:
-            idx = (
-                slice(-self.k_endog * (self.q - 1), None),
-                slice(-self.k_endog * self.q, -self.k_endog),
+            transition[-self.k_endog * (self.q - 1) :, -self.k_endog * self.q : -self.k_endog] = (
+                np.eye(self.k_endog * (self.q - 1))
             )
-            self.ssm[("transition", *idx)] = np.eye(self.k_endog * (self.q - 1))
+
+        transition = pt.as_tensor_variable(transition)
 
         if self.p > 0:
-            ar_param_idx = ("transition", slice(0, self.k_endog), slice(0, self.k_endog * self.p))
-
             # Register the AR parameter matrix as a (k, p, k), then reshape it and allocate it in the transition matrix
             # This way the user can use 3 dimensions in the prior (clearer?)
             ar_params = self.make_and_register_variable(
@@ -438,36 +435,37 @@ class BayesianVARMAX(PyMCStateSpace):
             )
 
             ar_params = ar_params.reshape((self.k_endog, self.k_endog * self.p))
-            self.ssm[ar_param_idx] = ar_params
-
-        # The selection matrix is (k_states, k_obs), with two (k_obs, k_obs) identity
-        # matrix blocks inside. One is always on top, the other starts after (k_obs * p) rows
-        self.ssm["selection"] = np.zeros((self.k_states, self.k_endog))
-        self.ssm["selection", slice(0, self.k_endog), :] = np.eye(self.k_endog)
-        if self.q > 0:
-            ma_param_idx = (
-                "transition",
-                slice(0, self.k_endog),
-                slice(self.k_endog * max(1, self.p), None),
+            transition = pt.set_subtensor(
+                transition[: self.k_endog, : self.k_endog * self.p], ar_params
             )
 
+        if self.q > 0:
             # Same as above, register with 3 dimensions then reshape
             ma_params = self.make_and_register_variable(
                 "ma_params", shape=(self.k_endog, self.q, self.k_endog), dtype=floatX
             )
 
             ma_params = ma_params.reshape((self.k_endog, self.k_endog * self.q))
-            self.ssm[ma_param_idx] = ma_params
+            transition = pt.set_subtensor(
+                transition[: self.k_endog, self.k_endog * max(1, self.p) :], ma_params
+            )
 
+        self.ssm["transition"] = transition
+
+        # The selection matrix is (k_states, k_obs), with two (k_obs, k_obs) identity
+        # matrix blocks inside. One is always on top, the other starts after (k_obs * p) rows
+        selection = np.zeros((self.k_states, self.k_endog))
+        selection[: self.k_endog, :] = np.eye(self.k_endog)
+        if self.q > 0:
             end = -self.k_endog * (self.q - 1) if self.q > 1 else None
-            self.ssm["selection", slice(self.k_endog * -self.q, end), :] = np.eye(self.k_endog)
+            selection[-self.k_endog * self.q : end, :] = np.eye(self.k_endog)
+        self.ssm["selection"] = selection
 
         if self.measurement_error:
-            obs_cov_idx = ("obs_cov", *np.diag_indices(self.k_endog))
             sigma_obs = self.make_and_register_variable(
                 "sigma_obs", shape=(self.k_endog,), dtype=floatX
             )
-            self.ssm[obs_cov_idx] = sigma_obs
+            self.ssm["obs_cov"] = pt.diag(sigma_obs)
 
         state_cov = self.make_and_register_variable(
             "state_cov", shape=(self.k_posdef, self.k_posdef), dtype=floatX

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -397,13 +397,13 @@ class BayesianVARMAX(PyMCStateSpace):
         if not self.stationary_initialization:
             # initial states
             x0 = self.make_and_register_variable("x0", shape=(self.k_states,), dtype=floatX)
-            self.ssm["initial_state", :] = x0
+            self.ssm["initial_state"] = x0
 
             # initial covariance
             P0 = self.make_and_register_variable(
                 "P0", shape=(self.k_states, self.k_states), dtype=floatX
             )
-            self.ssm["initial_state_cov", :, :] = P0
+            self.ssm["initial_state_cov"] = P0
 
         # Design matrix is a truncated identity (first k_obs states observed). Written as an
         # indexed update rather than a whole matrix because of #736.
@@ -470,7 +470,7 @@ class BayesianVARMAX(PyMCStateSpace):
         state_cov = self.make_and_register_variable(
             "state_cov", shape=(self.k_posdef, self.k_posdef), dtype=floatX
         )
-        self.ssm["state_cov", :, :] = state_cov
+        self.ssm["state_cov"] = state_cov
 
         if self.exog_state_names is not None:
             if isinstance(self.exog_state_names, list):
@@ -541,5 +541,5 @@ class BayesianVARMAX(PyMCStateSpace):
                 pt.linalg.matrix_dot(R, Q, R.T),
                 method="direct" if self.k_states < 10 else "bilinear",
             )
-            self.ssm["initial_state", :] = x0
-            self.ssm["initial_state_cov", :, :] = P0
+            self.ssm["initial_state"] = x0
+            self.ssm["initial_state_cov"] = P0

--- a/pymc_extras/statespace/models/structural/components/autoregressive.py
+++ b/pymc_extras/statespace/models/structural/components/autoregressive.py
@@ -192,7 +192,6 @@ class Autoregressive(Component):
         k_endog_effective = 1 if self.share_states else k_endog
 
         k_states = self.k_states // k_endog_effective
-        k_posdef = self.k_posdef
 
         k_nonzero = int(sum(self.order))
         ar_params = self.make_and_register_variable(
@@ -218,14 +217,14 @@ class Autoregressive(Component):
                 transition_matrices.append(T)
             T = pt.linalg.block_diag(*transition_matrices)
 
-        self.ssm["transition", :, :] = T
+        self.ssm["transition"] = T
 
         R = np.eye(k_states)
         R_mask = np.full((k_states,), False)
         R_mask[0] = True
         R = R[:, R_mask]
 
-        self.ssm["selection", :, :] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
+        self.ssm["selection"] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
 
         Zs = [pt.zeros((1, k_states))[0, 0].set(1.0) for _ in range(k_endog)]
 
@@ -233,10 +232,9 @@ class Autoregressive(Component):
             Z = pt.join(0, *Zs)
         else:
             Z = pt.linalg.block_diag(*Zs)
-        self.ssm["design", :, :] = Z
+        self.ssm["design"] = Z
 
-        cov_idx = ("state_cov", *np.diag_indices(k_posdef))
-        self.ssm[cov_idx] = sigma_ar**2
+        self.ssm["state_cov"] = pt.diag(pt.atleast_1d(sigma_ar**2))
 
 
 def __getattr__(name: str):

--- a/pymc_extras/statespace/models/structural/components/cycle.py
+++ b/pymc_extras/statespace/models/structural/components/cycle.py
@@ -313,13 +313,13 @@ class Cycle(Component):
         # when innovations=False, state cov Q=0, hence R @ Q @ R.T = 0
         R = np.eye(2)  # 2x2 identity for each cycle component
         selection_matrix = block_diag(*[R for _ in range(k_endog_effective)])
-        self.ssm["selection", :, :] = pt.as_tensor_variable(selection_matrix)
+        self.ssm["selection"] = pt.as_tensor_variable(selection_matrix)
 
         init_state = self.make_and_register_variable(
             f"params_{self.name}",
             shape=(k_endog_effective, 2) if k_endog_effective > 1 else (self.k_states,),
         )
-        self.ssm["initial_state", :] = init_state.ravel()
+        self.ssm["initial_state"] = init_state.ravel()
 
         if self.estimate_cycle_length:
             lamb = self.make_and_register_variable(f"length_{self.name}", shape=())
@@ -332,22 +332,22 @@ class Cycle(Component):
             rho = 1
 
         T = rho * _frequency_transition_block(lamb, j=1)
-        self.ssm["transition", :, :] = block_diag(*[T for _ in range(k_endog_effective)])
+        self.ssm["transition"] = block_diag(*[T for _ in range(k_endog_effective)])
 
         if self.innovations:
             if k_endog_effective == 1:
                 sigma_cycle = self.make_and_register_variable(f"sigma_{self.name}", shape=())
-                self.ssm["state_cov", :, :] = pt.eye(self.k_posdef) * sigma_cycle**2
+                self.ssm["state_cov"] = pt.eye(self.k_posdef) * sigma_cycle**2
             else:
                 sigma_cycle = self.make_and_register_variable(
                     f"sigma_{self.name}", shape=(k_endog_effective,)
                 )
-                self.ssm["state_cov", :, :] = block_diag(
+                self.ssm["state_cov"] = block_diag(
                     *[pt.eye(2) * sigma_cycle[i] ** 2 for i in range(k_endog_effective)]
                 )
         else:
             # explicitly set state cov to 0 when no innovations
-            self.ssm["state_cov", :, :] = pt.zeros((self.k_posdef, self.k_posdef))
+            self.ssm["state_cov"] = pt.zeros((self.k_posdef, self.k_posdef))
 
 
 def __getattr__(name: str):

--- a/pymc_extras/statespace/models/structural/components/level_trend.py
+++ b/pymc_extras/statespace/models/structural/components/level_trend.py
@@ -291,17 +291,17 @@ class LevelTrend(Component):
             f"initial_{self.name}",
             shape=(k_states,) if k_endog_effective == 1 else (k_endog, k_states),
         )
-        self.ssm["initial_state", :] = initial_trend.ravel()
+        self.ssm["initial_state"] = initial_trend.ravel()
 
         triu_idx = pt.triu_indices(k_states)
         T = pt.zeros((k_states, k_states))[triu_idx[0], triu_idx[1]].set(1)
 
-        self.ssm["transition", :, :] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
+        self.ssm["transition"] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
 
         R = np.eye(k_states)
         R = R[:, self.innovations_order]
 
-        self.ssm["selection", :, :] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
+        self.ssm["selection"] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
 
         Z = np.array([1.0] + [0.0] * (k_states - 1)).reshape((1, -1))
 

--- a/pymc_extras/statespace/models/structural/components/regression.py
+++ b/pymc_extras/statespace/models/structural/components/regression.py
@@ -236,9 +236,9 @@ class Regression(Component):
         )
         regression_data = self.make_and_register_data(f"data_{self.name}", shape=(None, k_states))
 
-        self.ssm["initial_state", :] = betas.ravel()
-        self.ssm["transition", :, :] = pt.eye(self.k_states)
-        self.ssm["selection", :, :] = pt.eye(self.k_states)
+        self.ssm["initial_state"] = betas.ravel()
+        self.ssm["transition"] = pt.eye(self.k_states)
+        self.ssm["selection"] = pt.eye(self.k_states)
 
         if self.share_states:
             self.ssm["design"] = pt.join(

--- a/pymc_extras/statespace/models/structural/components/seasonality.py
+++ b/pymc_extras/statespace/models/structural/components/seasonality.py
@@ -573,7 +573,7 @@ class TimeSeasonality(Component):
         k_posdef = self._k_posdef_per_endog()
 
         R = pt.zeros((k_states, k_posdef))[0, 0].set(1.0)
-        self.ssm["selection", :, :] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
+        self.ssm["selection"] = pt.linalg.block_diag(*[R for _ in range(k_endog_effective)])
 
         sigma = self.make_and_register_variable(
             f"sigma_{self.name}",
@@ -592,7 +592,7 @@ class TimeSeasonality(Component):
             self.ssm["transition"] = T
             self.ssm.declare_time_varying("transition")
         else:
-            self.ssm["transition", :, :] = T
+            self.ssm["transition"] = T
 
         # Design matrix
         self.ssm["design", :, :] = self._build_design_matrix()
@@ -617,7 +617,7 @@ class TimeSeasonality(Component):
         )
         initial_state = self._apply_start_state_shift(initial_state, T_for_shift)
 
-        self.ssm["initial_state", :] = initial_state
+        self.ssm["initial_state"] = initial_state
 
         # Selection and state covariance
         self._build_selection_and_state_cov()
@@ -835,12 +835,12 @@ class FrequencySeasonality(Component):
 
         T_mats = [_frequency_transition_block(self.season_length, j + 1) for j in range(self.n)]
         T = pt.linalg.block_diag(*T_mats)
-        self.ssm["transition", :, :] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
+        self.ssm["transition"] = pt.linalg.block_diag(*[T for _ in range(k_endog_effective)])
 
         if self.innovations:
             sigma_season = self.make_and_register_variable(
                 f"sigma_{self.name}", shape=() if k_endog_effective == 1 else (k_endog_effective,)
             )
             sigma_vec = pt.repeat(sigma_season**2, k_states)
-            self.ssm["selection", :, :] = pt.eye(self.k_states)
-            self.ssm["state_cov", :, :] = pt.diag(sigma_vec)
+            self.ssm["selection"] = pt.eye(self.k_states)
+            self.ssm["state_cov"] = pt.diag(sigma_vec)

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -206,7 +206,7 @@ class StructuralTimeSeries(PyMCStateSpace):
         self._exog_names = data_info.exogenous_names
         self._needs_exog_data = data_info.needs_exogenous_data
 
-        self._init_ssm(ssm, k_posdef)
+        self._init_ssm(ssm)
 
     def _init_info_objects(
         self,
@@ -248,20 +248,24 @@ class StructuralTimeSeries(PyMCStateSpace):
         self._shock_names = strip(self._shock_info.names)
         self._param_names = strip(self._param_info.names)
 
-    def _init_ssm(self, ssm: PytensorRepresentation, k_posdef: int) -> None:
-        """Initialize state space model representation."""
-        self.ssm = ssm.copy()
+    def _init_ssm(self, ssm: PytensorRepresentation) -> None:
+        """Build this model's representation from the component's matrices."""
+        matrices = {name: ssm[name] for name in LONG_MATRIX_NAMES}
+        matrices["initial_state_cov"] = self.make_and_register_variable(
+            "P0", shape=(self.k_states, self.k_states)
+        )
 
-        if k_posdef == 0:
+        if ssm.k_posdef == 0:
             # Components without shocks degrade to a one-shock placeholder so the filter has
             # consistent dims; the placeholder selection/state_cov are zero, so the shock has
             # no effect.
-            self.ssm.k_posdef = self.k_posdef
-            self.ssm["state_cov"] = pt.zeros((1, 1))
-            self.ssm["selection"] = pt.zeros((self.k_states, 1))
+            matrices["state_cov"] = pt.zeros((1, 1))
+            matrices["selection"] = pt.zeros((self.k_states, 1))
 
-        P0 = self.make_and_register_variable("P0", shape=(self.k_states, self.k_states))
-        self.ssm["initial_state_cov"] = P0
+        self.ssm = PytensorRepresentation(
+            k_endog=ssm.k_endog, k_states=ssm.k_states, k_posdef=self.k_posdef, **matrices
+        )
+        self.ssm.declare_time_varying(*ssm.time_varying_names)
 
     def _populate_properties(self) -> None:
         # The base class method needs to be overridden because we directly set properties in

--- a/tests/statespace/core/test_representation.py
+++ b/tests/statespace/core/test_representation.py
@@ -125,6 +125,16 @@ class BasicFunctionality(unittest.TestCase):
         assert_allclose(fast_eval(ssm["selection"][-1, -1]), 9.9, atol=atol)
         assert_allclose(fast_eval(ssm["state_intercept"][:, 0]), np.arange(n), atol=atol)
 
+    def test_assignment_does_not_rename_the_assigned_variable(self):
+        """Model parameters are looked up by name, so storing one must leave its name alone."""
+        ssm = PytensorRepresentation(k_endog=1, k_states=3, k_posdef=1)
+        x0 = pt.vector("x0", shape=(3,))
+
+        ssm["initial_state"] = x0
+
+        self.assertEqual(x0.name, "x0")
+        self.assertEqual(ssm["initial_state"].name, "initial_state")
+
     def test_invalid_key_name_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
         with self.assertRaises(IndexError) as e:

--- a/tests/statespace/core/test_representation.py
+++ b/tests/statespace/core/test_representation.py
@@ -1,4 +1,3 @@
-import copy
 import unittest
 
 import numpy as np
@@ -176,21 +175,6 @@ class BasicFunctionality(unittest.TestCase):
             ssm["transition"] = T
         msg = str(e.exception)
         self.assertEqual(msg, "Trailing dims of transition are (10, 10), expected (5, 5)")
-
-    def test_copy_does_not_alias_time_varying_names(self):
-        for make_copy in (PytensorRepresentation.copy, copy.copy):
-            with self.subTest(make_copy=make_copy.__qualname__):
-                ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)
-                copied = make_copy(ssm)
-
-                copied.declare_time_varying("design")
-
-                self.assertNotIn("design", ssm.time_varying_names)
-                self.assertIn("design", copied.time_varying_names)
-
-                # Everything else is still shared, which is what makes this a shallow copy.
-                self.assertIs(copied.transition, ssm.transition)
-                self.assertEqual(copied.k_states, ssm.k_states)
 
 
 if __name__ == "__main__":

--- a/tests/statespace/models/structural/components/test_autoregressive.py
+++ b/tests/statespace/models/structural/components/test_autoregressive.py
@@ -124,7 +124,7 @@ def test_autoregressive_multiple_observed_data(rng):
     params = {
         "params_auto_regressive": np.array([0.9, 0.8, 0.5]).reshape((3, 1)),
         "sigma_auto_regressive": np.array([0.05, 0.12, 0.22]),
-        "initial_state_cov": np.eye(3),
+        "P0": np.eye(3),
     }
 
     # Recover the AR(1) coefficients from the simulated data via OLS

--- a/tests/statespace/models/structural/components/test_seasonality.py
+++ b/tests/statespace/models/structural/components/test_seasonality.py
@@ -338,7 +338,7 @@ def test_add_two_time_seasonality_different_observed(rng, d1, d2):
         "params_season2": np.array([3.0, 0.0, 0.0, 0.0], dtype=config.floatX),
         "sigma_season1": np.array(0.0, dtype=config.floatX),
         "sigma_season2": np.array(0.0, dtype=config.floatX),
-        "initial_state_cov": np.eye(mod.k_states, dtype=config.floatX),
+        "P0": np.eye(mod.k_states, dtype=config.floatX),
     }
 
     x, y = simulate_from_numpy_model(mod, rng, params, steps=3 * 5 * 5 * d1 * d2)
@@ -395,7 +395,7 @@ def test_add_two_time_seasonality_different_observed_time_varying(rng, d1, d2):
         "params_season2": np.array([3.0, 0.0, 0.0, 0.0], dtype=config.floatX),
         "sigma_season1": np.array(0.0, dtype=config.floatX),
         "sigma_season2": np.array(0.0, dtype=config.floatX),
-        "initial_state_cov": np.eye(mod.k_states, dtype=config.floatX),
+        "P0": np.eye(mod.k_states, dtype=config.floatX),
     }
     x, y = simulate_from_numpy_model(mod, rng, params, steps=s1 * s2 * max(d1, d2) * 2)
     assert_pattern_repeats(y[:, 0], s1 * d1, atol=ATOL, rtol=RTOL)
@@ -435,7 +435,7 @@ def test_add_time_varying_and_static_seasonality(rng):
         "params_monthly": np.array([2.0, 0.0, 0.0, 0.0], dtype=config.floatX),
         "sigma_weekly": np.array(0.0, dtype=config.floatX),
         "sigma_monthly": np.array(0.0, dtype=config.floatX),
-        "initial_state_cov": np.eye(mod.k_states, dtype=config.floatX),
+        "P0": np.eye(mod.k_states, dtype=config.floatX),
     }
     # Pattern repeats every LCM(s1*d1, s2*d2) = LCM(12, 10) = 60
     steps = 60 * 3
@@ -565,7 +565,7 @@ def test_add_two_frequency_seasonality_different_observed(rng):
         "params_freq2": np.array([3.0, 0.0], dtype=config.floatX),
         "sigma_freq1": np.array(0.0, dtype=config.floatX),
         "sigma_freq2": np.array(0.0, dtype=config.floatX),
-        "initial_state_cov": np.eye(mod.k_states, dtype=config.floatX),
+        "P0": np.eye(mod.k_states, dtype=config.floatX),
     }
 
     x, y = simulate_from_numpy_model(mod, rng, params, steps=4 * 6 * 3)

--- a/tests/statespace/models/structural/test_against_statsmodels.py
+++ b/tests/statespace/models/structural/test_against_statsmodels.py
@@ -55,8 +55,8 @@ def _assert_all_statespace_matrices_match(mod, params, sm_mod):
 
 
 def _assert_coord_shapes_match_matrices(mod, params):
-    if "initial_state_cov" not in params:
-        params["initial_state_cov"] = np.eye(mod.k_states)
+    if "P0" not in params:
+        params["P0"] = np.eye(mod.k_states)
 
     x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(mod, params)
 

--- a/tests/statespace/models/structural/test_core.py
+++ b/tests/statespace/models/structural/test_core.py
@@ -8,6 +8,7 @@ import pytest
 from numpy.testing import assert_allclose
 from pytensor import config
 from pytensor import tensor as pt
+from pytensor.graph.traversal import explicit_graph_inputs
 from scipy import linalg
 
 from pymc_extras.statespace.models import structural as st
@@ -16,6 +17,28 @@ from tests.statespace.test_utilities import unpack_symbolic_matrices_with_params
 floatX = config.floatX
 ATOL = 1e-8 if floatX.endswith("64") else 1e-4
 RTOL = 0 if floatX.endswith("64") else 1e-6
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_building_a_component_twice_gives_independent_models():
+    """Each build gets its own representation, so the first model keeps its own P0 placeholder."""
+    component = st.LevelTrend(order=2, innovations_order=1)
+    first = component.build(verbose=False)
+    second = component.build(verbose=False)
+
+    assert first.ssm is not second.ssm
+    assert first._name_to_variable["P0"] is not second._name_to_variable["P0"]
+    for mod in (first, second):
+        inputs = set(explicit_graph_inputs([mod.ssm["initial_state_cov"]]))
+        assert mod._name_to_variable["P0"] in inputs
+
+    # The earlier model must still be able to substitute its own parameters.
+    data = np.zeros((20, 1), dtype=config.floatX)
+    with pm.Model(coords=first.coords):
+        pm.Normal("initial_level_trend", dims=["state_level_trend"])
+        pm.Deterministic("P0", pt.eye(first.k_states, dtype=config.floatX))
+        pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+        first.build_statespace_graph(data)
 
 
 def test_add_components():

--- a/tests/statespace/models/test_ETS.py
+++ b/tests/statespace/models/test_ETS.py
@@ -140,7 +140,7 @@ def test_statespace_matrices(
         "initial_level": rng.normal() ** 2,
         "initial_trend": rng.normal() ** 2,
         "initial_seasonal": np.ones(seasonal_periods),
-        "initial_state_cov": np.eye(expected_states),
+        "P0": np.eye(expected_states),
     }
 
     matrices = x0, P0, c, d, T, Z, R, H, Q = mod._unpack_statespace_with_placeholders()
@@ -237,7 +237,7 @@ def test_statespace_matches_statsmodels(rng, order: tuple[str, str, str], params
     test_values["initial_level"] = rng.normal()
     test_values["initial_trend"] = rng.normal()
     test_values["initial_seasonal"] = rng.normal(size=seasonal_periods)
-    test_values["initial_state_cov"] = np.eye(mod.k_states)
+    test_values["P0"] = np.eye(mod.k_states)
     test_values["sigma_state"] = 1.0
 
     sm_test_values = test_values.copy()
@@ -306,7 +306,7 @@ def test_ETS_with_multiple_endog(rng, order, params, dense_cov):
         size=mod.k_endog,
     )
     test_values["initial_seasonal"] = rng.normal(size=(mod.k_endog, seasonal_periods))
-    test_values["initial_state_cov"] = np.eye(mod.k_states)
+    test_values["P0"] = np.eye(mod.k_states)
 
     if not dense_cov:
         test_values["sigma_state"] = np.ones(
@@ -338,7 +338,7 @@ def test_ETS_with_multiple_endog(rng, order, params, dense_cov):
         d = {
             name: (
                 test_values[name][i]
-                if name != "initial_state_cov"
+                if name != "P0"
                 else test_values_subset[name][single_slice, single_slice]
             )
             for name in single_input_names

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -410,7 +410,7 @@ def test_representations_are_equivalent(p, d, q, P, D, Q, S, data, rng):
         shared_params.update(
             {
                 "x0": np.zeros(mod.k_states, dtype=floatX),
-                "initial_state_cov": np.eye(mod.k_states, dtype=floatX) * 100,
+                "P0": np.eye(mod.k_states, dtype=floatX) * 100,
             }
         )
         x, y = simulate_from_numpy_model(mod, rng, shared_params)

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -160,6 +160,30 @@ def test_VARMAX_update_matches_statsmodels(data, order, rng):
         assert_allclose(matrix_dict[matrix], sm_var.ssm[matrix])
 
 
+def test_measurement_error_enters_obs_cov_as_a_variance():
+    """``sigma_obs`` is a standard deviation, so the observation covariance holds its square."""
+    mod = BayesianVARMAX(
+        endog_names=["a", "b"],
+        order=(1, 0),
+        measurement_error=True,
+        stationary_initialization=False,
+        verbose=False,
+    )
+    sigma = np.array([0.5, 2.0], dtype=floatX)
+
+    with pm.Model():
+        pm.Deterministic("x0", pt.zeros(mod.k_states, dtype=floatX))
+        pm.Deterministic("P0", pt.eye(mod.k_states, dtype=floatX))
+        pm.Deterministic("ar_params", pt.zeros((mod.k_endog, mod.p, mod.k_endog), dtype=floatX))
+        pm.Deterministic("state_cov", pt.eye(mod.k_posdef, dtype=floatX))
+        pm.Deterministic("sigma_obs", pt.as_tensor_variable(sigma))
+        mod._insert_random_variables()
+        matrices = pm.draw(mod.subbed_ssm)
+
+    obs_cov = dict(zip(SHORT_NAME_TO_LONG.values(), matrices))["obs_cov"]
+    assert_allclose(obs_cov, np.diag(sigma**2))
+
+
 @pytest.mark.parametrize("filter_output", ["filtered", "predicted", "smoothed"])
 def test_all_prior_covariances_are_PSD(filter_output, varma_mod, idata, rng):
     cov_name = f"{filter_output}_covariances"


### PR DESCRIPTION
`PytensorRepresentation` renamed every variable handed to it, so assigning a model parameter renamed the parameter itself — which is why models built their matrices through `[:, :]` slice writes instead of just assigning them. It names a copy now, and `StructuralTimeSeries` constructs its representation rather than copying and mutating one, which incidentally fixes two models built from the same component sharing a `P0`.

One behavior change to look at twice: `sigma_obs` is squared in VARMAX now, matching SARIMAX and DFM, so a prior on it means something different than it did.
