### PR TITLE
Return substituted statespace matrices instead of storing them

### DIFF
--- a/notebooks/DFM_Example_(Coincident_Index).ipynb
+++ b/notebooks/DFM_Example_(Coincident_Index).ipynb
@@ -1112,7 +1112,7 @@
     "\n",
     "    # Build symbolic graph\n",
     "    dfm.build_statespace_graph(data=endog)\n",
-    "    matrices = dfm._insert_random_variables()"
+    "    matrices = dfm.unpack_statespace()"
    ]
   },
   {
@@ -1677,7 +1677,7 @@
    "source": [
     "with pm.Model() as index_mod:\n",
     "    dfm._build_dummy_graph()\n",
-    "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm._insert_random_variables()\n",
+    "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm.unpack_statespace()\n",
     "\n",
     "    dfm.build_statespace_graph(data=endog, save_kalman_filter_outputs_in_idata=True)\n",
     "    predicted_covariance = index_mod[\"predicted_covariances\"]\n",

--- a/notebooks/DFM_Example_(Coincident_Index).ipynb
+++ b/notebooks/DFM_Example_(Coincident_Index).ipynb
@@ -977,16 +977,18 @@
     "]\n",
     "\n",
     "\n",
-    "def print_model_ssm(mod, how=\"eval\", precision=2, repr_width=40):\n",
+    "def print_model_ssm(mod, matrices=None, precision=2, repr_width=40):\n",
+    "    \"\"\"Print mod's statespace matrices. Pass bound matrices to draw from them; otherwise the\n",
+    "    unbound placeholder template is evaluated at its default values.\"\"\"\n",
     "    header = f\"{'name':<20}{'__repr__':<{repr_width}}{'shape':<10}{'value'}\"\n",
     "    print(header)\n",
     "    print(\"=\" * len(header))\n",
-    "    if how == \"eval\":\n",
-    "        matrices = [x.eval() for x in mod._unpack_statespace_with_placeholders()]\n",
-    "    elif how == \"draw\":\n",
-    "        matrices = pm.draw(mod.unpack_statespace())\n",
+    "    if matrices is None:\n",
+    "        values = [x.eval() for x in mod._unpack_statespace_with_placeholders()]\n",
+    "    else:\n",
+    "        values = pm.draw(matrices)\n",
     "\n",
-    "    for name, value in zip(matrix_names, matrices):\n",
+    "    for name, value in zip(matrix_names, values):\n",
     "        var = mod.ssm[name]\n",
     "        # Constants repr their full data; show a label instead and let the value column carry it.\n",
     "        repr_ = \"TensorConstant\" if isinstance(var, pt.TensorConstant) else str(var)\n",
@@ -1109,7 +1111,8 @@
     "    error_sigma = pm.HalfNormal(\"error_sigma\", sigma=0.2, shape=(4))\n",
     "\n",
     "    # Build symbolic graph\n",
-    "    dfm.build_statespace_graph(data=endog)"
+    "    dfm.build_statespace_graph(data=endog)\n",
+    "    matrices = dfm._insert_random_variables()"
    ]
   },
   {
@@ -1191,7 +1194,7 @@
     }
    ],
    "source": [
-    "print_model_ssm(dfm, \"draw\")"
+    "print_model_ssm(dfm, matrices)"
    ]
   },
   {
@@ -1674,8 +1677,7 @@
    "source": [
     "with pm.Model() as index_mod:\n",
     "    dfm._build_dummy_graph()\n",
-    "    dfm._insert_random_variables()\n",
-    "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm.unpack_statespace()\n",
+    "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm._insert_random_variables()\n",
     "\n",
     "    dfm.build_statespace_graph(data=endog, save_kalman_filter_outputs_in_idata=True)\n",
     "    predicted_covariance = index_mod[\"predicted_covariances\"]\n",

--- a/notebooks/DFM_Example_(Coincident_Index).ipynb
+++ b/notebooks/DFM_Example_(Coincident_Index).ipynb
@@ -1679,7 +1679,7 @@
     "    dfm._build_dummy_graph()\n",
     "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm.unpack_statespace()\n",
     "\n",
-    "    dfm.build_statespace_graph(data=endog, save_kalman_filter_outputs_in_idata=True)\n",
+    "    dfm.build_statespace_graph(data=endog)\n",
     "    predicted_covariance = index_mod[\"predicted_covariances\"]\n",
     "    filtered_state = index_mod[\"filtered_states\"]\n",
     "\n",

--- a/notebooks/Making a Custom Statespace Model.ipynb
+++ b/notebooks/Making a Custom Statespace Model.ipynb
@@ -38,16 +38,18 @@
     "]\n",
     "\n",
     "\n",
-    "def print_model_ssm(mod, how=\"eval\"):\n",
+    "def print_model_ssm(mod, matrices=None):\n",
+    "    \"\"\"Print mod's statespace matrices. Pass bound matrices to draw from them; otherwise the\n",
+    "    unbound placeholder template is evaluated at its default values.\"\"\"\n",
     "    nice_heading = f\"{'name':<20}{'__repr__':<50}{'shape':<10}{'value':<20}\"\n",
     "    print(nice_heading)\n",
     "    print(\"=\" * len(nice_heading))\n",
-    "    if how == \"eval\":\n",
-    "        matrices = [x.eval() for x in mod._unpack_statespace_with_placeholders()]\n",
-    "    elif how == \"draw\":\n",
-    "        matrices = pm.draw(mod.unpack_statespace())\n",
+    "    if matrices is None:\n",
+    "        values = [x.eval() for x in mod._unpack_statespace_with_placeholders()]\n",
+    "    else:\n",
+    "        values = pm.draw(matrices)\n",
     "\n",
-    "    for name, value in zip(matrix_names, matrices):\n",
+    "    for name, value in zip(matrix_names, values):\n",
     "        repr_ = str(mod.ssm[name])\n",
     "        shape = str(mod.ssm[name].type.shape)\n",
     "        value = str(value).replace(\"\\n \", \"\\n\" + \" \" * 81)\n",
@@ -560,7 +562,7 @@
     "    P0 = pm.Deterministic(\"P0\", pt.eye(3) * 10.0)\n",
     "    ar_params = pm.Deterministic(\"ar_params\", pt.as_tensor_variable([10.0, 11.0, 12.0]))\n",
     "    sigma_x = pm.Deterministic(\"sigma_x\", pt.as_tensor_variable(13.0, dtype=\"float64\"))\n",
-    "    ar3._insert_random_variables()"
+    "    matrices = ar3._insert_random_variables()"
    ]
   },
   {
@@ -568,7 +570,7 @@
    "id": "2503dfaf",
    "metadata": {},
    "source": [
-    "Nothing happens right away, but we now have access to a new class method: `unpack_statespace`:"
+    "It returns the nine statespace matrices, rewritten so that the model's random variables sit where the symbolic placeholders were:"
    ]
   },
   {
@@ -589,7 +591,6 @@
     }
    ],
    "source": [
-    "matrices = ar3.unpack_statespace()\n",
     "len(matrices)"
    ]
   },
@@ -641,7 +642,7 @@
     }
    ],
    "source": [
-    "print_model_ssm(ar3, \"draw\")"
+    "print_model_ssm(ar3, matrices)"
    ]
   },
   {
@@ -726,7 +727,8 @@
     "    ar_params = pm.Normal(\"ar_params\", sigma=0.25, shape=(3,))\n",
     "    sigma_x = pm.Exponential(\"sigma_x\", 1)\n",
     "\n",
-    "    ar3.build_statespace_graph(data=data)"
+    "    ar3.build_statespace_graph(data=data)\n",
+    "    matrices = ar3._insert_random_variables()"
    ]
   },
   {
@@ -777,7 +779,7 @@
     }
    ],
    "source": [
-    "print_model_ssm(ar3, \"draw\")"
+    "print_model_ssm(ar3, matrices)"
    ]
   },
   {

--- a/notebooks/Making a Custom Statespace Model.ipynb
+++ b/notebooks/Making a Custom Statespace Model.ipynb
@@ -728,7 +728,7 @@
     "    sigma_x = pm.Exponential(\"sigma_x\", 1)\n",
     "\n",
     "    ar3.build_statespace_graph(data=data)\n",
-    "    matrices = ar3._insert_random_variables()"
+    "    matrices = ar3.unpack_statespace()"
    ]
   },
   {

--- a/notebooks/SARIMAX Example.ipynb
+++ b/notebooks/SARIMAX Example.ipynb
@@ -954,8 +954,7 @@
    "source": [
     "with pm.Model(coords=ss_mod.coords):\n",
     "    ss_mod._build_dummy_graph()\n",
-    "    ss_mod._insert_random_variables()\n",
-    "    x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()\n",
+    "    x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_random_variables()\n",
     "\n",
     "    mu_star = pm.Deterministic(\n",
     "        \"mu_star\", pt.linalg.inv(pt.eye(ss_mod.k_states) - T) @ c, dims=[\"state\"]\n",

--- a/notebooks/SARIMAX Example.ipynb
+++ b/notebooks/SARIMAX Example.ipynb
@@ -954,7 +954,7 @@
    "source": [
     "with pm.Model(coords=ss_mod.coords):\n",
     "    ss_mod._build_dummy_graph()\n",
-    "    x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_random_variables()\n",
+    "    x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()\n",
     "\n",
     "    mu_star = pm.Deterministic(\n",
     "        \"mu_star\", pt.linalg.inv(pt.eye(ss_mod.k_states) - T) @ c, dims=[\"state\"]\n",

--- a/pymc_extras/statespace/core/dummy_graph.py
+++ b/pymc_extras/statespace/core/dummy_graph.py
@@ -70,7 +70,8 @@ def kalman_filter_outputs_from_dummy_graph(
     Returns
     -------
     matrices : list of tensors
-        Statespace matrices with dummy parameters.
+        Statespace matrices with dummy parameters substituted in, still carrying the ``n_timesteps``
+        placeholder. Pin it with :meth:`PyMCStateSpace._insert_constant_timestep` for the span you need.
     grouped_outputs : list of tuple of tensors
         A list of tuples, each containing the mean and covariance of the filtered, predicted, and smoothed
         states.
@@ -80,27 +81,25 @@ def kalman_filter_outputs_from_dummy_graph(
 
     pm_mod = modelcontext(None)
     build_dummy_graph(ss_mod)
-    ss_mod._insert_random_variables()
+    matrices = ss_mod._insert_random_variables()
 
     for name in ss_mod.data_names:
         if name not in pm_mod:
             pm.Data(**ss_mod._fit_exog_data[name])
 
-    ss_mod._insert_data_variables()
+    matrices = ss_mod._insert_data_variables(matrices)
 
     for name in ss_mod.data_names:
         if name in scenario.keys():
             pm.set_data({name: scenario[name]})
 
-    matrices = ss_mod.unpack_statespace()
-
     if data is None:
         data = ss_mod._fit_data
 
-    # Replace n_timesteps with data length for time-varying matrices
+    # Pinned to the data length only for the filter below; the returned matrices keep the
+    # n_timesteps placeholder so a caller can build over a different span.
     data_len = data.shape[0] if hasattr(data, "shape") else len(data)
-    matrices = ss_mod._insert_constant_timestep(matrices, data_len)
-    x0, P0, c, d, T, Z, R, H, Q = matrices
+    x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_constant_timestep(matrices, data_len)
 
     obs_coords = pm_mod.coords.get(OBS_STATE_DIM, None)
 
@@ -134,4 +133,4 @@ def kalman_filter_outputs_from_dummy_graph(
         (smoothed_states, smoothed_covariances),
     ]
 
-    return [x0, P0, c, d, T, Z, R, H, Q], grouped_outputs
+    return matrices, grouped_outputs

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -428,7 +428,7 @@ def _build_forecast_model(
         cov_dims = ["data_time", ALL_STATE_DIM, ALL_STATE_AUX_DIM]
 
     with pm.Model(coords=temp_coords) as forecast_model:
-        _, grouped_outputs = ss_mod._kalman_filter_outputs_from_dummy_graph(
+        unpinned_matrices, grouped_outputs = ss_mod._kalman_filter_outputs_from_dummy_graph(
             data_dims=["data_time", OBS_STATE_DIM],
         )
 
@@ -455,13 +455,12 @@ def _build_forecast_model(
             "P0_slice", cov_frozen[t0_idx], dims=cov_dims[1:] if cov_dims is not None else None
         )
 
-        # Get fresh matrices with n_timesteps placeholder still intact.
         # Build for the full timeline (training + forecast) so that time-varying matrices
         # continue at the correct phase, then slice to keep only the forecast portion.
         n_train = len(time_index)
         n_total = n_train + len(forecast_index)
 
-        full_matrices = ss_mod._insert_constant_timestep(ss_mod.unpack_statespace(), n_total)
+        full_matrices = ss_mod._insert_constant_timestep(unpinned_matrices, n_total)
         _, _, *forecast_matrices = full_matrices
 
         # For exogenous-data-driven matrices the time dimension comes from the

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -480,9 +480,8 @@ def sample_filter_outputs(
         dummy_graph.build_dummy_graph(ss_mod)
         matrices = ss_mod._insert_random_variables()
 
-        if ss_mod.data_names:
-            for name in ss_mod.data_names:
-                pm.Data(**ss_mod._fit_exog_data[name])
+        for name in ss_mod.data_names:
+            pm.Data(**ss_mod._fit_exog_data[name])
 
         matrices = ss_mod._insert_data_variables(matrices)
 

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -92,20 +92,13 @@ def _sample_conditional(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     with pm.Model(coords=ss_mod._fit_coords) as forward_model:
-        (
-            [
-                x0,
-                P0,
-                c,
-                d,
-                T,
-                Z,
-                R,
-                H,
-                Q,
-            ],
-            grouped_outputs,
-        ) = dummy_graph.kalman_filter_outputs_from_dummy_graph(ss_mod, data=data)
+        matrices, grouped_outputs = dummy_graph.kalman_filter_outputs_from_dummy_graph(
+            ss_mod, data=data
+        )
+        # The returned matrices keep the n_timesteps placeholder; pin it to the span the filter
+        # actually ran over so the observed-state graphs line up with grouped_outputs.
+        n_timesteps = grouped_outputs[0][0].shape[0]
+        x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_constant_timestep(matrices, n_timesteps)
 
         for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs):
             dummy_ll = pt.zeros_like(mu)
@@ -282,15 +275,15 @@ def _sample_unconditional(
 
     with pm.Model(coords=temp_coords if dims is not None else None) as forward_model:
         dummy_graph.build_dummy_graph(ss_mod)
-        ss_mod._insert_random_variables()
+        matrices = ss_mod._insert_random_variables()
 
         for name in ss_mod.data_names:
             pm.Data(**ss_mod._fit_exog_data[name])
 
-        ss_mod._insert_data_variables()
+        matrices = ss_mod._insert_data_variables(matrices)
         # The unconditional trajectory spans ``steps + 1`` timesteps, and time-varying
         # matrices carry one row per timestep.
-        matrices = ss_mod._insert_constant_timestep(ss_mod.unpack_statespace(), step=steps + 1)
+        matrices = ss_mod._insert_constant_timestep(matrices, step=steps + 1)
         x0, P0, c, d, T, Z, R, H, Q = matrices
 
         if not ss_mod.measurement_error:
@@ -426,13 +419,12 @@ def sample_statespace_matrices(
 
     with pm.Model(coords=ss_mod._fit_coords) as forward_model:
         dummy_graph.build_dummy_graph(ss_mod)
-        ss_mod._insert_random_variables()
+        matrices = ss_mod._insert_random_variables()
 
         for name in ss_mod.data_names:
             pm.Data(**ss_mod._fit_exog_data[name])
 
-        ss_mod._insert_data_variables()
-        matrices = ss_mod.unpack_statespace()
+        matrices = ss_mod._insert_data_variables(matrices)
         for short_name, matrix in zip(MATRIX_NAMES, matrices, strict=True):
             long_name = SHORT_NAME_TO_LONG[short_name]
             if (long_name in matrix_names) or (short_name in matrix_names):
@@ -486,15 +478,15 @@ def sample_filter_outputs(
 
     with pm.Model(coords=ss_mod.coords) as m:
         dummy_graph.build_dummy_graph(ss_mod)
-        ss_mod._insert_random_variables()
+        matrices = ss_mod._insert_random_variables()
 
         if ss_mod.data_names:
             for name in ss_mod.data_names:
                 pm.Data(**ss_mod._fit_exog_data[name])
 
-        ss_mod._insert_data_variables()
+        matrices = ss_mod._insert_data_variables(matrices)
 
-        x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()
+        x0, P0, c, d, T, Z, R, H, Q = matrices
         data = ss_mod._fit_data
 
         obs_coords = m.coords.get(OBS_STATE_DIM, None)

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -67,9 +67,9 @@ def impulse_response_function(
 
     with pm.Model(coords=simulation_coords):
         dummy_graph.build_dummy_graph(ss_mod)
-        ss_mod._insert_random_variables()
+        matrices = ss_mod._insert_random_variables()
 
-        matrices = ss_mod._insert_constant_timestep(ss_mod.unpack_statespace(), step=n_steps)
+        matrices = ss_mod._insert_constant_timestep(matrices, step=n_steps)
         P0, _, c, d, T, Z, R, H, post_Q = matrices
         x0 = pm.Deterministic("x0_new", pt.zeros(ss_mod.k_states), dims=[ALL_STATE_DIM])
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -517,9 +517,7 @@ class PyMCStateSpace:
         if not self._free_n_timesteps(matrices):
             return matrices
 
-        return self._insert_data_shape_into_n_timesteps(
-            matrices, self._observed_statespace_variable(pymc_model)
-        )
+        return self._insert_data_shape_into_n_timesteps(matrices, self._observed_data(pymc_model))
 
     def _free_n_timesteps(self, matrices: list[pt.TensorVariable]) -> tuple[Variable, ...]:
         """Return the ``n_timesteps`` inputs of ``matrices`` that no substitution has resolved."""
@@ -529,10 +527,13 @@ class PyMCStateSpace:
         )
 
     @staticmethod
-    def _observed_statespace_variable(pymc_model: Model) -> pt.TensorVariable:
-        """Return the filtered observation ``build_statespace_graph`` registered on the model.
+    def _observed_data(pymc_model: Model) -> pt.TensorVariable:
+        """Return the data ``build_statespace_graph`` registered as the filter's observation.
 
-        Identified by its ``Op`` rather than by name, so a user variable cannot be mistaken for it.
+        The observation is found by its ``Op`` rather than its name, so a user variable cannot be
+        mistaken for it. Its *value* is what gets returned, because that is a root of the model
+        graph -- taking the length off the observation itself would make every returned matrix
+        depend on the filter that produced it.
         """
         observed = [
             variable
@@ -549,7 +550,7 @@ class PyMCStateSpace:
                 f"Found {len(observed)} statespace observations on the active PyMC model, so "
                 "which one supplies the number of timesteps is ambiguous."
             )
-        return observed[0]
+        return pymc_model.rvs_to_values[observed[0]]
 
     @property
     def n_timesteps(self) -> Variable:

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -774,25 +774,17 @@ class PyMCStateSpace:
 
             ss_mod = pmss.BayesianSARIMAX(order=(2, 0, 2), verbose=False, stationary_initialization=True)
             with pm.Model():
-                 x0 = pm.Normal('x0', size=ss_mod.k_states)
-                 ar_params = pm.Normal('ar_params', size=ss_mod.p)
-                 ma_parama = pm.Normal('ma_params', size=ss_mod.q)
-                 sigma_state = pm.Normal('sigma_state')
+                x0 = pm.Normal("x0", size=ss_mod.k_states)
+                ar_params = pm.Normal("ar_params", size=ss_mod.p)
+                ma_params = pm.Normal("ma_params", size=ss_mod.q)
+                sigma_state = pm.Normal("sigma_state")
 
-                 matrices = ss_mod._insert_random_variables()
+                x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_random_variables()
 
-            pm.draw(matrices['transition'], random_seed=RANDOM_SEED)
+            pm.draw(T, random_seed=RANDOM_SEED)
             >>> array([[-0.90590386,  1.        ,  0.        ],
             >>>        [ 1.25190143,  0.        ,  1.        ],
             >>>        [ 0.        ,  0.        ,  0.        ]])
-
-            pm.draw(matrices['selection'], random_seed=RANDOM_SEED)
-            >>> array([[ 1.        ],
-            >>>        [-2.46741039],
-            >>>        [-0.28947689]])
-
-            pm.draw(matrices['state_cov'], random_seed=RANDOM_SEED)
-            >>> array([[-1.69353533]])
         """
 
         pymc_model = modelcontext(None)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -281,9 +281,6 @@ class PyMCStateSpace:
         # All models contain a state space representation and a Kalman filter
         self.ssm = PytensorRepresentation(k_endog, k_states, k_posdef)
 
-        # This will be populated with PyMC random matrices after calling _insert_random_variables
-        self.subbed_ssm: list[pt.TensorVariable] | None = None
-
         if filter_type.lower() not in FILTER_FACTORY.keys():
             raise NotImplementedError(
                 "The following are valid filter types: " + ", ".join(list(FILTER_FACTORY.keys()))
@@ -480,17 +477,12 @@ class PyMCStateSpace:
 
     def unpack_statespace(self) -> list[pt.TensorVariable]:
         """
-        Helper function to quickly obtain all statespace matrices in the standard order.
+        Return this model's statespace matrices in the standard order.
+
+        These are the template's own symbolic matrices, carrying a placeholder variable for every
+        model parameter. They are not bound to any PyMC model.
         """
-
-        if self.subbed_ssm is None:
-            raise ValueError(
-                "Cannot unpack the complete statespace system until PyMC model variables have been "
-                "inserted. To build the random statespace matrices, call build_statespace_graph() inside"
-                "a PyMC model context. "
-            )
-
-        return self.subbed_ssm
+        return list(self._unpack_statespace_with_placeholders())
 
     @property
     def n_timesteps(self) -> Variable:
@@ -773,7 +765,7 @@ class PyMCStateSpace:
                 "dims": pymc_mod.named_vars_to_dims.get(data_name, None),
             }
 
-    def _insert_random_variables(self):
+    def _insert_random_variables(self) -> list[pt.TensorVariable]:
         """
         Replace pytensor symbolic variables with PyMC random variables.
 
@@ -788,8 +780,7 @@ class PyMCStateSpace:
                  ma_parama = pm.Normal('ma_params', size=ss_mod.q)
                  sigma_state = pm.Normal('sigma_state')
 
-                 ss_mod._insert_random_variables()
-                 matrics = ss_mod.unpack_statespace()
+                 matrices = ss_mod._insert_random_variables()
 
             pm.draw(matrices['transition'], random_seed=RANDOM_SEED)
             >>> array([[-0.90590386,  1.        ,  0.        ],
@@ -830,9 +821,9 @@ class PyMCStateSpace:
         matrices = list(self._unpack_statespace_with_placeholders())
 
         replacement_dict = {var: pymc_model[name] for name, var in self._name_to_variable.items()}
-        self.subbed_ssm = graph_replace(matrices, replace=replacement_dict, strict=True)
+        return graph_replace(matrices, replace=replacement_dict, strict=True)
 
-    def _insert_data_variables(self):
+    def _insert_data_variables(self, matrices: list[pt.TensorVariable]) -> list[pt.TensorVariable]:
         """
         Replace symbolic pytensor variables with PyMC data containers.
 
@@ -840,7 +831,7 @@ class PyMCStateSpace:
         """
         data_names = self.data_names
         if not data_names:
-            return
+            return matrices
 
         pymc_model = modelcontext(None)
         found_data = []
@@ -858,9 +849,11 @@ class PyMCStateSpace:
             )
 
         replacement_dict = {data: pymc_model[name] for name, data in self._name_to_data.items()}
-        self.subbed_ssm = graph_replace(self.subbed_ssm, replace=replacement_dict, strict=True)
+        return graph_replace(matrices, replace=replacement_dict, strict=True)
 
-    def _insert_data_shape_into_n_timesteps(self, data):
+    def _insert_data_shape_into_n_timesteps(
+        self, matrices: list[pt.TensorVariable], data: pt.TensorVariable
+    ) -> list[pt.TensorVariable]:
         """
         Replace any occurrence of the n_timesteps symbolic variable with the length of the data.
 
@@ -872,25 +865,22 @@ class PyMCStateSpace:
         # Otherwise, we don't get symbolic linkage between time-varying matrix shapes and the data when the user calls
         # pm.set_data
         assert isinstance(data, pt.TensorVariable)
-        matrices = (
-            self.subbed_ssm
-            if self.subbed_ssm is not None
-            else self._unpack_statespace_with_placeholders()
-        )
-
         n_timestep_variables = tuple(
             variable
             for variable in explicit_graph_inputs(matrices)
             if variable.name == "n_timesteps"
         )
+        if not n_timestep_variables:
+            return matrices
 
-        if n_timestep_variables:
-            self._shared_timestep = data.shape[0].astype("int32")
-            replacement_dict = {var: self._shared_timestep for var in n_timestep_variables}
+        self._shared_timestep = data.shape[0].astype("int32")
+        replacement_dict = {var: self._shared_timestep for var in n_timestep_variables}
 
-            self.subbed_ssm = graph_replace(self.subbed_ssm, replace=replacement_dict, strict=False)
+        return graph_replace(matrices, replace=replacement_dict, strict=False)
 
-    def _insert_constant_timestep(self, matrices, step: int | pt.TensorVariable):
+    def _insert_constant_timestep(
+        self, matrices: list[pt.TensorVariable], step: int | pt.TensorVariable
+    ) -> list[pt.TensorVariable]:
         """
         Replace any occurrence of the n_timesteps symbolic variable with a constant integer.
 
@@ -973,9 +963,9 @@ class PyMCStateSpace:
 
         pm_mod = modelcontext(None)
 
-        self._insert_random_variables()
+        matrices = self._insert_random_variables()
         self._save_exogenous_data_info()
-        self._insert_data_variables()
+        matrices = self._insert_data_variables(matrices)
 
         obs_coords = pm_mod.coords.get(OBS_STATE_DIM, None)
         self._fit_data = data
@@ -988,12 +978,10 @@ class PyMCStateSpace:
         )
 
         # Order is important here: only call _insert_data_shape_into_n_timesteps after data has been registered.
-        self._insert_data_shape_into_n_timesteps(data)
+        matrices = self._insert_data_shape_into_n_timesteps(matrices, data)
 
         kalman_filter, _ = self.make_filters()
-        filter_outputs = kalman_filter.build_graph(
-            pt.as_tensor_variable(data), *self.unpack_statespace()
-        )
+        filter_outputs = kalman_filter.build_graph(pt.as_tensor_variable(data), *matrices)
 
         logp = filter_outputs.pop(-1)
         *_, observed_states = filter_outputs[:3]

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -483,6 +483,13 @@ class PyMCStateSpace:
         """
         return list(self._unpack_statespace_with_placeholders())
 
+    def _free_n_timesteps(self, matrices: list[pt.TensorVariable]) -> tuple[Variable, ...]:
+        """Return the ``n_timesteps`` inputs of ``matrices`` that no substitution has resolved."""
+        name = self.n_timesteps.name
+        return tuple(
+            variable for variable in explicit_graph_inputs(matrices) if variable.name == name
+        )
+
     @property
     def n_timesteps(self) -> Variable:
         """Symbolic placeholder for the number of time steps in the data."""
@@ -856,11 +863,7 @@ class PyMCStateSpace:
         # Otherwise, we don't get symbolic linkage between time-varying matrix shapes and the data when the user calls
         # pm.set_data
         assert isinstance(data, pt.TensorVariable)
-        n_timestep_variables = tuple(
-            variable
-            for variable in explicit_graph_inputs(matrices)
-            if variable.name == "n_timesteps"
-        )
+        n_timestep_variables = self._free_n_timesteps(matrices)
         if not n_timestep_variables:
             return matrices
 
@@ -879,12 +882,7 @@ class PyMCStateSpace:
         """
         step = pt.as_tensor_variable(step).astype("int32")
 
-        n_timestep_variables = tuple(
-            variable
-            for variable in explicit_graph_inputs(matrices)
-            if variable.name == "n_timesteps"
-        )
-
+        n_timestep_variables = self._free_n_timesteps(matrices)
         if not n_timestep_variables:
             return matrices
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -782,9 +782,9 @@ class PyMCStateSpace:
                 x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_random_variables()
 
             pm.draw(T, random_seed=RANDOM_SEED)
-            >>> array([[-0.90590386,  1.        ,  0.        ],
-            >>>        [ 1.25190143,  0.        ,  1.        ],
-            >>>        [ 0.        ,  0.        ,  0.        ]])
+            # array([[-0.90590386,  1.        ,  0.        ],
+            #        [ 1.25190143,  0.        ,  1.        ],
+            #        [ 0.        ,  0.        ,  0.        ]])
         """
 
         pymc_model = modelcontext(None)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -259,7 +259,6 @@ class PyMCStateSpace:
         self._fit_dims: dict[str, Sequence[str]] | None = None
         self._fit_data: pt.TensorVariable | None = None
         self._fit_exog_data: dict[str, dict] = {}
-        self._shared_timestep: pt.TensorVariable | None = None
 
         self._needs_exog_data = None
         self._tensor_variable_info = SymbolicVariableInfo()
@@ -873,8 +872,8 @@ class PyMCStateSpace:
         if not n_timestep_variables:
             return matrices
 
-        self._shared_timestep = data.shape[0].astype("int32")
-        replacement_dict = {var: self._shared_timestep for var in n_timestep_variables}
+        n_timesteps = data.shape[0].astype("int32")
+        replacement_dict = {var: n_timesteps for var in n_timestep_variables}
 
         return graph_replace(matrices, replace=replacement_dict, strict=False)
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -8,7 +8,7 @@ import pandas as pd
 import pytensor
 import pytensor.tensor as pt
 
-from pymc.model import modelcontext
+from pymc.model import Model, modelcontext
 from pymc.util import RandomState
 from pytensor.graph.basic import Variable
 from pytensor.graph.replace import graph_replace
@@ -44,6 +44,7 @@ from pymc_extras.statespace.filters import (
     UnivariateFilter,
 )
 from pymc_extras.statespace.filters.distributions import (
+    KalmanFilterRV,
     SequenceMvNormal,
 )
 from pymc_extras.statespace.filters.kalman_filter import BaseFilter
@@ -475,13 +476,50 @@ class PyMCStateSpace:
         return a0, P0, c, d, T, Z, R, H, Q
 
     def unpack_statespace(self) -> list[pt.TensorVariable]:
-        """
-        Return this model's statespace matrices in the standard order.
+        r"""
+        Return the statespace matrices bound to the active model's variables and data.
 
-        These are the template's own symbolic matrices, carrying a placeholder variable for every
-        model parameter. They are not bound to any PyMC model.
+        Call inside the model context :meth:`build_statespace_graph` was called in, to derive
+        further quantities from the fitted system -- the eigenvalues of :math:`T`, a steady-state
+        covariance, and so on:
+
+        .. code:: python
+
+            with pm.Model() as model:
+                ...
+                ss_mod.build_statespace_graph(data)
+                x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()
+                pm.Deterministic("T_eigenvalues", pt.linalg.eigvalsh(T))
+
+        Each call substitutes afresh, so the returned matrices are new graph nodes rather than the
+        ones the filter was built from. They evaluate identically.
+
+        Returns
+        -------
+        matrices : list of TensorVariable
+            ``x0``, ``P0``, ``c``, ``d``, ``T``, ``Z``, ``R``, ``H``, ``Q``.
+
+        Raises
+        ------
+        TypeError
+            If called outside a PyMC model context.
+        ValueError
+            If a matrix is built against ``n_timesteps`` and the active model holds no statespace
+            observation to take that length from.
         """
-        return list(self._unpack_statespace_with_placeholders())
+        pymc_model = modelcontext(None)
+        matrices = self._insert_random_variables()
+        matrices = self._insert_data_variables(matrices)
+
+        # Most models get their time axis from the exogenous data, which the substitution above
+        # already supplied. Only a matrix built directly against ``n_timesteps`` -- a seasonality
+        # with a duration, say -- still needs a length, and only that needs the observation.
+        if not self._free_n_timesteps(matrices):
+            return matrices
+
+        return self._insert_data_shape_into_n_timesteps(
+            matrices, self._observed_statespace_variable(pymc_model)
+        )
 
     def _free_n_timesteps(self, matrices: list[pt.TensorVariable]) -> tuple[Variable, ...]:
         """Return the ``n_timesteps`` inputs of ``matrices`` that no substitution has resolved."""
@@ -489,6 +527,29 @@ class PyMCStateSpace:
         return tuple(
             variable for variable in explicit_graph_inputs(matrices) if variable.name == name
         )
+
+    @staticmethod
+    def _observed_statespace_variable(pymc_model: Model) -> pt.TensorVariable:
+        """Return the filtered observation ``build_statespace_graph`` registered on the model.
+
+        Identified by its ``Op`` rather than by name, so a user variable cannot be mistaken for it.
+        """
+        observed = [
+            variable
+            for variable in pymc_model.observed_RVs
+            if isinstance(variable.owner.op, KalmanFilterRV)
+        ]
+        if not observed:
+            raise ValueError(
+                "The active PyMC model holds no statespace observation. Call "
+                "build_statespace_graph() inside this model context first."
+            )
+        if len(observed) > 1:
+            raise ValueError(
+                f"Found {len(observed)} statespace observations on the active PyMC model, so "
+                "which one supplies the number of timesteps is ambiguous."
+            )
+        return observed[0]
 
     @property
     def n_timesteps(self) -> Variable:

--- a/tests/statespace/core/conftest.py
+++ b/tests/statespace/core/conftest.py
@@ -68,7 +68,7 @@ def pymc_mod(ss_mod):
 
         ss_mod.build_statespace_graph(data=nile)
         names = ["x0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
-        for name, matrix in zip(names, ss_mod.unpack_statespace()):
+        for name, matrix in zip(names, ss_mod._insert_random_variables()):
             pm.Deterministic(name, matrix)
 
     return pymc_mod

--- a/tests/statespace/core/conftest.py
+++ b/tests/statespace/core/conftest.py
@@ -68,7 +68,7 @@ def pymc_mod(ss_mod):
 
         ss_mod.build_statespace_graph(data=nile)
         names = ["x0", "P0", "c", "d", "T", "Z", "R", "H", "Q"]
-        for name, matrix in zip(names, ss_mod._insert_random_variables()):
+        for name, matrix in zip(names, ss_mod._insert_random_variables(), strict=True):
             pm.Deterministic(name, matrix)
 
     return pymc_mod

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -8,7 +8,7 @@ import pytest
 
 from numpy.testing import assert_allclose
 from pymc.exceptions import ImputationWarning
-from pytensor.graph.traversal import explicit_graph_inputs
+from pytensor.graph.traversal import ancestors
 
 from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
@@ -260,10 +260,27 @@ def test_build_graph_does_not_mutate_the_filters(ss_mod):
     assert kalman_smoother.__dict__ == smoother_state
 
 
-def test_post_estimation_leaves_template_matrices_alone(ss_mod, pymc_mod, idata, rng):
+@pytest.mark.parametrize(
+    ("method_name", "kwargs"),
+    [
+        ("forecast", {"start": -1, "periods": 10}),
+        ("impulse_response_function", {"n_steps": 10}),
+        ("sample_conditional_prior", {}),
+    ],
+    ids=["forecast", "irf", "sample_conditional_prior"],
+)
+def test_post_estimation_leaves_template_matrices_alone(
+    method_name, kwargs, ss_mod, pymc_mod, idata, rng
+):
+    """Each of these substitutes into a throwaway model, so none may touch the template.
+
+    The three cover distinct substitution paths. Identity rather than equality: a cached list of
+    substituted matrices would still compare equal element-wise while pointing at nodes bound to a
+    model that has gone out of scope.
+    """
     before = ss_mod.unpack_statespace()
-    ss_mod.forecast(idata, start=-1, periods=10, random_seed=rng)
+    getattr(ss_mod, method_name)(idata, random_seed=rng, **kwargs)
     after = ss_mod.unpack_statespace()
 
     assert all(x is y for x, y in zip(before, after, strict=True))
-    assert not set(pymc_mod.basic_RVs).intersection(explicit_graph_inputs(after))
+    assert not set(pymc_mod.basic_RVs).intersection(ancestors(after))

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -8,6 +8,7 @@ import pytest
 
 from numpy.testing import assert_allclose
 from pymc.exceptions import ImputationWarning
+from pytensor.graph.traversal import explicit_graph_inputs
 
 from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
@@ -32,18 +33,6 @@ def test_invalid_filter_name_raises():
         mod = make_statespace_mod(k_endog=1, k_states=5, k_posdef=1, filter_type="invalid_filter")
 
 
-def test_unpack_before_insert_raises(rng):
-    p, m, r, n = 2, 5, 1, 10
-    data, *inputs = make_test_inputs(p, m, r, n, rng, missing_data=0)
-    mod = make_statespace_mod(
-        k_endog=p, k_states=m, k_posdef=r, filter_type="standard", verbose=False
-    )
-
-    msg = "Cannot unpack the complete statespace system until PyMC model variables have been inserted."
-    with pytest.raises(ValueError, match=msg):
-        outputs = mod.unpack_statespace()
-
-
 def test_unpack_matrices(rng):
     p, m, r, n = 2, 5, 1, 10
     data, *inputs = make_test_inputs(p, m, r, n, rng, missing_data=0)
@@ -51,11 +40,8 @@ def test_unpack_matrices(rng):
         k_endog=p, k_states=m, k_posdef=r, filter_type="standard", verbose=False
     )
 
-    # mod is a dummy statespace, so there are no placeholders to worry about. Monkey patch subbed_ssm with the defaults
-    mod.subbed_ssm = mod._unpack_statespace_with_placeholders()
-
     outputs = mod.unpack_statespace()
-    for x, y in zip(inputs, outputs):
+    for x, y in zip(inputs, outputs, strict=True):
         assert_allclose(np.zeros_like(x), fast_eval(y))
 
 
@@ -272,3 +258,12 @@ def test_build_graph_does_not_mutate_the_filters(ss_mod):
 
     assert kalman_filter.__dict__ == filter_state
     assert kalman_smoother.__dict__ == smoother_state
+
+
+def test_post_estimation_leaves_template_matrices_alone(ss_mod, pymc_mod, idata, rng):
+    before = ss_mod.unpack_statespace()
+    ss_mod.forecast(idata, start=-1, periods=10, random_seed=rng)
+    after = ss_mod.unpack_statespace()
+
+    assert all(x is y for x, y in zip(before, after, strict=True))
+    assert not set(pymc_mod.basic_RVs).intersection(explicit_graph_inputs(after))

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -9,6 +9,7 @@ import pytest
 from numpy.testing import assert_allclose
 from pymc.exceptions import ImputationWarning
 from pytensor.graph.traversal import ancestors
+from pytensor.scan.op import Scan
 
 from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
@@ -268,6 +269,34 @@ def test_unpack_statespace_binds_matrices_to_the_active_model(ss_mod, pymc_mod):
 
     assert pymc_mod["rho"] in set(ancestors([T]))
     assert not set(ss_mod._name_to_variable.values()).intersection(ancestors(matrices))
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_unpack_statespace_does_not_depend_on_the_filter():
+    """A matrix sized against n_timesteps takes its length from the data, not from the filter.
+
+    Taking it from the observation instead would make every deterministic built off these matrices
+    recompute the Kalman filter.
+    """
+    mod = (
+        st.LevelTrend(order=1, innovations_order=1)
+        + st.TimeSeasonality(season_length=4, duration=3, innovations=False, name="s")
+    ).build(verbose=False)
+
+    with pm.Model(coords=mod.coords) as pymc_mod:
+        pm.Normal("initial_level_trend", dims=["state_level_trend"])
+        pm.Deterministic("P0", pt.eye(mod.k_states))
+        pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+        pm.Normal("params_s", dims=["state_s"])
+        mod.build_statespace_graph(np.zeros((30, 1), dtype=floatX))
+        matrices = mod.unpack_statespace()
+
+    assert pymc_mod["obs"] not in set(ancestors(matrices))
+    assert not [
+        variable
+        for variable in ancestors(matrices)
+        if variable.owner is not None and isinstance(variable.owner.op, Scan)
+    ]
 
 
 def test_unpack_statespace_outside_a_model_raises(ss_mod):

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -40,7 +40,7 @@ def test_unpack_matrices(rng):
         k_endog=p, k_states=m, k_posdef=r, filter_type="standard", verbose=False
     )
 
-    outputs = mod.unpack_statespace()
+    outputs = mod._unpack_statespace_with_placeholders()
     for x, y in zip(inputs, outputs, strict=True):
         assert_allclose(np.zeros_like(x), fast_eval(y))
 
@@ -260,6 +260,21 @@ def test_build_graph_does_not_mutate_the_filters(ss_mod):
     assert kalman_smoother.__dict__ == smoother_state
 
 
+def test_unpack_statespace_binds_matrices_to_the_active_model(ss_mod, pymc_mod):
+    """The escape hatch for building further deterministics off the fitted system."""
+    with pymc_mod:
+        matrices = ss_mod.unpack_statespace()
+    x0, P0, c, d, T, Z, R, H, Q = matrices
+
+    assert pymc_mod["rho"] in set(ancestors([T]))
+    assert not set(ss_mod._name_to_variable.values()).intersection(ancestors(matrices))
+
+
+def test_unpack_statespace_outside_a_model_raises(ss_mod):
+    with pytest.raises(TypeError, match="No model on context stack"):
+        ss_mod.unpack_statespace()
+
+
 @pytest.mark.parametrize(
     ("method_name", "kwargs"),
     [
@@ -278,9 +293,9 @@ def test_post_estimation_leaves_template_matrices_alone(
     substituted matrices would still compare equal element-wise while pointing at nodes bound to a
     model that has gone out of scope.
     """
-    before = ss_mod.unpack_statespace()
+    before = list(ss_mod._unpack_statespace_with_placeholders())
     getattr(ss_mod, method_name)(idata, random_seed=rng, **kwargs)
-    after = ss_mod.unpack_statespace()
+    after = list(ss_mod._unpack_statespace_with_placeholders())
 
     assert all(x is y for x, y in zip(before, after, strict=True))
     assert not set(pymc_mod.basic_RVs).intersection(ancestors(after))

--- a/tests/statespace/filters/test_distributions.py
+++ b/tests/statespace/filters/test_distributions.py
@@ -103,8 +103,7 @@ def test_loglike_vectors_agree(kfilter, pymc_model):
     # TODO: This test might be flakey, I've gotten random failures
     ss_mod = structural.LevelTrend(order=2).build("data", verbose=False, filter_type=kfilter)
     with pymc_model:
-        ss_mod._insert_random_variables()
-        matrices = ss_mod.unpack_statespace()
+        matrices = ss_mod._insert_random_variables()
 
         kalman_filter, _ = ss_mod.make_filters()
         filter_outputs = kalman_filter.build_graph(pymc_model["data"], *matrices)
@@ -150,8 +149,7 @@ def test_sequence_mvn_distribution():
 @pytest.mark.parametrize("output_name", ["states_latent", "states_observed"])
 def test_lgss_distribution_from_steps(output_name, ss_mod_me, pymc_model_2):
     with pymc_model_2:
-        ss_mod_me._insert_random_variables()
-        matrices = ss_mod_me.unpack_statespace()
+        matrices = ss_mod_me._insert_random_variables()
 
         # pylint: disable=unpacking-non-sequence
         latent_states, obs_states = LinearGaussianStateSpace("states", *matrices, steps=100)
@@ -167,8 +165,7 @@ def test_lgss_distribution_from_steps(output_name, ss_mod_me, pymc_model_2):
 @pytest.mark.parametrize("output_name", ["states_latent", "states_observed"])
 def test_lgss_distribution_with_dims(output_name, ss_mod_me, pymc_model_2):
     with pymc_model_2:
-        ss_mod_me._insert_random_variables()
-        matrices = ss_mod_me.unpack_statespace()
+        matrices = ss_mod_me._insert_random_variables()
 
         # pylint: disable=unpacking-non-sequence
         latent_states, obs_states = LinearGaussianStateSpace(
@@ -215,9 +212,8 @@ def test_lgss_with_time_varying_inputs(output_name, rng):
         sigma_trend = pm.Exponential("sigma_level_trend", 1, shape=(2,))
         beta_exog = pm.Normal("beta_exog", shape=(3,))
 
-        mod._insert_random_variables()
-        mod._insert_data_variables()
-        matrices = mod.unpack_statespace()
+        matrices = mod._insert_random_variables()
+        matrices = mod._insert_data_variables(matrices)
 
         # pylint: disable=unpacking-non-sequence
         latent_states, obs_states = LinearGaussianStateSpace(

--- a/tests/statespace/models/structural/components/test_regression.py
+++ b/tests/statespace/models/structural/components/test_regression.py
@@ -222,7 +222,8 @@ class TestPyMCIntegration:
                 sigma_beta_exog = pm.Exponential("sigma_beta_exog", 1, dims=["state_exog"])
 
             mod.build_statespace_graph(y)
-            x0, P0, c, d, T, Z, R, H, Q = mod.unpack_statespace()
+            matrices = mod._insert_random_variables()
+            x0, P0, c, d, T, Z, R, H, Q = mod._insert_data_variables(matrices)
             pm.Deterministic("Z", Z)
 
             prior = pm.sample_prior_predictive(draws=10)

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -318,8 +318,7 @@ def test_SARIMAX_update_matches_statsmodels(p, d, q, P, D, Q, S, data, rng):
 
         pm.Deterministic("sigma_state", pt.as_tensor_variable(np.sqrt(param_d["sigma2"])))
 
-        mod._insert_random_variables()
-        matrices = pm.draw(mod.subbed_ssm)
+        matrices = pm.draw(mod._insert_random_variables())
         matrix_dict = dict(zip(SHORT_NAME_TO_LONG.values(), matrices))
 
     for matrix in ["transition", "selection", "state_cov", "obs_cov", "design"]:

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -151,9 +151,8 @@ def test_VARMAX_update_matches_statsmodels(data, order, rng):
         state_chol = np.zeros((mod.k_posdef, mod.k_posdef), dtype=floatX)
         state_chol[np.tril_indices(mod.k_posdef)] = np.array([param_d[var] for var in state_cov])
         state_cov = pm.Deterministic("state_cov", pt.as_tensor_variable(state_chol @ state_chol.T))
-        mod._insert_random_variables()
 
-        matrices = pm.draw(mod.subbed_ssm)
+        matrices = pm.draw(mod._insert_random_variables())
         matrix_dict = dict(zip(SHORT_NAME_TO_LONG.values(), matrices))
 
     for matrix in ["transition", "selection", "state_cov", "obs_cov", "design"]:
@@ -177,8 +176,7 @@ def test_measurement_error_enters_obs_cov_as_a_variance():
         pm.Deterministic("ar_params", pt.zeros((mod.k_endog, mod.p, mod.k_endog), dtype=floatX))
         pm.Deterministic("state_cov", pt.eye(mod.k_posdef, dtype=floatX))
         pm.Deterministic("sigma_obs", pt.as_tensor_variable(sigma))
-        mod._insert_random_variables()
-        matrices = pm.draw(mod.subbed_ssm)
+        matrices = pm.draw(mod._insert_random_variables())
 
     obs_cov = dict(zip(SHORT_NAME_TO_LONG.values(), matrices))["obs_cov"]
     assert_allclose(obs_cov, np.diag(sigma**2))


### PR DESCRIPTION
`subbed_ssm` was a single mutable buffer that every post-estimation method overwrote. Each of them substitutes against a throwaway model of `pm.Flat` dummies, so after one `forecast()` the stored matrices pointed at nodes whose owning model had gone out of scope — `unpack_statespace()` was silently order-dependent, valid after `build`, garbage after `build → forecast`. The substitution helpers now return their result and the slot is gone.

`unpack_statespace()` keeps its role as the escape hatch for deriving further quantities from the fitted system, but substitutes afresh on each call:

```python
with pm.Model() as model:
    ...
    ss_mod.build_statespace_graph(data)
    x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()
    pm.Deterministic("T_eigenvalues", pt.linalg.eigvalsh(T))
```

It now requires a model context, and the matrices it returns are new graph nodes rather than the ones the filter was built from. For models whose time axis comes from exogenous data it works before `build_statespace_graph` too; a model that sizes a matrix directly against `n_timesteps` — seasonality with a duration — takes the length off the registered data, and raises naming that if no statespace observation is present.
