### PR TITLE
Carry the time-varying flag on the matrix instead of in name lists

### DIFF
--- a/pymc_extras/statespace/core/assumptions.py
+++ b/pymc_extras/statespace/core/assumptions.py
@@ -1,0 +1,99 @@
+from pytensor.assumptions import (
+    AssumptionKey,
+    FactState,
+    SpecifyAssumptions,
+    check_assumption,
+    register_assumption,
+    specify_assumption_rule,
+)
+from pytensor.graph.basic import Variable
+from pytensor.graph.fg import FunctionGraph
+from pytensor.tensor.basic import Join
+from pytensor.tensor.elemwise import Elemwise
+from pytensor.tensor.rewriting.assumptions import _KEY_BY_NAME
+from pytensor.tensor.subtensor import (
+    AdvancedIncSubtensor,
+    AdvancedSubtensor,
+    IncSubtensor,
+    Subtensor,
+)
+
+TIME_VARYING = AssumptionKey("time_varying", "tv")
+
+# Lets the feature read a declaration back off the node ``declare_time_varying`` inserts.
+register_assumption(TIME_VARYING, SpecifyAssumptions)(specify_assumption_rule)
+
+# The rewrite that drains declarations into the assumption cache snapshots the key registry when
+# pytensor imports, which is always before this module, so add ours to the snapshot by hand.
+_KEY_BY_NAME[TIME_VARYING.name] = TIME_VARYING
+
+
+@register_assumption(TIME_VARYING, Subtensor, AdvancedSubtensor)
+def _subtensor_keeps_time_axis(key, op, feature, fgraph, node, input_states):
+    """Slicing the leading axis shortens the sequence; indexing it removes the axis."""
+    if input_states[0] is not FactState.TRUE:
+        return [FactState.UNKNOWN]
+    index = op.idx_list
+    keeps_time = not index or isinstance(index[0], slice)
+    return [FactState.TRUE if keeps_time else FactState.FALSE]
+
+
+@register_assumption(TIME_VARYING, IncSubtensor, AdvancedIncSubtensor)
+def _set_subtensor_keeps_time_axis(key, op, feature, fgraph, node, input_states):
+    """Writing into a matrix leaves its shape alone, so the base decides."""
+    return [input_states[0]]
+
+
+@register_assumption(TIME_VARYING, Elemwise)
+def _elemwise_keeps_time_axis(key, op, feature, fgraph, node, input_states):
+    """Elementwise work over a sequence is still a sequence."""
+    if any(state is FactState.TRUE for state in input_states):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+@register_assumption(TIME_VARYING, Join)
+def _join_keeps_time_axis(key, op, feature, fgraph, node, input_states):
+    """Concatenation keeps the time axis.
+
+    Joining along it appends timesteps; joining along any other axis leaves it in place, since
+    ``Join`` requires every input to agree on the axes it does not join.
+    """
+    if any(state is FactState.TRUE for state in input_states):
+        return [FactState.TRUE]
+    return [FactState.UNKNOWN]
+
+
+def declare_time_varying(tensor: Variable) -> Variable:
+    """
+    Return ``tensor`` carrying the time-varying assumption.
+
+    Parameters
+    ----------
+    tensor : TensorVariable
+        Matrix whose leading axis indexes time.
+
+    Returns
+    -------
+    declared : TensorVariable
+        A no-op view of ``tensor`` that downstream code can ask about.
+    """
+    return SpecifyAssumptions({TIME_VARYING.name: FactState.TRUE})(tensor)
+
+
+def is_time_varying(*tensors: Variable) -> list[bool]:
+    """
+    Report which tensors still carry a declared time axis.
+
+    Parameters
+    ----------
+    *tensors : TensorVariable
+        Tensors to inspect.
+
+    Returns
+    -------
+    flags : list of bool
+        One entry per tensor, True when the time axis survives.
+    """
+    fgraph = FunctionGraph(outputs=list(tensors), clone=False)
+    return [check_assumption(fgraph, tensor, TIME_VARYING) for tensor in tensors]

--- a/pymc_extras/statespace/core/assumptions.py
+++ b/pymc_extras/statespace/core/assumptions.py
@@ -9,6 +9,7 @@ from pytensor.assumptions import (
 from pytensor.graph.basic import Variable
 from pytensor.graph.fg import FunctionGraph
 from pytensor.tensor.basic import Join
+from pytensor.tensor.blockwise import Blockwise
 from pytensor.tensor.elemwise import Elemwise
 from pytensor.tensor.rewriting.assumptions import _KEY_BY_NAME
 from pytensor.tensor.subtensor import (
@@ -62,6 +63,24 @@ def _join_keeps_time_axis(key, op, feature, fgraph, node, input_states):
     if any(state is FactState.TRUE for state in input_states):
         return [FactState.TRUE]
     return [FactState.UNKNOWN]
+
+
+@register_assumption(TIME_VARYING, Blockwise)
+def _blockwise_keeps_a_batched_time_axis(key, op, feature, fgraph, node, input_states):
+    """A ``Blockwise`` broadcasts its batch dims onto every output, so a time axis to the left of
+    an input's core dims survives the call.
+
+    ``Component.__add__`` builds the combined transition, selection and state covariance with
+    ``pt.linalg.block_diag``, and the filter takes a Cholesky of the covariances, so without this
+    the declaration is lost exactly where components are combined. A declaration sitting on a core
+    axis instead says nothing about the result, since the core op is free to reshape it.
+    """
+    n_outputs = len(op.outputs_sig)
+    batched_time = any(
+        state is FactState.TRUE and variable.type.ndim > len(core_dims)
+        for state, core_dims, variable in zip(input_states, op.inputs_sig, node.inputs, strict=True)
+    )
+    return [FactState.TRUE if batched_time else FactState.UNKNOWN] * n_outputs
 
 
 def declare_time_varying(tensor: Variable) -> Variable:

--- a/pymc_extras/statespace/core/compile.py
+++ b/pymc_extras/statespace/core/compile.py
@@ -5,7 +5,6 @@ import pytensor.tensor as pt
 
 from pymc_extras.statespace.core import PyMCStateSpace
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
-from pymc_extras.statespace.utils.constants import LONG_NAME_TO_SHORT
 
 
 def compile_statespace(
@@ -16,13 +15,9 @@ def compile_statespace(
 
     x0, _, c, d, T, Z, R, H, Q = statespace_model._unpack_statespace_with_placeholders()
 
-    sequence_names = [LONG_NAME_TO_SHORT[name] for name in statespace_model.ssm.time_varying_names]
-
     P0 = pt.zeros((x0.shape[0], x0.shape[0]))
 
-    outputs = LinearGaussianStateSpace.dist(
-        x0, P0, c, d, T, Z, R, H, Q, steps=steps, sequence_names=sequence_names
-    )
+    outputs = LinearGaussianStateSpace.dist(x0, P0, c, d, T, Z, R, H, Q, steps=steps)
 
     inputs = list(pytensor.graph.traversal.explicit_graph_inputs(outputs))
 

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -21,7 +21,6 @@ from pymc_extras.statespace.core.fit_recovery import (
     verify_group,
 )
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
-from pymc_extras.statespace.filters.utilities import scan_sequence_names
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
     ALL_STATE_DIM,
@@ -527,7 +526,6 @@ def _build_forecast_model(
             *forecast_matrices,
             steps=len(forecast_index),
             dims=trajectory_dims,
-            sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
             k_endog=ss_mod.k_endog,
             append_x0=False,
             method=mvn_method,

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -13,6 +13,7 @@ from pymc.util import RandomState
 from pytensor.graph.replace import graph_replace
 from xarray import DataTree
 
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.core.fit_recovery import (
     coords_from_idata,
     data_from_idata,
@@ -25,9 +26,7 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
     ALL_STATE_DIM,
     FILTER_OUTPUT_TYPES,
-    MATRIX_NAMES,
     OBS_STATE_DIM,
-    SHORT_NAME_TO_LONG,
     TIME_DIM,
 )
 
@@ -510,13 +509,13 @@ def _build_forecast_model(
                     forecast_matrices, replace=exog_replace, strict=False
                 )
 
-        forecast_names = MATRIX_NAMES[2:]  # c, d, T, Z, R, H, Q
-        time_varying_names = ss_mod.ssm.time_varying_names
         # Start one step early: the transition into the first forecast period uses the
         # matrices of the last training period, and its observation is discarded.
         forecast_matrices = [
-            m[n_train - 1 :] if SHORT_NAME_TO_LONG[name] in time_varying_names else m
-            for m, name in zip(forecast_matrices, forecast_names)
+            m[n_train - 1 :] if varying else m
+            for m, varying in zip(
+                forecast_matrices, is_time_varying(*forecast_matrices), strict=True
+            )
         ]
 
         _ = LinearGaussianStateSpace(

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -21,7 +21,7 @@ from pymc_extras.statespace.filters.distributions import (
     SequenceMvNormal,
     SimulationSmoother,
 )
-from pymc_extras.statespace.filters.utilities import scan_sequence_names, stabilize
+from pymc_extras.statespace.filters.utilities import stabilize
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     FILTER_OUTPUT_DIMS,
@@ -138,7 +138,6 @@ def _sample_conditional(
                     Q=Q,
                     kalman_filter=kalman_filter,
                     kalman_smoother=kalman_smoother,
-                    sequence_names=tuple(scan_sequence_names(ss_mod.ssm.time_varying_names)),
                     dims=state_dims,
                     method=mvn_method,
                 )
@@ -306,7 +305,6 @@ def _sample_unconditional(
             steps=steps,
             dims=trajectory_dims,
             method=mvn_method,
-            sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
             k_endog=ss_mod.k_endog,
         )
 

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -11,6 +11,7 @@ import pytensor.tensor as pt
 from pymc.util import RandomState
 
 from pymc_extras.statespace.core import dummy_graph
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.core.fit_recovery import (
     coords_from_idata,
     dims_from_idata,
@@ -233,7 +234,7 @@ def impulse_response_function(
             shock_trajectory = pt.as_tensor_variable(shock_trajectory)[..., None]
 
         x0 = pt.zeros((ss_mod.k_states, n_impulse))
-        time_varying_T = "transition" in ss_mod.ssm.time_varying_names
+        [time_varying_T] = is_time_varying(T)
 
         def irf_step(*args):
             if time_varying_T:

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
-from pymc_extras.statespace.core.assumptions import declare_time_varying
+from pymc_extras.statespace.core.assumptions import declare_time_varying, is_time_varying
 
 floatX = pytensor.config.floatX
 KeyLike = tuple[str | int, ...] | str
@@ -270,10 +270,23 @@ class PytensorRepresentation:
         ----------
         *names : str
             Names of the matrices to mark.
+
+        Raises
+        ------
+        ValueError
+            If a named matrix is at its core rank, leaving no leading axis to iterate over.
         """
         for name in names:
             self._validate_name(name)
-            setattr(self, name, declare_time_varying(getattr(self, name)))
+            tensor = getattr(self, name)
+            if tensor.ndim == _CORE_NDIM[name]:
+                raise ValueError(
+                    f"{name} has ndim={tensor.ndim}, its core rank, so it has no leading axis "
+                    f"to iterate over. Assign a matrix of shape "
+                    f"(time, {', '.join(map(str, self._core_shape(name)))}) before declaring it "
+                    f"time-varying."
+                )
+            setattr(self, name, declare_time_varying(tensor))
 
     def __getitem__(self, key: KeyLike) -> pt.TensorVariable:
         if isinstance(key, str):
@@ -295,7 +308,16 @@ class PytensorRepresentation:
     ) -> None:
         if isinstance(key, str):
             self._validate_name(key)
-            setattr(self, key, self._coerce(key, value))
+            tensor = self._coerce(key, value)
+            existing = getattr(self, key)
+            # A replacement of the same rank describes the same axes as what it replaces, so a
+            # declared time axis carries over. A change of rank redefines them, and the model has
+            # to say again what the leading axis means.
+            if tensor.ndim == existing.ndim:
+                [time_varying] = is_time_varying(existing)
+                if time_varying:
+                    tensor = declare_time_varying(tensor)
+            setattr(self, key, tensor)
             return
 
         if isinstance(key, tuple) and isinstance(key[0], str):

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -11,7 +11,7 @@ KeyLike = tuple[str | int, ...] | str
 
 # Number of trailing dims that define each matrix's "core" shape (1 for vectors, 2 for
 # matrices). Anything to the left is a time and/or batch dim; downstream consumers
-# distinguish them by consulting ``Representation.time_varying_names``.
+# distinguish them with ``is_time_varying``.
 _CORE_NDIM: dict[str, int] = {
     "design": 2,
     "obs_intercept": 1,
@@ -102,8 +102,9 @@ class PytensorRepresentation:
 
     Any matrix may carry a leading dim of length ``n`` (the number of observations) to
     make it time-varying. The model is responsible for declaring which matrices vary over
-    time via :meth:`declare_time_varying`; downstream consumers (filter, smoother, etc.)
-    read :attr:`time_varying_names` to dispatch.
+    time via :meth:`declare_time_varying`; downstream consumers (filter, smoother, etc.) ask
+    each matrix for itself with
+    :func:`~pymc_extras.statespace.core.assumptions.is_time_varying`.
 
     .. warning::
 
@@ -147,7 +148,6 @@ class PytensorRepresentation:
     """
 
     __slots__ = (
-        "_time_varying_names",
         "design",
         "initial_state",
         "initial_state_cov",
@@ -192,8 +192,6 @@ class PytensorRepresentation:
             "initial_state": initial_state,
             "initial_state_cov": initial_state_cov,
         }
-
-        self._time_varying_names: set[str] = set()
 
         for name in _CORE_NDIM:
             value = provided[name]
@@ -262,25 +260,19 @@ class PytensorRepresentation:
 
         return tensor
 
-    @property
-    def time_varying_names(self) -> frozenset[str]:
-        """Names of matrices the model declared as time-varying.
-
-        The Kalman filter iterates over the leading dim of these tensors at scan time;
-        all other matrices are passed in as scan non-sequences (i.e. used unchanged at
-        every step).
-        """
-        return frozenset(self._time_varying_names)
-
     def declare_time_varying(self, *names: str) -> None:
-        """Mark matrices as time-varying. The filter will iterate over the leading dim.
+        """Mark matrices as time-varying, so the filter iterates over their leading dim.
 
         The declaration rides on the tensor itself, so it survives substitution and slicing and
         travels with the matrix into any graph built from it.
+
+        Parameters
+        ----------
+        *names : str
+            Names of the matrices to mark.
         """
         for name in names:
             self._validate_name(name)
-            self._time_varying_names.add(name)
             setattr(self, name, declare_time_varying(getattr(self, name)))
 
     def __getitem__(self, key: KeyLike) -> pt.TensorVariable:

--- a/pymc_extras/statespace/core/representation.py
+++ b/pymc_extras/statespace/core/representation.py
@@ -4,6 +4,8 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
+from pymc_extras.statespace.core.assumptions import declare_time_varying
+
 floatX = pytensor.config.floatX
 KeyLike = tuple[str | int, ...] | str
 
@@ -271,10 +273,15 @@ class PytensorRepresentation:
         return frozenset(self._time_varying_names)
 
     def declare_time_varying(self, *names: str) -> None:
-        """Mark matrices as time-varying. The filter will iterate over the leading dim."""
+        """Mark matrices as time-varying. The filter will iterate over the leading dim.
+
+        The declaration rides on the tensor itself, so it survives substitution and slicing and
+        travels with the matrix into any graph built from it.
+        """
         for name in names:
             self._validate_name(name)
             self._time_varying_names.add(name)
+            setattr(self, name, declare_time_varying(getattr(self, name)))
 
     def __getitem__(self, key: KeyLike) -> pt.TensorVariable:
         if isinstance(key, str):

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1106,16 +1106,12 @@ class PyMCStateSpace:
         kalman_filter : BaseFilter
             Filter of the type this model was constructed with.
         kalman_smoother : KalmanSmoother
-            Smoother carrying the same time-varying names and jitter.
+            Smoother carrying the same jitter.
         """
         kalman_filter = FILTER_FACTORY[self.filter_type](
-            time_varying_names=self.ssm.time_varying_names,
-            cov_jitter=self.cov_jitter,
-            missing_fill_value=self.missing_fill_value,
+            cov_jitter=self.cov_jitter, missing_fill_value=self.missing_fill_value
         )
-        kalman_smoother = KalmanSmoother(
-            time_varying_names=self.ssm.time_varying_names, cov_jitter=self.cov_jitter
-        )
+        kalman_smoother = KalmanSmoother(cov_jitter=self.cov_jitter)
         return kalman_filter, kalman_smoother
 
     def _register_additional_statespace_variables(self) -> None:

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -10,6 +10,13 @@ from pymc.pytensorf import intX, normalize_rng_param
 from pytensor.graph.basic import Node
 from pytensor.tensor.random import multivariate_normal
 
+from pymc_extras.statespace.core.assumptions import declare_time_varying, is_time_varying
+from pymc_extras.statespace.filters.utilities import (
+    PARAM_NAMES,
+    split_by_time_axis,
+    unpack_scan_step,
+)
+
 floatX = pytensor.config.floatX
 COV_ZERO_TOL = 0
 
@@ -68,6 +75,40 @@ def make_signature(sequence_names):
     )
 
 
+def _matrix_dummies(matrices, varying):
+    """
+    Build fresh input variables for an ``OpFromGraph`` over the statespace matrices.
+
+    A dummy carries none of its source's assumptions, so the ones standing in for a
+    time-varying matrix are declared again for use inside the op.
+
+    Parameters
+    ----------
+    matrices : sequence of TensorVariable
+        The matrices, in ``PARAM_NAMES`` order.
+    varying : list of bool
+        Whether each matrix carries a time axis.
+
+    Returns
+    -------
+    dummies : list of TensorVariable
+        Named inputs for the op.
+    declared : list of TensorVariable
+        The same inputs, declared time-varying wherever their source was, for the inner graph.
+    """
+    dummies = []
+    for name, matrix in zip(PARAM_NAMES, matrices, strict=True):
+        dummy = matrix.type()
+        dummy.name = name
+        dummies.append(dummy)
+
+    declared = [
+        declare_time_varying(dummy) if flag else dummy
+        for dummy, flag in zip(dummies, varying, strict=True)
+    ]
+    return dummies, declared
+
+
 def _forward_simulate_latent_and_obs(
     a0,
     P0,
@@ -81,7 +122,6 @@ def _forward_simulate_latent_and_obs(
     *,
     steps,
     rng,
-    sequence_names=(),
     method="svd",
     append_x0=True,
 ):
@@ -101,15 +141,12 @@ def _forward_simulate_latent_and_obs(
     ----------
     a0, P0, c, d, T, Z, R, H, Q : TensorVariable
         State-space matrices in the canonical order. Either core-shape (static) or
-        time-varying ``(time, *core)``; declare time-varying entries via
-        ``sequence_names``.
+        time-varying ``(time, *core)``; declare the latter with
+        :func:`~pymc_extras.statespace.core.assumptions.declare_time_varying`.
     steps : TensorVariable or int
         Number of forward simulation steps.
     rng : RandomGenerator
         Pytensor RNG to thread through the scan.
-    sequence_names : iterable of str, optional
-        Short names ("c", "d", "T", "Z", "R", "H", "Q") of matrices that are
-        time-varying. Default empty (everything static).
     method : str, optional
         Multivariate-normal sampling method passed to ``pm.MvNormal.dist``.
         Default ``"svd"``.
@@ -126,34 +163,14 @@ def _forward_simulate_latent_and_obs(
     next_rng : Variable
         RNG state after sampling.
     """
-    sequence_names = tuple(sequence_names)
-
-    canonical = ["c", "d", "T", "Z", "R", "H", "Q"]
-    all_inputs = [c, d, T, Z, R, H, Q]
-
-    sequences = []
-    non_sequences = []
-    seq_positions = []
-    non_seq_positions = []
-    for i, (x, name) in enumerate(zip(all_inputs, canonical, strict=True)):
-        if name in sequence_names:
-            sequences.append(x)
-            seq_positions.append(i)
-        else:
-            non_sequences.append(x)
-            non_seq_positions.append(i)
-
-    n_seq = len(sequences)
+    sequences, non_sequences, seq_names, non_seq_names = split_by_time_axis(
+        dict(zip(PARAM_NAMES, [c, d, T, Z, R, H, Q], strict=True))
+    )
 
     def step_fn(*args):
-        seqs, (rng, a, *non_seqs) = args[:n_seq], args[n_seq:]
-
-        ordered = [None] * len(canonical)
-        for src_idx, dst_idx in enumerate(seq_positions):
-            ordered[dst_idx] = seqs[src_idx]
-        for src_idx, dst_idx in enumerate(non_seq_positions):
-            ordered[dst_idx] = non_seqs[src_idx]
-        c, d, T, Z, R, H, Q = ordered
+        (rng, a), (c, d, T, Z, R, H, Q) = unpack_scan_step(
+            args, seq_names, non_seq_names, PARAM_NAMES
+        )
 
         middle_rng, y_innovation = pm.MvNormal.dist(
             mu=0, cov=H, rng=rng, method=method, return_next_rng=True
@@ -218,7 +235,6 @@ class _LinearGaussianStateSpace(Continuous):
         H,
         Q,
         steps=None,
-        sequence_names=None,
         append_x0=True,
         method="svd",
         **kwargs,
@@ -246,7 +262,6 @@ class _LinearGaussianStateSpace(Continuous):
             H,
             Q,
             steps=steps,
-            sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,
             **kwargs,
@@ -265,7 +280,6 @@ class _LinearGaussianStateSpace(Continuous):
         H,
         Q,
         steps=None,
-        sequence_names=None,
         append_x0=True,
         method="svd",
         **kwargs,
@@ -281,7 +295,6 @@ class _LinearGaussianStateSpace(Continuous):
 
         return super().dist(
             [a0, P0, c, d, T, Z, R, H, Q, steps],
-            sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,
             **kwargs,
@@ -302,38 +315,23 @@ class _LinearGaussianStateSpace(Continuous):
         steps,
         size=None,
         rng=None,
-        sequence_names=None,
         append_x0=True,
         method="svd",
     ):
-        if sequence_names is None:
-            sequence_names = []
+        varying = is_time_varying(c, d, T, Z, R, H, Q)
+        sequence_names = [name for name, flag in zip(PARAM_NAMES, varying, strict=True) if flag]
 
-        a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = (x.type() for x in (a0, P0, c, d, T, Z, R, H, Q))
-
-        c_.name = "c"
-        d_.name = "d"
-        T_.name = "T"
-        Z_.name = "Z"
-        R_.name = "R"
-        H_.name = "H"
-        Q_.name = "Q"
+        a0_, P0_ = a0.type(), P0.type()
+        dummies, declared = _matrix_dummies((c, d, T, Z, R, H, Q), varying)
 
         rng = normalize_rng_param(rng)
 
         alpha, y, ss_rng = _forward_simulate_latent_and_obs(
             a0_,
             P0_,
-            c_,
-            d_,
-            T_,
-            Z_,
-            R_,
-            H_,
-            Q_,
+            *declared,
             steps=steps,
             rng=rng,
-            sequence_names=sequence_names,
             method=method,
             append_x0=append_x0,
         )
@@ -341,7 +339,7 @@ class _LinearGaussianStateSpace(Continuous):
         statespace_ = pt.specify_shape(statespace_, (steps + int(append_x0), None))
 
         linear_gaussian_ss_op = LinearGaussianStateSpaceRV(
-            inputs=[a0_, P0_, c_, d_, T_, Z_, R_, H_, Q_, steps, rng],
+            inputs=[a0_, P0_, *dummies, steps, rng],
             outputs=[ss_rng, statespace_],
             extended_signature=make_signature(sequence_names),
         )
@@ -371,7 +369,6 @@ class LinearGaussianStateSpace(Continuous):
         *,
         steps,
         k_endog=None,
-        sequence_names=None,
         append_x0=True,
         method="svd",
         **kwargs,
@@ -400,7 +397,6 @@ class LinearGaussianStateSpace(Continuous):
             H,
             Q,
             steps=steps,
-            sequence_names=sequence_names,
             append_x0=append_x0,
             method=method,
             **kwargs,
@@ -540,9 +536,6 @@ class SimulationSmoother(Continuous):
         graph. A Python-side graph builder, not a random-variable input.
     kalman_smoother : KalmanSmoother
         Smoother object exposing ``build_graph``, used the same way as ``kalman_filter``.
-    sequence_names : iterable of str, optional
-        Short names of time-varying matrices, mirroring
-        ``LinearGaussianStateSpace``'s ``sequence_names`` argument.
     method : str, optional
         Multivariate-normal sampling method. Default ``"svd"``.
 
@@ -571,7 +564,6 @@ class SimulationSmoother(Continuous):
         *,
         kalman_filter,
         kalman_smoother,
-        sequence_names=(),
         method="svd",
         **kwargs,
     ):
@@ -579,7 +571,6 @@ class SimulationSmoother(Continuous):
             [a_smooth, x0, P0, c, d, T, Z, R, H, Q],
             kalman_filter=kalman_filter,
             kalman_smoother=kalman_smoother,
-            sequence_names=tuple(sequence_names),
             method=method,
             **kwargs,
         )
@@ -600,24 +591,16 @@ class SimulationSmoother(Continuous):
         *,
         kalman_filter,
         kalman_smoother,
-        sequence_names=(),
         method="svd",
         size=None,
         rng=None,
     ):
-        sequence_names = tuple(sequence_names)
-        a_smooth_, x0_, P0_, c_, d_, T_, Z_, R_, H_, Q_ = (
-            x.type() for x in (a_smooth, x0, P0, c, d, T, Z, R, H, Q)
-        )
+        varying = is_time_varying(c, d, T, Z, R, H, Q)
+        sequence_names = [name for name, flag in zip(PARAM_NAMES, varying, strict=True) if flag]
 
+        a_smooth_, x0_, P0_ = (x.type() for x in (a_smooth, x0, P0))
         a_smooth_.name = "a_smooth"
-        c_.name = "c"
-        d_.name = "d"
-        T_.name = "T"
-        Z_.name = "Z"
-        R_.name = "R"
-        H_.name = "H"
-        Q_.name = "Q"
+        dummies, (c_, d_, T_, Z_, R_, H_, Q_) = _matrix_dummies((c, d, T, Z, R, H, Q), varying)
 
         rng = normalize_rng_param(rng)
 
@@ -644,7 +627,6 @@ class SimulationSmoother(Continuous):
             Q_,
             steps=steps - 1,
             rng=rng,
-            sequence_names=sequence_names,
             method=method,
             append_x0=True,
         )
@@ -682,7 +664,7 @@ class SimulationSmoother(Continuous):
         # time, so shape inference reaches through them. The JAX backend needs the
         # resulting static ``n_steps`` to dispatch its scan.
         op = SimulationSmootherRV(
-            inputs=[a_smooth_, x0_, P0_, c_, d_, T_, Z_, R_, H_, Q_, rng],
+            inputs=[a_smooth_, x0_, P0_, *dummies, rng],
             outputs=[mid_rng, alpha_sample],
             extended_signature=_simulation_smoother_signature(sequence_names),
             inline=True,

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from collections.abc import Iterable
 
 import numpy as np
 import pytensor
@@ -14,12 +13,14 @@ from pytensor.scan.utils import until
 from pytensor.tensor import TensorConstant, TensorVariable
 from pytensor.tensor.linalg import solve_triangular
 
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.filters.utilities import (
     PARAM_NAMES,
     dim_of,
     quad_form_sym,
-    scan_sequence_names,
+    split_by_time_axis,
     stabilize,
+    unpack_scan_step,
 )
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_NAMES,
@@ -38,7 +39,6 @@ assert_time_varying_dim_correct = Assert(
 class BaseFilter(ABC):
     def __init__(
         self,
-        time_varying_names: Iterable[str] = (),
         cov_jitter: float | None = None,
         missing_fill_value: float | None = None,
     ):
@@ -46,12 +46,12 @@ class BaseFilter(ABC):
         Abstract base class for Kalman filter implementations.
 
         :meth:`build_graph` only reads these settings, so one filter builds any number of graphs.
+        Which matrices ``scan`` receives as sequences is read off the matrices themselves, which
+        callers mark with
+        :func:`~pymc_extras.statespace.core.assumptions.declare_time_varying`.
 
         Parameters
         ----------
-        time_varying_names : iterable of str, optional
-            Long names of the matrices the model declared time-varying, which the filter passes to
-            ``scan`` as sequences rather than non-sequences. Default is no time-varying matrices.
         cov_jitter : float, optional
             Jitter added to the diagonal of every covariance matrix at each step. Default 1e-8, or
             1e-6 if ``pytensor.config.floatX`` is float32.
@@ -60,9 +60,6 @@ class BaseFilter(ABC):
         """
         self.cov_jitter = JITTER_DEFAULT if cov_jitter is None else cov_jitter
         self.missing_fill_value = MISSING_FILL if missing_fill_value is None else missing_fill_value
-
-        self.seq_names = scan_sequence_names(time_varying_names)
-        self.non_seq_names = [name for name in PARAM_NAMES if name not in self.seq_names]
 
     def check_params(self, data, a0, P0, c, d, T, Z, R, H, Q):
         """
@@ -103,40 +100,6 @@ class BaseFilter(ABC):
         ]
 
         return params_with_assert
-
-    def unpack_args(self, args) -> tuple:
-        """
-        The order of inputs to the inner scan function is not known, since some, all, or none of the input matrices
-        can be time varying. The order arguments are fed to the inner function is sequences, outputs_info,
-        non-sequences. This function works out which matrices are where, and returns a standardized order expected
-        by the kalman_step function.
-
-        The standard order is: y, a0, P0, c, d, T, Z, R, H, Q
-        """
-        # If there are no sequence parameters (all params are static),
-        # no changes are needed, params will be in order.
-        args = list(args)
-        n_seq = len(self.seq_names)
-        if n_seq == 0:
-            return tuple(args)
-
-        # The first arg is always y
-        y = args.pop(0)
-
-        # There are always two outputs_info wedged between the seqs and non_seqs
-        seqs, (a0, P0), non_seqs = args[:n_seq], args[n_seq : n_seq + 2], args[n_seq + 2 :]
-        return_ordered = []
-        for name in PARAM_NAMES:
-            if name in self.seq_names:
-                idx = self.seq_names.index(name)
-                return_ordered.append(seqs[idx])
-            else:
-                idx = self.non_seq_names.index(name)
-                return_ordered.append(non_seqs[idx])
-
-        c, d, T, Z, R, H, Q = return_ordered
-
-        return y, a0, P0, c, d, T, Z, R, H, Q
 
     def build_graph(
         self,
@@ -187,18 +150,19 @@ class BaseFilter(ABC):
         data, a0, P0, *params = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)
         k_states, k_endog = dim_of(a0, 0), dim_of(Z, -2)
         data = pt.specify_shape(data, (data.type.shape[0], k_endog))
-        sequences = [
-            p for p, name in zip(params, PARAM_NAMES, strict=True) if name in self.seq_names
-        ]
-        non_sequences = [
-            p for p, name in zip(params, PARAM_NAMES, strict=True) if name in self.non_seq_names
-        ]
 
+        sequences, non_sequences, seq_names, non_seq_names = split_by_time_axis(
+            dict(zip(PARAM_NAMES, params, strict=True))
+        )
         if len(sequences) > 0:
             sequences = self.add_check_on_time_varying_shapes(data, sequences)
 
+        def step_fn(y, *rest):
+            (a, P), matrices = unpack_scan_step(rest, seq_names, non_seq_names, PARAM_NAMES)
+            return self.kalman_step(y, a, P, *matrices)
+
         results = pytensor.scan(
-            self.kalman_step,
+            step_fn,
             sequences=[data, *sequences],
             outputs_info=[None, a0, None, None, P0, None, None],
             non_sequences=non_sequences,
@@ -436,7 +400,7 @@ class BaseFilter(ABC):
         """
         raise NotImplementedError
 
-    def kalman_step(self, *args) -> tuple:
+    def kalman_step(self, y, a, P, c, d, T, Z, R, H, Q) -> tuple:
         """
         Performs a single iteration of the Kalman filter, which is composed of two steps : an update step and a
         prediction step. The timing convention follows [1], in which initial state and covariance estimates a0 and P0
@@ -507,7 +471,6 @@ class BaseFilter(ABC):
         .. [1] Durbin, J., and S. J. Koopman. Time Series Analysis by State Space Methods.
                2nd ed, Oxford University Press, 2012.
         """
-        y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
         y_masked, Z_masked, H_masked, d_masked, all_nan_flag = self.handle_missing_values(
             y, Z, H, d
         )
@@ -779,9 +742,7 @@ class UnivariateFilter(BaseFilter):
 
         return a_filtered, P_filtered, pt.atleast_1d(y_hat), pt.atleast_2d(F), ll_inner
 
-    def kalman_step(self, *args):
-        y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
-
+    def kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
         nan_mask = pt.or_(pt.isnan(y), pt.eq(y, self.missing_fill_value))
         y_masked, Z_masked, H_masked, d_masked, all_nan_flag = self.handle_missing_values(
             y, Z, H, d
@@ -871,21 +832,11 @@ class ConvergentFilter(StandardFilter):
 
     def __init__(
         self,
-        time_varying_names: Iterable[str] = (),
         cov_jitter: float | None = None,
         missing_fill_value: float | None = None,
         tol: float = 1e-10,
     ):
-        super().__init__(
-            time_varying_names=time_varying_names,
-            cov_jitter=cov_jitter,
-            missing_fill_value=missing_fill_value,
-        )
-        if self.seq_names:
-            raise ValueError(
-                "ConvergentFilter requires time-invariant matrices; got time-varying: "
-                f"{sorted(time_varying_names)}. Use StandardFilter instead."
-            )
+        super().__init__(cov_jitter=cov_jitter, missing_fill_value=missing_fill_value)
         self.tol = tol
 
     def _check_data(self, data):
@@ -1157,6 +1108,17 @@ class ConvergentFilter(StandardFilter):
         H,
         Q,
     ):
+        varying = [
+            name
+            for name, flag in zip(PARAM_NAMES, is_time_varying(c, d, T, Z, R, H, Q), strict=True)
+            if flag
+        ]
+        if varying:
+            raise ValueError(
+                f"ConvergentFilter requires time-invariant matrices; got time-varying: {varying}. "
+                "Use StandardFilter instead."
+            )
+
         data = self._check_data(data)
         data, a0, P0, c, d, T, Z, R, H, Q = self.check_params(data, a0, P0, c, d, T, Z, R, H, Q)
         k_states, k_endog = dim_of(a0, 0), dim_of(Z, -2)

--- a/pymc_extras/statespace/filters/kalman_smoother.py
+++ b/pymc_extras/statespace/filters/kalman_smoother.py
@@ -1,13 +1,13 @@
-from collections.abc import Iterable
-
 import pytensor
 import pytensor.tensor as pt
 
 from pymc_extras.statespace.filters.utilities import (
     quad_form_sym,
+    split_by_time_axis,
     stabilize,
+    unpack_scan_step,
 )
-from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, LONG_NAME_TO_SHORT
+from pymc_extras.statespace.utils.constants import JITTER_DEFAULT
 
 # The smoother's backward pass only ever touches these three matrices.
 SMOOTHER_PARAM_NAMES = ("T", "R", "Q")
@@ -19,71 +19,22 @@ class KalmanSmoother:
 
     """
 
-    def __init__(
-        self,
-        time_varying_names: Iterable[str] = (),
-        cov_jitter: float | None = None,
-    ):
+    def __init__(self, cov_jitter: float | None = None):
         """
         Kalman smoother.
 
-        :meth:`build_graph` only reads these settings, so one smoother builds any number of graphs.
+        :meth:`build_graph` only reads this setting, so one smoother builds any number of graphs.
+        Which matrices ``scan`` receives as sequences is read off the matrices themselves, which
+        callers mark with
+        :func:`~pymc_extras.statespace.core.assumptions.declare_time_varying`.
 
         Parameters
         ----------
-        time_varying_names : iterable of str, optional
-            Long names of the matrices the model declared time-varying. Only the transition, selection
-            and state covariance matrices reach the smoother. Default is no time-varying matrices.
         cov_jitter : float, optional
             Jitter added to the diagonal of every covariance matrix at each step. Default 1e-8, or
             1e-6 if ``pytensor.config.floatX`` is float32.
         """
         self.cov_jitter = JITTER_DEFAULT if cov_jitter is None else cov_jitter
-
-        time_varying_short = {LONG_NAME_TO_SHORT[name] for name in time_varying_names}
-        self.seq_names = [name for name in SMOOTHER_PARAM_NAMES if name in time_varying_short]
-        self.non_seq_names = [
-            name for name in SMOOTHER_PARAM_NAMES if name not in time_varying_short
-        ]
-
-    def unpack_args(self, args):
-        """
-        The order of inputs to the inner scan function is not known, since some, all, or none of the input matrices
-        can be time varying. The order arguments are fed to the inner function is sequences, outputs_info,
-        non-sequences. This function works out which matrices are where, and returns a standardized order expected
-        by the kalman_step function.
-
-        The standard order is: a, P, a_smooth, P_smooth, T, R, Q
-        """
-        # If there are no sequence parameters (all params are static),
-        # no changes are needed, params will be in order.
-        args = list(args)
-        n_seq = len(self.seq_names)
-        if n_seq == 0:
-            return args
-
-        # The first two args are always a and P
-        a = args.pop(0)
-        P = args.pop(0)
-
-        # There are always two outputs_info wedged between the seqs and non_seqs
-        seqs, (a_smooth, P_smooth), non_seqs = (
-            args[:n_seq],
-            args[n_seq : n_seq + 2],
-            args[n_seq + 2 :],
-        )
-        return_ordered = []
-        for name in SMOOTHER_PARAM_NAMES:
-            if name in self.seq_names:
-                idx = self.seq_names.index(name)
-                return_ordered.append(seqs[idx])
-            else:
-                idx = self.non_seq_names.index(name)
-                return_ordered.append(non_seqs[idx])
-
-        T, R, Q = return_ordered
-
-        return a, P, a_smooth, P_smooth, T, R, Q
 
     def build_graph(
         self,
@@ -98,12 +49,18 @@ class KalmanSmoother:
         a_last = pt.specify_shape(filtered_states[-1], (k,))
         P_last = pt.specify_shape(filtered_covariances[-1], (k, k))
 
-        params = dict(zip(SMOOTHER_PARAM_NAMES, [T, R, Q], strict=True))
-        sequences = [params[name] for name in self.seq_names]
-        non_sequences = [params[name] for name in self.non_seq_names]
+        sequences, non_sequences, seq_names, non_seq_names = split_by_time_axis(
+            dict(zip(SMOOTHER_PARAM_NAMES, [T, R, Q], strict=True))
+        )
+
+        def step_fn(a, P, *rest):
+            (a_smooth, P_smooth), matrices = unpack_scan_step(
+                rest, seq_names, non_seq_names, SMOOTHER_PARAM_NAMES
+            )
+            return self.smoother_step(a, P, a_smooth, P_smooth, *matrices)
 
         smoothed_states, smoothed_covariances = pytensor.scan(
-            self.smoother_step,
+            step_fn,
             sequences=[filtered_states[:-1], filtered_covariances[:-1], *sequences],
             outputs_info=[a_last, P_last],
             non_sequences=non_sequences,
@@ -124,8 +81,7 @@ class KalmanSmoother:
 
         return smoothed_states, smoothed_covariances
 
-    def smoother_step(self, *args):
-        a, P, a_smooth, P_smooth, T, R, Q = self.unpack_args(args)
+    def smoother_step(self, a, P, a_smooth, P_smooth, T, R, Q):
         a_hat, P_hat = self.predict(a, P, T, R, Q)
 
         # Use pinv, otherwise P_hat is singular when there is missing data

--- a/pymc_extras/statespace/filters/utilities.py
+++ b/pymc_extras/statespace/filters/utilities.py
@@ -1,12 +1,9 @@
-from collections.abc import Iterable
-
 import pytensor.tensor as pt
 
-from pymc_extras.statespace.utils.constants import (
-    JITTER_DEFAULT,
-    LONG_NAME_TO_SHORT,
-    MATRIX_NAMES,
-)
+from pytensor.graph.basic import Variable
+
+from pymc_extras.statespace.core.assumptions import is_time_varying
+from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, MATRIX_NAMES
 
 # The filter's scan takes x0 and P0 as outputs_info rather than inputs, so they are not
 # among the matrices split into sequences and non-sequences.
@@ -34,56 +31,78 @@ def dim_of(tensor, axis: int):
     return static_length if static_length is not None else tensor.shape[axis]
 
 
-def scan_sequence_names(time_varying_names: Iterable[str]) -> list[str]:
+def split_by_time_axis(
+    matrices: dict[str, Variable],
+) -> tuple[list[Variable], list[Variable], list[str], list[str]]:
     """
-    Return the names of the matrices the Kalman filter passes to ``scan`` as sequences.
+    Split matrices into ``scan`` sequences and non-sequences by asking each for its time axis.
 
     Parameters
     ----------
-    time_varying_names : iterable of str
-        Long names of the matrices the model declared time-varying, as given by
-        :attr:`PytensorRepresentation.time_varying_names`.
+    matrices : dict mapping str to TensorVariable
+        Matrices to split, keyed by short name.
 
     Returns
     -------
+    sequences : list of TensorVariable
+        Matrices carrying a time axis, in the order ``matrices`` gives them.
+    non_sequences : list of TensorVariable
+        The rest, in the same order.
     seq_names : list of str
-        Short matrix names, ordered as ``scan`` receives them.
+        Names matching ``sequences``.
+    non_seq_names : list of str
+        Names matching ``non_sequences``.
     """
-    time_varying_short = {LONG_NAME_TO_SHORT[name] for name in time_varying_names}
-    return [name for name in PARAM_NAMES if name in time_varying_short]
+    varying = is_time_varying(*matrices.values())
+    seq_names = [name for name, flag in zip(matrices, varying, strict=True) if flag]
+    non_seq_names = [name for name, flag in zip(matrices, varying, strict=True) if not flag]
+
+    return (
+        [matrices[name] for name in seq_names],
+        [matrices[name] for name in non_seq_names],
+        seq_names,
+        non_seq_names,
+    )
 
 
-def split_vars_into_seq_and_nonseq(params, param_names, time_varying_names: Iterable[str]):
-    """Split filter inputs into scan sequences and non-sequences.
+def unpack_scan_step(
+    args: tuple, seq_names: list[str], non_seq_names: list[str], order: tuple[str, ...]
+) -> tuple[tuple, tuple]:
+    """
+    Split one ``scan`` step's arguments into its recurrent states and its matrices.
+
+    ``scan`` passes sequences first, then ``outputs_info``, then non-sequences, so where a given
+    matrix lands depends on how many of them carry a time axis.
 
     Parameters
     ----------
-    params : sequence of TensorVariable
-        Filter input matrices in the order given by ``param_names``.
-    param_names : sequence of str
-        Long names of the matrices in ``params``.
-    time_varying_names : iterable of str
-        Names of matrices the model declared as time-varying. Anything in this set is
-        treated as a scan sequence; everything else is a non-sequence.
+    args : tuple
+        The step function's arguments, less any leading sequences the caller took for itself.
+    seq_names : list of str
+        Names of the matrices passed as sequences, in the order ``scan`` receives them.
+    non_seq_names : list of str
+        Names of the matrices passed as non-sequences, in the order ``scan`` receives them.
+    order : tuple of str
+        Names of the matrices to return, in the order the caller wants them.
 
     Returns
     -------
-    sequences, non_sequences, seq_names, non_seq_names : four lists
-        The split inputs and their names.
+    recurrent : tuple
+        The ``outputs_info`` values, which sit between the sequences and the non-sequences.
+    matrices : tuple
+        The matrices named by ``order``.
     """
-    time_varying_names = frozenset(time_varying_names)
-    sequences, non_sequences = [], []
-    seq_names, non_seq_names = [], []
+    n_seq, n_non_seq = len(seq_names), len(non_seq_names)
+    n_recurrent = len(args) - n_seq - n_non_seq
 
-    for param, name in zip(params, param_names):
-        if name in time_varying_names:
-            sequences.append(param)
-            seq_names.append(name)
-        else:
-            non_sequences.append(param)
-            non_seq_names.append(name)
+    seqs = args[:n_seq]
+    recurrent = args[n_seq : n_seq + n_recurrent]
+    non_seqs = args[n_seq + n_recurrent :]
 
-    return sequences, non_sequences, seq_names, non_seq_names
+    matrices = dict(zip(seq_names, seqs, strict=True)) | dict(
+        zip(non_seq_names, non_seqs, strict=True)
+    )
+    return recurrent, tuple(matrices[name] for name in order)
 
 
 def stabilize(cov, jitter=JITTER_DEFAULT):

--- a/pymc_extras/statespace/models/structural/core.py
+++ b/pymc_extras/statespace/models/structural/core.py
@@ -265,7 +265,6 @@ class StructuralTimeSeries(PyMCStateSpace):
         self.ssm = PytensorRepresentation(
             k_endog=ssm.k_endog, k_states=ssm.k_states, k_posdef=self.k_posdef, **matrices
         )
-        self.ssm.declare_time_varying(*ssm.time_varying_names)
 
     def _populate_properties(self) -> None:
         # The base class method needs to be overridden because we directly set properties in
@@ -912,8 +911,6 @@ class Component:
             obs_cov=obs_cov,
             state_cov=state_cov,
         )
-        new_ssm.declare_time_varying(*(self.ssm.time_varying_names | other.ssm.time_varying_names))
-
         return new_ssm
 
     def _combine_component_info(self, other):

--- a/tests/statespace/core/test_assumptions.py
+++ b/tests/statespace/core/test_assumptions.py
@@ -1,0 +1,55 @@
+import numpy as np
+import pytensor.tensor as pt
+import pytest
+
+from pymc_extras.statespace.core.assumptions import declare_time_varying, is_time_varying
+
+Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
+
+
+@pytest.mark.parametrize(
+    ("expression", "expected"),
+    [
+        (Z, True),
+        (Z * 2, True),
+        (Z[5:], True),
+        (Z[5:20], True),
+        (pt.specify_shape(Z, (100, 2, 3)), True),
+        (pt.concatenate([Z[:5], Z[5:]], axis=0), True),
+        (pt.concatenate([Z, Z], axis=1), True),
+        (Z[:, :, np.array([2, 0, 1])], True),
+        (pt.set_subtensor(Z[0, 0, 0], 1.0), True),
+        (pt.set_subtensor(Z[:, 0, 0], pt.vector("v", shape=(100,))), True),
+        (Z[0], False),
+        (Z[0][None], False),
+        (Z[np.array([2, 0, 1])], False),
+        (Z.sum(axis=0), False),
+        (pt.zeros((100, 2, 3)) + Z.sum(), False),
+        (pt.tensor("W", shape=(100, 2, 3)), False),
+    ],
+    ids=[
+        "declared",
+        "elemwise",
+        "open_slice",
+        "closed_slice",
+        "specify_shape",
+        "join_on_time",
+        "join_off_time",
+        "reorder_off_time",
+        "write_one_element",
+        "write_a_column",
+        "index_time",
+        "index_then_expand",
+        "gather_time",
+        "reduce_time",
+        "static_from_a_reduction",
+        "undeclared",
+    ],
+)
+def test_declaration_survives_exactly_the_ops_that_keep_the_time_axis(expression, expected):
+    assert is_time_varying(expression) == [expected]
+
+
+def test_matrices_are_reported_in_the_order_they_are_given():
+    static = pt.matrix("static")
+    assert is_time_varying(static, Z, static, Z) == [False, True, False, True]

--- a/tests/statespace/core/test_assumptions.py
+++ b/tests/statespace/core/test_assumptions.py
@@ -7,6 +7,10 @@ from pytensor.graph.replace import graph_replace
 from pymc_extras.statespace.core.assumptions import declare_time_varying, is_time_varying
 
 Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
+# Square, so it can go through the Blockwise linalg ops the models and the filter use.
+T = declare_time_varying(pt.tensor("T", shape=(100, 3, 3)))
+# Declared on a core axis rather than a batch one, which a Blockwise may reshape away.
+T_core = declare_time_varying(pt.tensor("T_core", shape=(3, 3)))
 
 
 @pytest.mark.parametrize(
@@ -29,6 +33,15 @@ Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
         (Z.sum(axis=0), False),
         (pt.zeros((100, 2, 3)) + Z.sum(), False),
         (pt.tensor("W", shape=(100, 2, 3)), False),
+        (pt.linalg.block_diag(T, pt.tensor("S", shape=(2, 2))), True),
+        (pt.linalg.block_diag(pt.tensor("S", shape=(2, 2)), T), True),
+        (pt.linalg.cholesky(T), True),
+        (pt.linalg.solve(T, T, b_ndim=2), True),
+        (pt.linalg.block_diag(T_core, pt.tensor("S", shape=(2, 2))), False),
+        (
+            pt.linalg.block_diag(pt.tensor("S", shape=(2, 2)), pt.tensor("S2", shape=(3, 3))),
+            False,
+        ),
     ],
     ids=[
         "declared",
@@ -48,6 +61,12 @@ Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
         "reduce_time",
         "static_from_a_reduction",
         "undeclared",
+        "block_diag_time_varying_first",
+        "block_diag_time_varying_second",
+        "blockwise_cholesky",
+        "blockwise_solve",
+        "block_diag_declared_on_a_core_axis",
+        "block_diag_of_static_matrices",
     ],
 )
 def test_declaration_survives_exactly_the_ops_that_keep_the_time_axis(expression, expected):

--- a/tests/statespace/core/test_assumptions.py
+++ b/tests/statespace/core/test_assumptions.py
@@ -2,6 +2,8 @@ import numpy as np
 import pytensor.tensor as pt
 import pytest
 
+from pytensor.graph.replace import graph_replace
+
 from pymc_extras.statespace.core.assumptions import declare_time_varying, is_time_varying
 
 Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
@@ -20,6 +22,7 @@ Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
         (Z[:, :, np.array([2, 0, 1])], True),
         (pt.set_subtensor(Z[0, 0, 0], 1.0), True),
         (pt.set_subtensor(Z[:, 0, 0], pt.vector("v", shape=(100,))), True),
+        (pt.set_subtensor(pt.tensor("S", shape=(2, 3))[0], Z[0, 0]), False),
         (Z[0], False),
         (Z[0][None], False),
         (Z[np.array([2, 0, 1])], False),
@@ -38,6 +41,7 @@ Z = declare_time_varying(pt.tensor("Z", shape=(100, 2, 3)))
         "reorder_off_time",
         "write_one_element",
         "write_a_column",
+        "write_a_time_varying_value_into_a_static_base",
         "index_time",
         "index_then_expand",
         "gather_time",
@@ -53,3 +57,13 @@ def test_declaration_survives_exactly_the_ops_that_keep_the_time_axis(expression
 def test_matrices_are_reported_in_the_order_they_are_given():
     static = pt.matrix("static")
     assert is_time_varying(static, Z, static, Z) == [False, True, False, True]
+
+
+def test_declaration_survives_substitution():
+    """Models declare on a placeholder and swap in the real parameter with ``graph_replace``."""
+    placeholder = pt.tensor("Z", shape=(None, 2, 3))
+    declared = declare_time_varying(placeholder)
+
+    substituted = graph_replace(declared, {placeholder: pt.tensor("Z_real", shape=(100, 2, 3))})
+
+    assert is_time_varying(substituted) == [True]

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -7,6 +7,7 @@ import pytest
 
 from numpy.testing import assert_allclose, assert_array_equal
 
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
 from pymc_extras.statespace.utils.constants import (
     FILTER_OUTPUT_DIMS,
@@ -266,11 +267,18 @@ def test_sample_statespace_matrices_keeps_its_dims(exog_ss_mod, idata_exog):
         idata_exog, matrix_names=LONG_MATRIX_NAMES, group="prior"
     )
     sampled = matrix_idata.posterior_predictive
+    varying = dict(
+        zip(
+            LONG_MATRIX_NAMES,
+            is_time_varying(*(exog_ss_mod.ssm[name] for name in LONG_MATRIX_NAMES)),
+            strict=True,
+        )
+    )
 
     for short_name in MATRIX_NAMES:
         long_name = SHORT_NAME_TO_LONG[short_name]
         expected = ("chain", "draw", *MATRIX_DIMS[short_name])
-        if long_name in exog_ss_mod.ssm.time_varying_names:
+        if varying[long_name]:
             expected = ("chain", "draw", TIME_DIM, *MATRIX_DIMS[short_name])
 
         assert sampled[long_name].dims == expected, f"{long_name} lost its dims"

--- a/tests/statespace/core/test_representation.py
+++ b/tests/statespace/core/test_representation.py
@@ -6,6 +6,7 @@ import pytensor.tensor as pt
 
 from numpy.testing import assert_allclose
 
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.core.representation import PytensorRepresentation
 from tests.statespace.shared_fixtures import TEST_SEED
 from tests.statespace.test_utilities import fast_eval, make_test_inputs
@@ -133,6 +134,28 @@ class BasicFunctionality(unittest.TestCase):
 
         self.assertEqual(x0.name, "x0")
         self.assertEqual(ssm["initial_state"].name, "initial_state")
+
+    def test_declaring_a_core_rank_matrix_time_varying_raises(self):
+        """There is no leading axis to iterate over, so the declaration cannot mean anything."""
+        ssm = PytensorRepresentation(k_endog=2, k_states=3, k_posdef=1)
+
+        with self.assertRaises(ValueError) as e:
+            ssm.declare_time_varying("design")
+
+        self.assertIn("(time, 2, 3)", str(e.exception))
+
+    def test_replacing_a_matrix_of_equal_rank_keeps_the_declaration(self):
+        """A same-rank replacement describes the same axes, so the time axis carries over."""
+        ssm = PytensorRepresentation(k_endog=1, k_states=1, k_posdef=1)
+        ssm["state_cov"] = pt.tensor("Q", shape=(None, 1, 1))
+        ssm.declare_time_varying("state_cov")
+
+        ssm["state_cov"] = pt.tensor("Q_new", shape=(None, 1, 1))
+        self.assertEqual(is_time_varying(ssm["state_cov"]), [True])
+
+        # Dropping back to the core rank redefines the axes, so the declaration does not survive.
+        ssm["state_cov"] = pt.matrix("Q_static", shape=(1, 1))
+        self.assertEqual(is_time_varying(ssm["state_cov"]), [False])
 
     def test_invalid_key_name_raises(self):
         ssm = PytensorRepresentation(k_endog=3, k_states=5, k_posdef=1)

--- a/tests/statespace/filters/test_distributions.py
+++ b/tests/statespace/filters/test_distributions.py
@@ -8,6 +8,7 @@ from numpy.testing import assert_allclose
 from scipy.stats import multivariate_normal
 
 from pymc_extras.statespace import structural
+from pymc_extras.statespace.core.assumptions import declare_time_varying
 from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
     SequenceMvNormal,
@@ -173,7 +174,6 @@ def test_lgss_distribution_with_dims(output_name, ss_mod_me, pymc_model_2):
             *matrices,
             steps=100,
             dims=[TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM],
-            sequence_names=[],
             k_endog=ss_mod_me.k_endog,
         )
         # pylint: enable=unpacking-non-sequence
@@ -220,7 +220,6 @@ def test_lgss_with_time_varying_inputs(output_name, rng):
             "states",
             *matrices,
             steps=9,
-            sequence_names=["d", "Z"],
             dims=[TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM],
         )
         # pylint: enable=unpacking-non-sequence
@@ -247,13 +246,15 @@ def test_forward_simulation_reads_one_matrix_row_per_timestep(append_x0):
     steps = 4
     scalar_zero = np.zeros((1, 1), dtype=floatX)
     scalar_one = np.ones((1, 1), dtype=floatX)
-    d_time_varying = (np.arange(steps + 1, dtype=floatX) * 100).reshape(-1, 1)
+    d_time_varying = declare_time_varying(
+        pt.as_tensor_variable((np.arange(steps + 1, dtype=floatX) * 100).reshape(-1, 1))
+    )
 
     alpha, y, _ = _forward_simulate_latent_and_obs(
         pt.as_tensor_variable(np.zeros(1, dtype=floatX)),
         pt.as_tensor_variable(scalar_zero),
         pt.as_tensor_variable(np.ones(1, dtype=floatX)),
-        pt.as_tensor_variable(d_time_varying),
+        d_time_varying,
         pt.as_tensor_variable(scalar_one),
         pt.as_tensor_variable(scalar_one),
         pt.as_tensor_variable(scalar_one),
@@ -261,7 +262,6 @@ def test_forward_simulation_reads_one_matrix_row_per_timestep(append_x0):
         pt.as_tensor_variable(scalar_zero),
         steps=steps,
         rng=pytensor.shared(np.random.default_rng(0)),
-        sequence_names=("d",),
         append_x0=append_x0,
     )
     alpha_val, y_val = (v.ravel() for v in pytensor.function([], [alpha, y])())
@@ -294,10 +294,8 @@ def test_lgss_signature():
     assert lgss.owner.op.ndims_params == [1, 2, 1, 1, 2, 2, 2, 2, 2]
 
     # Case with time-varying matrices
-    T = pt.tensor("T", shape=(None, None, None))
-    lgss = _LinearGaussianStateSpace.dist(
-        x0, P0, c, d, T, Z, R, H, Q, steps=100, sequence_names=["T"]
-    )
+    T = declare_time_varying(pt.tensor("T", shape=(None, None, None)))
+    lgss = _LinearGaussianStateSpace.dist(x0, P0, c, d, T, Z, R, H, Q, steps=100)
 
     assert (
         lgss.owner.op.extended_signature
@@ -446,7 +444,7 @@ def test_simulation_smoother_signature(small_lgssm):
     )
 
     # Time-varying case: the declared matrix gains a leading time axis.
-    d_time_varying = pt.tensor("d", shape=(None, None))
+    d_time_varying = declare_time_varying(pt.tensor("d", shape=(None, None)))
     sample = SimulationSmoother.dist(
         a_smooth,
         pt.as_tensor_variable(params["a0"]),
@@ -458,9 +456,8 @@ def test_simulation_smoother_signature(small_lgssm):
         pt.as_tensor_variable(params["R"]),
         pt.as_tensor_variable(params["H"]),
         pt.as_tensor_variable(params["Q"]),
-        kalman_filter=StandardFilter(time_varying_names=["obs_intercept"]),
+        kalman_filter=StandardFilter(),
         kalman_smoother=KalmanSmoother(),
-        sequence_names=("d",),
     )
     assert (
         sample.owner.op.extended_signature
@@ -510,8 +507,8 @@ def test_simulation_smoother_unbiased_under_large_d(small_lgssm):
 def test_simulation_smoother_with_time_varying_matrix(small_lgssm):
     """Draws stay centered on the smoothed mean when a matrix varies over time.
 
-    Exercises the ``sequence_names`` path, where the forward simulation, the filter and
-    the smoother must all index the same timestep of ``d``.
+    The forward simulation, the filter and the smoother must all index the same timestep
+    of ``d``.
     """
     params = small_lgssm
     n_steps, k_endog = params["n_steps"], params["d"].shape[0]
@@ -524,10 +521,10 @@ def test_simulation_smoother_with_time_varying_matrix(small_lgssm):
     tensors = {
         k: pt.as_tensor_variable(params[k]) for k in ("a0", "P0", "c", "T", "Z", "R", "H", "Q")
     }
-    d = pt.as_tensor_variable(d_time_varying)
+    d = declare_time_varying(pt.as_tensor_variable(d_time_varying))
     y = pt.as_tensor_variable(np.asarray(params["y"], dtype=floatX))
 
-    filt = StandardFilter(time_varying_names=["obs_intercept"]).build_graph(
+    filt = StandardFilter().build_graph(
         y,
         tensors["a0"],
         tensors["P0"],
@@ -554,9 +551,8 @@ def test_simulation_smoother_with_time_varying_matrix(small_lgssm):
         tensors["R"],
         tensors["H"],
         tensors["Q"],
-        kalman_filter=StandardFilter(time_varying_names=["obs_intercept"]),
+        kalman_filter=StandardFilter(),
         kalman_smoother=KalmanSmoother(),
-        sequence_names=("d",),
         rng=pytensor.shared(np.random.default_rng(7), name="rng"),
     )
     f = pm.compile([], [a_smooth, sample], on_unused_input="ignore")

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -8,6 +8,7 @@ import pytest
 
 from numpy.testing import assert_allclose, assert_array_less
 
+from pymc_extras.statespace.core.assumptions import declare_time_varying
 from pymc_extras.statespace.filters import (
     KalmanSmoother,
     SquareRootFilter,
@@ -15,11 +16,7 @@ from pymc_extras.statespace.filters import (
     UnivariateFilter,
 )
 from pymc_extras.statespace.filters.kalman_filter import BaseFilter
-from pymc_extras.statespace.utils.constants import (
-    LONG_NAME_TO_SHORT,
-    MATRIX_NAMES,
-    MISSING_FILL,
-)
+from pymc_extras.statespace.utils.constants import MATRIX_NAMES, MISSING_FILL
 from tests.statespace.shared_fixtures import (  # pylint: disable=unused-import
     rng,
 )
@@ -124,8 +121,7 @@ def test_output_shapes_when_some_states_are_deterministic(filter_name, rng):
 
 @pytest.fixture
 def f_standard_nd():
-    time_varying_names = ("transition", "design", "selection", "obs_cov", "state_cov")
-    ksmoother = KalmanSmoother(time_varying_names=time_varying_names)
+    ksmoother = KalmanSmoother()
     data = pt.tensor(name="data", dtype=floatX, shape=(None, None))
     a0 = pt.vector(name="a0", dtype=floatX)
     P0 = pt.matrix(name="P0", dtype=floatX)
@@ -138,6 +134,7 @@ def f_standard_nd():
     Z = pt.tensor(name="Z", dtype=floatX, shape=(None, None, None))
 
     inputs = [data, a0, P0, c, d, T, Z, R, H, Q]
+    T, Z, R, H, Q = (declare_time_varying(m) for m in (T, Z, R, H, Q))
 
     (
         filtered_states,
@@ -147,7 +144,7 @@ def f_standard_nd():
         predicted_covs,
         observed_covs,
         ll_obs,
-    ) = StandardFilter(time_varying_names=time_varying_names).build_graph(*inputs)
+    ) = StandardFilter().build_graph(data, a0, P0, c, d, T, Z, R, H, Q)
 
     smoothed_states, smoothed_covs = ksmoother.build_graph(T, R, Q, filtered_states, filtered_covs)
 
@@ -168,37 +165,23 @@ def f_standard_nd():
 
 
 @pytest.mark.parametrize(
-    ("time_varying_names", "expected_seq_names"),
-    [
-        ((), []),
-        (("transition",), ["T"]),
-        (("design", "obs_intercept"), ["d", "Z"]),
-        (
-            ("transition", "design", "selection", "obs_cov", "state_cov"),
-            ["T", "Z", "R", "H", "Q"],
-        ),
-    ],
+    "declared_names",
+    [(), ("T",), ("Z", "d"), ("T", "Z", "R", "H", "Q")],
     ids=["none", "one", "declared_out_of_order", "many"],
 )
-def test_time_varying_matrices_become_scan_sequences_in_matrix_order(
-    time_varying_names, expected_seq_names, rng
-):
-    """``scan`` receives sequences in matrix order, not the order the model declared them."""
+def test_time_varying_matrices_become_scan_sequences_in_matrix_order(declared_names, rng):
+    """``scan`` receives sequences in matrix order, not the order the caller declared them."""
     p, m, r, n = 1, 5, 2, 10
-    inputs = list(make_test_inputs(p, m, r, n, rng))
+    inputs = [pt.as_tensor_variable(x) for x in make_test_inputs(p, m, r, n, rng)]
 
     # inputs are [data, a0, P0, c, d, T, Z, R, H, Q]; a time-varying matrix needs a leading time axis.
     index_of = dict(zip(MATRIX_NAMES[2:], range(3, 10), strict=True))
-    for long_name in time_varying_names:
-        i = index_of[LONG_NAME_TO_SHORT[long_name]]
-        inputs[i] = np.repeat(np.expand_dims(inputs[i], 0), n, axis=0)
-
-    kfilter = StandardFilter(time_varying_names=time_varying_names)
-    assert kfilter.seq_names == expected_seq_names
-    assert kfilter.non_seq_names == [n for n in MATRIX_NAMES[2:] if n not in expected_seq_names]
+    for name in declared_names:
+        i = index_of[name]
+        inputs[i] = declare_time_varying(pt.repeat(inputs[i][None], n, axis=0))
 
     # Building proves the split is usable: a mis-ordered sequence fails on a shape mismatch.
-    kfilter.build_graph(*[pt.as_tensor_variable(x) for x in inputs])
+    StandardFilter().build_graph(*inputs)
 
 
 def test_output_shapes_with_time_varying_matrices(f_standard_nd, rng):
@@ -546,13 +529,13 @@ def test_convergent_filter_rejects_time_varying_params():
     P0 = pt.matrix("P0")
     c = pt.vector("c")
     d = pt.vector("d")
-    T = pt.matrix("T")
+    T = declare_time_varying(pt.tensor3("T"))
     Z = pt.matrix("Z")
     R = pt.matrix("R")
     H = pt.matrix("H")
     Q = pt.matrix("Q")
-    with pytest.raises(ValueError, match=r"time-invariant.*\['transition'\]"):
-        ConvergentFilter(time_varying_names=["transition"])
+    with pytest.raises(ValueError, match=r"time-invariant.*\['T'\]"):
+        ConvergentFilter().build_graph(data, a0, P0, c, d, T, Z, R, H, Q)
 
 
 def test_convergent_filter_rejects_nan_constant_data():

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -35,6 +35,17 @@ floatX = pytensor.config.floatX
 ATOL = 1e-6 if floatX.endswith("64") else 1e-3
 RTOL = 1e-6 if floatX.endswith("64") else 1e-3
 
+# The order BaseFilter.build_graph returns its outputs in.
+BUILD_GRAPH_OUTPUT_NAMES = (
+    "filtered_states",
+    "predicted_states",
+    "observed_states",
+    "filtered_covariances",
+    "predicted_covariances",
+    "observed_covariances",
+    "loglike_obs",
+)
+
 
 @cache
 def get_filter_function(filter_name: str) -> Callable:
@@ -167,21 +178,34 @@ def f_standard_nd():
 @pytest.mark.parametrize(
     "declared_names",
     [(), ("T",), ("Z", "d"), ("T", "Z", "R", "H", "Q")],
-    ids=["none", "one", "declared_out_of_order", "many"],
+    ids=["none", "one", "two", "many"],
 )
-def test_time_varying_matrices_become_scan_sequences_in_matrix_order(declared_names, rng):
-    """``scan`` receives sequences in matrix order, not the order the caller declared them."""
+def test_declared_matrices_filter_identically_to_their_static_form(declared_names, rng):
+    """A matrix repeated over time filters the same as the static matrix it repeats.
+
+    Any matrix handed to ``scan`` as the wrong sequence, or read at the wrong timestep, moves the
+    filtered states away from the static answer.
+    """
     p, m, r, n = 1, 5, 2, 10
     inputs = [pt.as_tensor_variable(x) for x in make_test_inputs(p, m, r, n, rng)]
 
     # inputs are [data, a0, P0, c, d, T, Z, R, H, Q]; a time-varying matrix needs a leading time axis.
     index_of = dict(zip(MATRIX_NAMES[2:], range(3, 10), strict=True))
+    declared_inputs = list(inputs)
     for name in declared_names:
         i = index_of[name]
-        inputs[i] = declare_time_varying(pt.repeat(inputs[i][None], n, axis=0))
+        declared_inputs[i] = declare_time_varying(pt.repeat(inputs[i][None], n, axis=0))
 
-    # Building proves the split is usable: a mis-ordered sequence fails on a shape mismatch.
-    StandardFilter().build_graph(*inputs)
+    static = StandardFilter().build_graph(*inputs)
+    declared = StandardFilter().build_graph(*declared_inputs)
+
+    results = pytensor.function([], [*static, *declared], on_unused_input="ignore")()
+    n_outputs = len(static)
+
+    for name, expected, got in zip(
+        BUILD_GRAPH_OUTPUT_NAMES, results[:n_outputs], results[n_outputs:], strict=True
+    ):
+        assert_allclose(expected, got, err_msg=name, atol=ATOL, rtol=RTOL)
 
 
 def test_output_shapes_with_time_varying_matrices(f_standard_nd, rng):

--- a/tests/statespace/models/structural/test_core.py
+++ b/tests/statespace/models/structural/test_core.py
@@ -11,6 +11,7 @@ from pytensor import tensor as pt
 from pytensor.graph.traversal import explicit_graph_inputs
 from scipy import linalg
 
+from pymc_extras.statespace.core.assumptions import is_time_varying
 from pymc_extras.statespace.models import structural as st
 from pymc_extras.statespace.utils.constants import MATRIX_NAMES
 from tests.statespace.test_utilities import (
@@ -21,6 +22,16 @@ from tests.statespace.test_utilities import (
 floatX = config.floatX
 ATOL = 1e-8 if floatX.endswith("64") else 1e-4
 RTOL = 0 if floatX.endswith("64") else 1e-6
+
+
+def test_combining_components_preserves_a_time_varying_declaration():
+    """Composition pads, reorders and concatenates the design matrix; time-variance survives it."""
+    regression = st.Regression(state_names=["a"], name="exog", observed_state_names=["y1"])
+    assert is_time_varying(regression.ssm["design"]) == [True]
+
+    combined = st.LevelTrend(order=1, observed_state_names=["y1", "y2"]) + regression
+    assert is_time_varying(combined.ssm["design"]) == [True]
+    assert is_time_varying(combined.build(verbose=False).ssm["design"]) == [True]
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")


### PR DESCRIPTION
Which matrices are time-varying was tracked as a set of names on the representation and then hand-carried to everything downstream — `sequence_names` through four call layers, `time_varying_names` into the filter and smoother constructors, and a module-level list in `_forward_simulate_latent_and_obs` to put the scan's arguments back in order. Any transformation that produced a new variable dropped the fact on the floor, so every consumer had to be told again.

Now `declare_time_varying` tags the tensor with a pytensor assumption and consumers ask the matrix. Slicing, substitution, elementwise math, and component composition preserve it; indexing or reducing the time axis clears it.

User-facing API is unchanged — `self.ssm.declare_time_varying("state_cov")` in `make_symbolic_graph` as before. One behavior change: declaring a matrix still at its core rank now raises instead of silently doing nothing, since there's no leading axis to attach the fact to.
