### PR TITLE
Take fit state off the statespace model and make rebuilds work

### DIFF
--- a/notebooks/DFM_Example_(Coincident_Index).ipynb
+++ b/notebooks/DFM_Example_(Coincident_Index).ipynb
@@ -1676,7 +1676,7 @@
    ],
    "source": [
     "with pm.Model() as index_mod:\n",
-    "    dfm._build_dummy_graph()\n",
+    "    dfm._build_dummy_graph(idata_dfm_py)\n",
     "    x0, P0, C, D, T, Z, R, H, Q = matrices = dfm.unpack_statespace()\n",
     "\n",
     "    dfm.build_statespace_graph(data=endog)\n",

--- a/notebooks/SARIMAX Example.ipynb
+++ b/notebooks/SARIMAX Example.ipynb
@@ -953,7 +953,7 @@
    ],
    "source": [
     "with pm.Model(coords=ss_mod.coords):\n",
-    "    ss_mod._build_dummy_graph()\n",
+    "    ss_mod._build_dummy_graph(idata)\n",
     "    x0, P0, c, d, T, Z, R, H, Q = ss_mod.unpack_statespace()\n",
     "\n",
     "    mu_star = pm.Deterministic(\n",

--- a/pymc_extras/statespace/core/dummy_graph.py
+++ b/pymc_extras/statespace/core/dummy_graph.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import pandas as pd
@@ -13,12 +14,30 @@ if TYPE_CHECKING:
     from pymc_extras.statespace.core.statespace import PyMCStateSpace
 
 
-def build_dummy_graph(ss_mod: "PyMCStateSpace") -> None:
+def build_dummy_graph(
+    ss_mod: "PyMCStateSpace", *, coords: dict[str, Sequence], dims: dict[str, list[str]]
+) -> None:
     """
     Build a dummy computation graph for the state space model matrices.
 
     Create "dummy" ``pm.Flat`` variables representing the deep parameters used in the state space model, so
     post-estimation sampling functions can re-derive the statespace matrices from posterior draws.
+
+    Parameters
+    ----------
+    ss_mod : PyMCStateSpace
+        Model whose parameters to stand in for.
+    coords : dict mapping str to sequence
+        Coords the model was fit with, from
+        :func:`~pymc_extras.statespace.core.fit_recovery.coords_from_idata`.
+    dims : dict mapping str to list of str
+        Dims each parameter was fit with, from
+        :func:`~pymc_extras.statespace.core.fit_recovery.dims_from_idata`.
+
+    Raises
+    ------
+    ValueError
+        If a parameter's shape is not fully known and no dims were recovered to size it from.
     """
 
     def infer_variable_shape(name):
@@ -26,14 +45,16 @@ def build_dummy_graph(ss_mod: "PyMCStateSpace") -> None:
         if not any(dim is None for dim in shape):
             return shape
 
-        dim_names = ss_mod._fit_dims.get(name, None)
+        dim_names = dims.get(name, None)
         if dim_names is None:
             raise ValueError(
-                f"Could not infer shape for {name}, because it was not given coords during model"
-                f"fitting"
+                f"Could not infer a shape for {name}, which was given no coords when the model was "
+                f"fit. If you did give it one, check its name: a dim called exactly "
+                f"{name}_dim_0 cannot be told apart from the name PyMC generates for a variable "
+                f"declared without dims, so it is discarded. Rename it."
             )
 
-        shape_from_coords = tuple([len(ss_mod._fit_coords[dim]) for dim in dim_names])
+        shape_from_coords = tuple([len(coords[dim]) for dim in dim_names])
         return tuple(
             [shape[i] if shape[i] is not None else shape_from_coords[i] for i in range(len(shape))]
         )
@@ -42,13 +63,17 @@ def build_dummy_graph(ss_mod: "PyMCStateSpace") -> None:
         pm.Flat(
             name,
             shape=infer_variable_shape(name),
-            dims=ss_mod._fit_dims.get(name, None),
+            dims=dims.get(name, None),
         )
 
 
 def kalman_filter_outputs_from_dummy_graph(
     ss_mod: "PyMCStateSpace",
-    data: pt.TensorLike | None = None,
+    data: pt.TensorLike,
+    *,
+    coords: dict[str, Sequence],
+    dims: dict[str, list[str]],
+    exog: dict[str, dict],
     data_dims: str | tuple[str] | list[str] | None = None,
     scenario: dict[str, pd.DataFrame] | pd.DataFrame | None = None,
 ) -> tuple[list[pt.TensorVariable], list[tuple[pt.TensorVariable, pt.TensorVariable]]]:
@@ -80,21 +105,18 @@ def kalman_filter_outputs_from_dummy_graph(
         scenario = dict()
 
     pm_mod = modelcontext(None)
-    build_dummy_graph(ss_mod)
+    build_dummy_graph(ss_mod, coords=coords, dims=dims)
     matrices = ss_mod._insert_random_variables()
 
     for name in ss_mod.data_names:
         if name not in pm_mod:
-            pm.Data(**ss_mod._fit_exog_data[name])
+            pm.Data(**exog[name])
 
     matrices = ss_mod._insert_data_variables(matrices)
 
     for name in ss_mod.data_names:
         if name in scenario.keys():
             pm.set_data({name: scenario[name]})
-
-    if data is None:
-        data = ss_mod._fit_data
 
     # Pinned to the data length only for the filter below; the returned matrices keep the
     # n_timesteps placeholder so a caller can build over a different span.

--- a/pymc_extras/statespace/core/fit_recovery.py
+++ b/pymc_extras/statespace/core/fit_recovery.py
@@ -1,0 +1,212 @@
+import re
+
+from collections.abc import Container, Sequence
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from xarray import Dataset, DataTree
+
+if TYPE_CHECKING:
+    from pymc_extras.statespace.core.statespace import PyMCStateSpace
+
+# ``chain`` and ``draw`` index the samples, not the variable, so they are never model dims.
+_SAMPLE_DIMS = frozenset({"chain", "draw"})
+
+# The name ``register_data_with_pymc`` gives the observed data when it registers it.
+_OBSERVED_DATA_NAME = "data"
+
+# What PyMC names the axes of a variable registered without dims.
+_GENERATED_DIM = re.compile(r"^(?P<variable>.+)_dim_\d+$")
+
+
+def _is_generated(dim: str, variables: Container[str]) -> bool:
+    """Report whether ``dim`` is a name PyMC made up for an axis of one of ``variables``."""
+    match = _GENERATED_DIM.match(dim)
+    return match is not None and match["variable"] in variables
+
+
+def _require_group(idata: DataTree, group: str) -> Dataset:
+    """Return one group of ``idata``, or raise naming the groups it does have."""
+    if group not in idata:
+        available = ", ".join(sorted(name.lstrip("/") for name in idata.groups if name != "/"))
+        raise ValueError(
+            f"Inference data has no {group!r} group, so there is nothing to recover from it. "
+            f"It holds: {available}."
+        )
+    return idata[group]
+
+
+def coords_from_idata(
+    ss_mod: "PyMCStateSpace",
+    idata: DataTree,
+    group: str,
+    coords: dict[str, Sequence] | None = None,
+) -> dict[str, Sequence]:
+    """
+    Rebuild the coords a model was fit with, from its template and one inference data group.
+
+    The two sources are complements. Structural coords -- ``shock``, ``shock_aux``,
+    ``observed_state_aux`` and the per-component ones -- are attached to no sampled or observed
+    variable, so they reach only the template. Dataset coords, ``time`` above all, are known only
+    to the inference data.
+
+    Parameters
+    ----------
+    ss_mod : PyMCStateSpace
+        Model supplying the structural coords.
+    idata : DataTree
+        Inference data to read.
+    group : str
+        Group carrying the dataset coords: ``"observed_data"`` for the data a model was fit on,
+        or the group a post-estimation result was written to.
+    coords : dict mapping str to sequence, optional
+        Coords to override the recovered ones with, for inference data that carries none.
+        Default None.
+
+    Returns
+    -------
+    coords : dict mapping str to sequence
+        The template's coords, updated with the group's.
+
+    Raises
+    ------
+    ValueError
+        If ``idata`` has no group named ``group``.
+    """
+    dataset = _require_group(idata, group)
+
+    recovered: dict[str, Sequence] = dict(ss_mod.coords)
+    for name, values in dataset.coords.items():
+        if name not in _SAMPLE_DIMS and not _is_generated(name, dataset.data_vars):
+            # ``to_index`` keeps a datetime coord as timestamps rather than degrading it to
+            # ``datetime64``, which is what lets the forecast index recover its frequency.
+            recovered[name] = values.to_index()
+
+    return recovered | (coords or {})
+
+
+def dims_from_idata(ss_mod: "PyMCStateSpace", idata: DataTree, group: str) -> dict[str, list[str]]:
+    """
+    Rebuild the dims each model parameter was given at fit time.
+
+    A parameter registered without dims is stored under PyMC's generated ``{name}_dim_{k}``
+    names, which are indistinguishable from real ones once written to inference data. Those are
+    dropped, so a parameter that was given no dims recovers none.
+
+    Parameters
+    ----------
+    ss_mod : PyMCStateSpace
+        Model whose parameters to look up.
+    idata : DataTree
+        Inference data to read.
+    group : str
+        Group holding the sampled parameters, usually ``"prior"`` or ``"posterior"``.
+
+    Returns
+    -------
+    dims : dict mapping str to list of str
+        Dims per parameter, omitting parameters that were given none.
+
+    Raises
+    ------
+    ValueError
+        If ``idata`` has no group named ``group``.
+    """
+    variables = _require_group(idata, group).data_vars
+
+    recovered: dict[str, list[str]] = {}
+    for name in ss_mod.param_names:
+        if name not in variables:
+            continue
+        dims = [
+            dim
+            for dim in variables[name].dims
+            if dim not in _SAMPLE_DIMS and not _is_generated(dim, variables)
+        ]
+        if dims:
+            recovered[name] = dims
+
+    return recovered
+
+
+def data_from_idata(idata: DataTree, group: str) -> pd.DataFrame:
+    """
+    Rebuild the observed data a model was fit on.
+
+    The recovered values carry the missing-data sentinel where the original held ``nan``, because
+    that substitution happens before the data is recorded. The filter derives its missing mask
+    from the sentinel, so the two filter identically.
+
+    Parameters
+    ----------
+    idata : DataTree
+        Inference data to read.
+    group : str
+        Group holding the registered data, ``"constant_data"`` for a fit.
+
+    Returns
+    -------
+    data : DataFrame
+        Observed data, indexed by the time coord it was fit against, with the frequency of a
+        datetime index restored.
+
+    Raises
+    ------
+    ValueError
+        If ``idata`` has no group named ``group``, or that group holds no observed data.
+    """
+    dataset = _require_group(idata, group)
+    if _OBSERVED_DATA_NAME not in dataset.data_vars:
+        raise ValueError(
+            f"The {group!r} group holds no {_OBSERVED_DATA_NAME!r} variable, so the observed data "
+            f"cannot be recovered. It holds: {', '.join(sorted(dataset.data_vars))}."
+        )
+
+    data = dataset[_OBSERVED_DATA_NAME].to_pandas()
+    if isinstance(data.index, pd.DatetimeIndex) and data.index.freq is None:
+        # A round-trip through the inference data drops the frequency, which the data
+        # preprocessor warns about and the forecast index needs.
+        data.index.freq = data.index.inferred_freq
+
+    return data
+
+
+def exog_from_idata(ss_mod: "PyMCStateSpace", idata: DataTree, group: str) -> dict[str, dict]:
+    """
+    Rebuild the ``pm.Data`` arguments for each exogenous variable a model was fit with.
+
+    Parameters
+    ----------
+    ss_mod : PyMCStateSpace
+        Model whose exogenous variables to look up.
+    idata : DataTree
+        Inference data to read.
+    group : str
+        Group holding the registered data, ``"constant_data"`` for a fit.
+
+    Returns
+    -------
+    exog : dict mapping str to dict
+        One ``pm.Data`` keyword mapping per exogenous variable, omitting any the group does not
+        hold.
+
+    Raises
+    ------
+    ValueError
+        If ``idata`` has no group named ``group``.
+    """
+    variables = _require_group(idata, group).data_vars
+
+    recovered: dict[str, dict] = {}
+    for name in ss_mod.data_names:
+        if name not in variables:
+            continue
+        dims = [dim for dim in variables[name].dims if not _is_generated(dim, variables)]
+        recovered[name] = {
+            "name": name,
+            "value": variables[name].values,
+            "dims": dims or None,
+        }
+
+    return recovered

--- a/pymc_extras/statespace/core/fit_recovery.py
+++ b/pymc_extras/statespace/core/fit_recovery.py
@@ -20,6 +20,12 @@ _OBSERVED_DATA_NAME = "data"
 _GENERATED_DIM = re.compile(r"^(?P<variable>.+)_dim_\d+$")
 
 
+def verify_group(group: str) -> None:
+    """Raise ValueError unless ``group`` names a group parameters can be drawn from."""
+    if group not in ("prior", "posterior"):
+        raise ValueError(f'Argument "group" must be one of "prior" or "posterior", found {group}')
+
+
 def _is_generated(dim: str, variables: Container[str]) -> bool:
     """Report whether ``dim`` is a name PyMC made up for an axis of one of ``variables``."""
     match = _GENERATED_DIM.match(dim)

--- a/pymc_extras/statespace/core/fit_recovery.py
+++ b/pymc_extras/statespace/core/fit_recovery.py
@@ -7,14 +7,13 @@ import pandas as pd
 
 from xarray import Dataset, DataTree
 
+from pymc_extras.statespace.utils.constants import OBSERVED_DATA_NAME
+
 if TYPE_CHECKING:
     from pymc_extras.statespace.core.statespace import PyMCStateSpace
 
 # ``chain`` and ``draw`` index the samples, not the variable, so they are never model dims.
 _SAMPLE_DIMS = frozenset({"chain", "draw"})
-
-# The name ``register_data_with_pymc`` gives the observed data when it registers it.
-_OBSERVED_DATA_NAME = "data"
 
 # What PyMC names the axes of a variable registered without dims.
 _GENERATED_DIM = re.compile(r"^(?P<variable>.+)_dim_\d+$")
@@ -163,13 +162,13 @@ def data_from_idata(idata: DataTree, group: str) -> pd.DataFrame:
         If ``idata`` has no group named ``group``, or that group holds no observed data.
     """
     dataset = _require_group(idata, group)
-    if _OBSERVED_DATA_NAME not in dataset.data_vars:
+    if OBSERVED_DATA_NAME not in dataset.data_vars:
         raise ValueError(
-            f"The {group!r} group holds no {_OBSERVED_DATA_NAME!r} variable, so the observed data "
+            f"The {group!r} group holds no {OBSERVED_DATA_NAME!r} variable, so the observed data "
             f"cannot be recovered. It holds: {', '.join(sorted(dataset.data_vars))}."
         )
 
-    data = dataset[_OBSERVED_DATA_NAME].to_pandas()
+    data = dataset[OBSERVED_DATA_NAME].to_pandas()
     if isinstance(data.index, pd.DatetimeIndex) and data.index.freq is None:
         # A round-trip through the inference data drops the frequency, which the data
         # preprocessor warns about and the forecast index needs.

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -12,6 +12,7 @@ from pymc.util import RandomState
 from pytensor.graph.replace import graph_replace
 from xarray import DataTree
 
+from pymc_extras.statespace.core.forward_sampling import _verify_group
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
 from pymc_extras.statespace.filters.utilities import scan_sequence_names
 from pymc_extras.statespace.utils.constants import (
@@ -525,9 +526,11 @@ def forecast(
     random_seed: RandomState | None = None,
     verbose: bool = True,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+    group: str = "posterior",
     **kwargs,
 ) -> DataTree:
     _validate_filter_arg(filter_output)
+    _verify_group(group)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
@@ -596,7 +599,7 @@ def forecast(
 
     with frozen_model:
         idata_forecast = pm.sample_posterior_predictive(
-            idata,
+            idata[group],
             var_names=["forecast_latent", "forecast_observed"],
             random_seed=random_seed,
             compile_kwargs=compile_kwargs,

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -430,9 +430,9 @@ def _build_forecast_model(
     fit_exog = exog_from_idata(ss_mod, idata, "constant_data")
     temp_coords = fit_coords.copy()
 
-    dims = None
+    trajectory_dims = None
     if all([dim in temp_coords for dim in [filter_time_dim, ALL_STATE_DIM, OBS_STATE_DIM]]):
-        dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
+        trajectory_dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
     t0_idx = np.flatnonzero(time_index == t0)[0]
 
@@ -524,7 +524,7 @@ def _build_forecast_model(
             P0,
             *forecast_matrices,
             steps=len(forecast_index),
-            dims=dims,
+            dims=trajectory_dims,
             sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
             k_endog=ss_mod.k_endog,
             append_x0=False,

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -426,6 +426,8 @@ def _build_forecast_model(
 ):
     filter_time_dim = TIME_DIM
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    fit_dims = dims_from_idata(ss_mod, idata, group)
+    fit_exog = exog_from_idata(ss_mod, idata, "constant_data")
     temp_coords = fit_coords.copy()
 
     dims = None
@@ -446,8 +448,8 @@ def _build_forecast_model(
         unpinned_matrices, grouped_outputs = ss_mod._kalman_filter_outputs_from_dummy_graph(
             data_from_idata(idata, "constant_data"),
             coords=fit_coords,
-            dims=dims_from_idata(ss_mod, idata, group),
-            exog=exog_from_idata(ss_mod, idata, "constant_data"),
+            dims=fit_dims,
+            exog=fit_exog,
             data_dims=["data_time", OBS_STATE_DIM],
         )
 
@@ -489,7 +491,6 @@ def _build_forecast_model(
         # TODO: Is there a way to handle this in a fully symbolic way, without having to
         #  run the full scan on training data to get the system's state at the start date?
         if scenario is not None and ss_mod._needs_exog_data:
-            fit_exog = exog_from_idata(ss_mod, idata, "constant_data")
             exog_replace = {}
             for name in ss_mod.data_names:
                 if name not in scenario:

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -1,5 +1,6 @@
 import logging
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Literal
 
 import numpy as np
@@ -12,7 +13,13 @@ from pymc.util import RandomState
 from pytensor.graph.replace import graph_replace
 from xarray import DataTree
 
-from pymc_extras.statespace.core.forward_sampling import _verify_group
+from pymc_extras.statespace.core.fit_recovery import (
+    coords_from_idata,
+    data_from_idata,
+    dims_from_idata,
+    exog_from_idata,
+    verify_group,
+)
 from pymc_extras.statespace.filters.distributions import LinearGaussianStateSpace
 from pymc_extras.statespace.filters.utilities import scan_sequence_names
 from pymc_extras.statespace.utils.constants import (
@@ -81,8 +88,10 @@ def _validate_forecast_args(
         )
 
 
-def _get_fit_time_index(ss_mod: "PyMCStateSpace") -> pd.RangeIndex | pd.DatetimeIndex:
-    time_index = ss_mod._fit_coords.get(TIME_DIM, None) if ss_mod._fit_coords is not None else None
+def _get_fit_time_index(
+    ss_mod: "PyMCStateSpace", idata: DataTree
+) -> pd.RangeIndex | pd.DatetimeIndex:
+    time_index = coords_from_idata(ss_mod, idata, "observed_data").get(TIME_DIM, None)
     if time_index is None:
         raise ValueError(
             "No time dimension found on coordinates used to fit the model. Has this model been fit?"
@@ -100,6 +109,7 @@ def _get_fit_time_index(ss_mod: "PyMCStateSpace") -> pd.RangeIndex | pd.Datetime
 def _validate_scenario_data(
     ss_mod: "PyMCStateSpace",
     scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
+    coords: dict[str, Sequence],
     name: str | None = None,
     verbose=True,
 ):
@@ -126,11 +136,7 @@ def _validate_scenario_data(
 
     if any(len(dims) > 1 for dims in var_to_dims.values()):
         raise NotImplementedError(">2d exogenous data is not yet supported.")
-    coords = {
-        var: ss_mod._fit_coords[dim[0]]
-        for var, dim in var_to_dims.items()
-        if dim[0] in ss_mod._fit_coords
-    }
+    var_to_coords = {var: coords[dim[0]] for var, dim in var_to_dims.items() if dim[0] in coords}
 
     if ss_mod._needs_exog_data and scenario is None:
         exog_str = ",".join(ss_mod.data_names)
@@ -150,7 +156,7 @@ def _validate_scenario_data(
 
             # Recursively call this function to trigger the non-dictionary branch of the checks on each object
             # inside the dictionary
-            scenario[name] = ss_mod._validate_scenario_data(data, name)
+            scenario[name] = ss_mod._validate_scenario_data(data, coords, name)
 
         # The provided dictionary might be a mix of numpy arrays and dataframes if the user is truly horrible.
         # For checking shapes, the first object will always be good enough. But we also need to make sure all the
@@ -193,22 +199,22 @@ def _validate_scenario_data(
         # Omit dataframe from this basic shape check so we can give more detailed information about missing columns
         # in the next check
         if not isinstance(scenario, pd.DataFrame | pd.Series) and scenario.shape[1] != len(
-            coords[name]
+            var_to_coords[name]
         ):
             raise ValueError(
                 f"Scenario data for variable '{name}' has the wrong number of columns. Expected "
-                f"{len(coords[name])}, got {scenario.shape[1]}"
+                f"{len(var_to_coords[name])}, got {scenario.shape[1]}"
             )
 
         if isinstance(scenario, pd.Series):
-            if len(coords[name]) > 1:
+            if len(var_to_coords[name]) > 1:
                 raise ValueError(
                     f"Scenario data for variable '{name}' has the wrong number of columns. Expected "
-                    f"{len(coords[name])}, got 1"
+                    f"{len(var_to_coords[name])}, got 1"
                 )
 
         if isinstance(scenario, pd.DataFrame):
-            expected_cols = coords[name]
+            expected_cols = var_to_coords[name]
             cols = scenario.columns
             missing_columns = sorted(list(set(expected_cols) - set(cols)))
             if len(missing_columns) > 0:
@@ -367,6 +373,7 @@ def _finalize_scenario_initialization(
     ss_mod: "PyMCStateSpace",
     scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
     forecast_index: pd.RangeIndex | pd.DatetimeIndex,
+    coords: dict[str, Sequence],
     name=None,
 ):
     if not ss_mod.data_info:
@@ -376,18 +383,16 @@ def _finalize_scenario_initialization(
 
     if any(len(dims) > 1 for dims in var_to_dims.values()):
         raise NotImplementedError(">2d exogenous data is not yet supported.")
-    coords = {
-        var: ss_mod._fit_coords[dim[0]]
-        for var, dim in var_to_dims.items()
-        if dim[0] in ss_mod._fit_coords
-    }
+    var_to_coords = {var: coords[dim[0]] for var, dim in var_to_dims.items() if dim[0] in coords}
 
     if scenario is None:
         return scenario
 
     if isinstance(scenario, dict):
         for name, data in scenario.items():
-            scenario[name] = ss_mod._finalize_scenario_initialization(data, forecast_index, name)
+            scenario[name] = ss_mod._finalize_scenario_initialization(
+                data, forecast_index, coords, name
+            )
         return scenario
 
     # This was already checked as valid
@@ -396,23 +401,32 @@ def _finalize_scenario_initialization(
     # Small tidying up in the case we just have a single scenario that's already a dataframe.
     if isinstance(scenario, pd.DataFrame | pd.Series):
         if isinstance(scenario, pd.Series):
-            scenario = scenario.to_frame(name=coords[name][0])
+            scenario = scenario.to_frame(name=var_to_coords[name][0])
         if not scenario.index.equals(forecast_index):
             scenario.index = forecast_index
 
     # lists and tuples were handled during validation, along with shape check, so just cast arrays to dataframes
     # with the correct index and columns
     if isinstance(scenario, np.ndarray):
-        scenario = pd.DataFrame(scenario, index=forecast_index, columns=coords[name])
+        scenario = pd.DataFrame(scenario, index=forecast_index, columns=var_to_coords[name])
 
     return scenario
 
 
 def _build_forecast_model(
-    ss_mod: "PyMCStateSpace", time_index, t0, forecast_index, scenario, filter_output, mvn_method
+    ss_mod: "PyMCStateSpace",
+    idata,
+    group,
+    time_index,
+    t0,
+    forecast_index,
+    scenario,
+    filter_output,
+    mvn_method,
 ):
     filter_time_dim = TIME_DIM
-    temp_coords = ss_mod._fit_coords.copy()
+    fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    temp_coords = fit_coords.copy()
 
     dims = None
     if all([dim in temp_coords for dim in [filter_time_dim, ALL_STATE_DIM, OBS_STATE_DIM]]):
@@ -424,12 +438,16 @@ def _build_forecast_model(
     temp_coords[TIME_DIM] = forecast_index
 
     mu_dims, cov_dims = None, None
-    if all([dim in ss_mod._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]]):
+    if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]]):
         mu_dims = ["data_time", ALL_STATE_DIM]
         cov_dims = ["data_time", ALL_STATE_DIM, ALL_STATE_AUX_DIM]
 
     with pm.Model(coords=temp_coords) as forecast_model:
         unpinned_matrices, grouped_outputs = ss_mod._kalman_filter_outputs_from_dummy_graph(
+            data_from_idata(idata, "constant_data"),
+            coords=fit_coords,
+            dims=dims_from_idata(ss_mod, idata, group),
+            exog=exog_from_idata(ss_mod, idata, "constant_data"),
             data_dims=["data_time", OBS_STATE_DIM],
         )
 
@@ -471,12 +489,13 @@ def _build_forecast_model(
         # TODO: Is there a way to handle this in a fully symbolic way, without having to
         #  run the full scan on training data to get the system's state at the start date?
         if scenario is not None and ss_mod._needs_exog_data:
+            fit_exog = exog_from_idata(ss_mod, idata, "constant_data")
             exog_replace = {}
             for name in ss_mod.data_names:
                 if name not in scenario:
                     continue
                 forecast_data = scenario[name]
-                train_val = ss_mod._fit_exog_data[name]["value"]
+                train_val = fit_exog[name]["value"]
                 fc_val = (
                     forecast_data.values
                     if isinstance(forecast_data, pd.DataFrame)
@@ -530,12 +549,12 @@ def forecast(
     **kwargs,
 ) -> DataTree:
     _validate_filter_arg(filter_output)
-    _verify_group(group)
+    verify_group(group)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
-    time_index = ss_mod._get_fit_time_index()
+    time_index = ss_mod._get_fit_time_index(idata)
 
     if start is None and verbose:
         _log.warning(
@@ -553,7 +572,8 @@ def forecast(
         [data_name] = ss_mod.data_names
         scenario = {data_name: scenario}
 
-    scenario: dict = ss_mod._validate_scenario_data(scenario, verbose=verbose)
+    scenario_coords = coords_from_idata(ss_mod, idata, "constant_data")
+    scenario: dict = ss_mod._validate_scenario_data(scenario, scenario_coords, verbose=verbose)
 
     ss_mod._validate_forecast_args(
         time_index=time_index,
@@ -573,9 +593,11 @@ def forecast(
         scenario=scenario,
         use_scenario_index=use_scenario_index,
     )
-    scenario = ss_mod._finalize_scenario_initialization(scenario, forecast_index)
+    scenario = ss_mod._finalize_scenario_initialization(scenario, forecast_index, scenario_coords)
 
     forecast_model = ss_mod._build_forecast_model(
+        idata=idata,
+        group=group,
         time_index=time_index,
         t0=t0,
         forecast_index=forecast_index,

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -262,7 +262,7 @@ def _sample_unconditional(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     group_idata = getattr(idata, group)
-    dims = None
+    trajectory_dims = None
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
     fit_dims = dims_from_idata(ss_mod, idata, group)
     temp_coords = fit_coords.copy()
@@ -281,9 +281,9 @@ def _sample_unconditional(
         steps = len(temp_coords[TIME_DIM]) - 1
 
     if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]]):
-        dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
+        trajectory_dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
-    with pm.Model(coords=temp_coords if dims is not None else None) as forward_model:
+    with pm.Model(coords=temp_coords if trajectory_dims is not None else None) as forward_model:
         dummy_graph.build_dummy_graph(ss_mod, coords=fit_coords, dims=fit_dims)
         matrices = ss_mod._insert_random_variables()
 
@@ -304,7 +304,7 @@ def _sample_unconditional(
             group,
             *matrices,
             steps=steps,
-            dims=dims,
+            dims=trajectory_dims,
             method=mvn_method,
             sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
             k_endog=ss_mod.k_endog,
@@ -446,8 +446,8 @@ def sample_statespace_matrices(
                 if matrix.ndim == len(matrix_dims) + 1:
                     # A time-varying matrix carries a leading time axis its static dims do not name.
                     matrix_dims = (TIME_DIM, *matrix_dims)
-                dims = [x if x in fit_coords else None for x in matrix_dims]
-                pm.Deterministic(name, matrix, dims=dims)
+                known_dims = [x if x in fit_coords else None for x in matrix_dims]
+                pm.Deterministic(name, matrix, dims=known_dims)
 
     # TODO: Remove this after pm.Flat has its initial_value fixed
     forward_model.rvs_to_initial_values = {

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -91,6 +91,7 @@ def _sample_conditional(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    fit_dims = dims_from_idata(ss_mod, idata, group)
     if data is None:
         data = data_from_idata(idata, "constant_data")
 
@@ -99,7 +100,7 @@ def _sample_conditional(
             ss_mod,
             data,
             coords=fit_coords,
-            dims=dims_from_idata(ss_mod, idata, group),
+            dims=fit_dims,
             exog=exog_from_idata(ss_mod, idata, "constant_data"),
         )
         # The returned matrices keep the n_timesteps placeholder; pin it to the span the filter
@@ -263,6 +264,7 @@ def _sample_unconditional(
     group_idata = getattr(idata, group)
     dims = None
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    fit_dims = dims_from_idata(ss_mod, idata, group)
     temp_coords = fit_coords.copy()
 
     if not use_data_time_dim and steps is not None:
@@ -282,9 +284,7 @@ def _sample_unconditional(
         dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
     with pm.Model(coords=temp_coords if dims is not None else None) as forward_model:
-        dummy_graph.build_dummy_graph(
-            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
-        )
+        dummy_graph.build_dummy_graph(ss_mod, coords=fit_coords, dims=fit_dims)
         matrices = ss_mod._insert_random_variables()
 
         for entry in exog_from_idata(ss_mod, idata, "constant_data").values():
@@ -428,11 +428,10 @@ def sample_statespace_matrices(
             raise ValueError(f"{sorted(unknown_matrix_names)} not a valid statespace matrix name!")
 
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    fit_dims = dims_from_idata(ss_mod, idata, group)
 
     with pm.Model(coords=fit_coords) as forward_model:
-        dummy_graph.build_dummy_graph(
-            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
-        )
+        dummy_graph.build_dummy_graph(ss_mod, coords=fit_coords, dims=fit_dims)
         matrices = ss_mod._insert_random_variables()
 
         for entry in exog_from_idata(ss_mod, idata, "constant_data").values():

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -108,19 +108,19 @@ def _sample_conditional(
         n_timesteps = grouped_outputs[0][0].shape[0]
         x0, P0, c, d, T, Z, R, H, Q = ss_mod._insert_constant_timestep(matrices, n_timesteps)
 
-        for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs):
-            dummy_ll = pt.zeros_like(mu)
+        state_dims = (
+            (TIME_DIM, ALL_STATE_DIM)
+            if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]])
+            else (None, None)
+        )
+        obs_dims = (
+            (TIME_DIM, OBS_STATE_DIM)
+            if all([dim in fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]])
+            else (None, None)
+        )
 
-            state_dims = (
-                (TIME_DIM, ALL_STATE_DIM)
-                if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]])
-                else (None, None)
-            )
-            obs_dims = (
-                (TIME_DIM, OBS_STATE_DIM)
-                if all([dim in fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]])
-                else (None, None)
-            )
+        for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs, strict=True):
+            dummy_ll = pt.zeros_like(mu)
 
             if name == "smoothed":
                 # The simulation smoother draws the whole latent path jointly, so the

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -9,6 +9,13 @@ from pymc.util import RandomState
 from xarray import DataTree
 
 from pymc_extras.statespace.core import dummy_graph
+from pymc_extras.statespace.core.fit_recovery import (
+    coords_from_idata,
+    data_from_idata,
+    dims_from_idata,
+    exog_from_idata,
+    verify_group,
+)
 from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
     SequenceMvNormal,
@@ -30,11 +37,6 @@ from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
 
 if TYPE_CHECKING:
     from pymc_extras.statespace.core.statespace import PyMCStateSpace
-
-
-def _verify_group(group):
-    if group not in ["prior", "posterior"]:
-        raise ValueError(f'Argument "group" must be one of "prior" or "posterior", found {group}')
 
 
 def _sample_conditional(
@@ -82,18 +84,23 @@ def _sample_conditional(
         A DataTree object containing sampled trajectories from the requested conditional distribution,
         with data variables "filtered_{group}", "predicted_{group}", and "smoothed_{group}".
     """
-    if data is None and ss_mod._fit_data is None:
-        raise ValueError("No data provided to condition the model")
-
-    _verify_group(group)
+    verify_group(group)
     group_idata = getattr(idata, group)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
-    with pm.Model(coords=ss_mod._fit_coords) as forward_model:
+    fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    if data is None:
+        data = data_from_idata(idata, "constant_data")
+
+    with pm.Model(coords=fit_coords) as forward_model:
         matrices, grouped_outputs = dummy_graph.kalman_filter_outputs_from_dummy_graph(
-            ss_mod, data=data
+            ss_mod,
+            data,
+            coords=fit_coords,
+            dims=dims_from_idata(ss_mod, idata, group),
+            exog=exog_from_idata(ss_mod, idata, "constant_data"),
         )
         # The returned matrices keep the n_timesteps placeholder; pin it to the span the filter
         # actually ran over so the observed-state graphs line up with grouped_outputs.
@@ -105,12 +112,12 @@ def _sample_conditional(
 
             state_dims = (
                 (TIME_DIM, ALL_STATE_DIM)
-                if all([dim in ss_mod._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]])
+                if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM]])
                 else (None, None)
             )
             obs_dims = (
                 (TIME_DIM, OBS_STATE_DIM)
-                if all([dim in ss_mod._fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]])
+                if all([dim in fit_coords for dim in [TIME_DIM, OBS_STATE_DIM]])
                 else (None, None)
             )
 
@@ -248,14 +255,15 @@ def _sample_unconditional(
         - posterior_observed represents the observed state trajectories `Y[t]`, which is obtained from
           the latent state trajectories: `y[t] = Z @ x[t] + nu[t]`, where `nu ~ N(0, H)`.
     """
-    _verify_group(group)
+    verify_group(group)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     group_idata = getattr(idata, group)
     dims = None
-    temp_coords = ss_mod._fit_coords.copy()
+    fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    temp_coords = fit_coords.copy()
 
     if not use_data_time_dim and steps is not None:
         temp_coords.update({TIME_DIM: np.arange(1 + steps, dtype="int")})
@@ -270,15 +278,17 @@ def _sample_unconditional(
     else:
         steps = len(temp_coords[TIME_DIM]) - 1
 
-    if all([dim in ss_mod._fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]]):
+    if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]]):
         dims = [TIME_DIM, ALL_STATE_DIM, OBS_STATE_DIM]
 
     with pm.Model(coords=temp_coords if dims is not None else None) as forward_model:
-        dummy_graph.build_dummy_graph(ss_mod)
+        dummy_graph.build_dummy_graph(
+            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
+        )
         matrices = ss_mod._insert_random_variables()
 
-        for name in ss_mod.data_names:
-            pm.Data(**ss_mod._fit_exog_data[name])
+        for entry in exog_from_idata(ss_mod, idata, "constant_data").values():
+            pm.Data(**entry)
 
         matrices = ss_mod._insert_data_variables(matrices)
         # The unconditional trajectory spans ``steps + 1`` timesteps, and time-varying
@@ -401,7 +411,7 @@ def sample_statespace_matrices(
     group: str = "posterior",
     **kwargs,
 ):
-    _verify_group(group)
+    verify_group(group)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
@@ -417,12 +427,16 @@ def sample_statespace_matrices(
         if unknown_matrix_names:
             raise ValueError(f"{sorted(unknown_matrix_names)} not a valid statespace matrix name!")
 
-    with pm.Model(coords=ss_mod._fit_coords) as forward_model:
-        dummy_graph.build_dummy_graph(ss_mod)
+    fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+
+    with pm.Model(coords=fit_coords) as forward_model:
+        dummy_graph.build_dummy_graph(
+            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
+        )
         matrices = ss_mod._insert_random_variables()
 
-        for name in ss_mod.data_names:
-            pm.Data(**ss_mod._fit_exog_data[name])
+        for entry in exog_from_idata(ss_mod, idata, "constant_data").values():
+            pm.Data(**entry)
 
         matrices = ss_mod._insert_data_variables(matrices)
         for short_name, matrix in zip(MATRIX_NAMES, matrices, strict=True):
@@ -433,7 +447,7 @@ def sample_statespace_matrices(
                 if matrix.ndim == len(matrix_dims) + 1:
                     # A time-varying matrix carries a leading time axis its static dims do not name.
                     matrix_dims = (TIME_DIM, *matrix_dims)
-                dims = [x if x in ss_mod._fit_coords else None for x in matrix_dims]
+                dims = [x if x in fit_coords else None for x in matrix_dims]
                 pm.Deterministic(name, matrix, dims=dims)
 
     # TODO: Remove this after pm.Flat has its initial_value fixed
@@ -477,16 +491,20 @@ def sample_filter_outputs(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     with pm.Model(coords=ss_mod.coords) as m:
-        dummy_graph.build_dummy_graph(ss_mod)
+        dummy_graph.build_dummy_graph(
+            ss_mod,
+            coords=coords_from_idata(ss_mod, idata, "observed_data"),
+            dims=dims_from_idata(ss_mod, idata, group),
+        )
         matrices = ss_mod._insert_random_variables()
 
-        for name in ss_mod.data_names:
-            pm.Data(**ss_mod._fit_exog_data[name])
+        for entry in exog_from_idata(ss_mod, idata, "constant_data").values():
+            pm.Data(**entry)
 
         matrices = ss_mod._insert_data_variables(matrices)
 
         x0, P0, c, d, T, Z, R, H, Q = matrices
-        data = ss_mod._fit_data
+        data = data_from_idata(idata, "constant_data")
 
         obs_coords = m.coords.get(OBS_STATE_DIM, None)
 

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -10,7 +10,11 @@ import pytensor.tensor as pt
 from pymc.util import RandomState
 
 from pymc_extras.statespace.core import dummy_graph
-from pymc_extras.statespace.core.forward_sampling import _verify_group
+from pymc_extras.statespace.core.fit_recovery import (
+    coords_from_idata,
+    dims_from_idata,
+    verify_group,
+)
 from pymc_extras.statespace.utils.constants import ALL_STATE_DIM, SHOCK_DIM, TIME_DIM
 
 if TYPE_CHECKING:
@@ -33,7 +37,7 @@ def impulse_response_function(
     group: str = "posterior",
     **kwargs,
 ):
-    _verify_group(group)
+    verify_group(group)
     options = [shock_size, shock_cov, shock_trajectory]
     n_options = sum(x is not None for x in options)
     Q = None  # No covariance matrix needed if a trajectory is provided. Will be overwritten later if needed.
@@ -65,11 +69,14 @@ def impulse_response_function(
         n_steps = n  # Overwrite steps with the length of the shock trajectory
         shock_trajectory = pt.as_tensor_variable(shock_trajectory)
 
-    simulation_coords = ss_mod._fit_coords.copy()
+    fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    simulation_coords = fit_coords.copy()
     simulation_coords[TIME_DIM] = np.arange(n_steps, dtype="int")
 
     with pm.Model(coords=simulation_coords):
-        dummy_graph.build_dummy_graph(ss_mod)
+        dummy_graph.build_dummy_graph(
+            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
+        )
         matrices = ss_mod._insert_random_variables()
 
         matrices = ss_mod._insert_constant_timestep(matrices, step=n_steps)

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -10,6 +10,7 @@ import pytensor.tensor as pt
 from pymc.util import RandomState
 
 from pymc_extras.statespace.core import dummy_graph
+from pymc_extras.statespace.core.forward_sampling import _verify_group
 from pymc_extras.statespace.utils.constants import ALL_STATE_DIM, SHOCK_DIM, TIME_DIM
 
 if TYPE_CHECKING:
@@ -29,8 +30,10 @@ def impulse_response_function(
     orthogonalize_shocks: bool = False,
     random_seed: RandomState | None = None,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+    group: str = "posterior",
     **kwargs,
 ):
+    _verify_group(group)
     options = [shock_size, shock_cov, shock_trajectory]
     n_options = sum(x is not None for x in options)
     Q = None  # No covariance matrix needed if a trajectory is provided. Will be overwritten later if needed.
@@ -126,7 +129,7 @@ def impulse_response_function(
         pm.Deterministic("irf", irf, dims=[TIME_DIM, ALL_STATE_DIM])
 
         irf_idata = pm.sample_posterior_predictive(
-            idata,
+            idata[group],
             var_names=["irf"],
             random_seed=random_seed,
             compile_kwargs=compile_kwargs,

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -70,13 +70,12 @@ def impulse_response_function(
         shock_trajectory = pt.as_tensor_variable(shock_trajectory)
 
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
+    fit_dims = dims_from_idata(ss_mod, idata, group)
     simulation_coords = fit_coords.copy()
     simulation_coords[TIME_DIM] = np.arange(n_steps, dtype="int")
 
     with pm.Model(coords=simulation_coords):
-        dummy_graph.build_dummy_graph(
-            ss_mod, coords=fit_coords, dims=dims_from_idata(ss_mod, idata, group)
-        )
+        dummy_graph.build_dummy_graph(ss_mod, coords=fit_coords, dims=fit_dims)
         matrices = ss_mod._insert_random_variables()
 
         matrices = ss_mod._insert_constant_timestep(matrices, step=n_steps)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1079,9 +1079,10 @@ class PyMCStateSpace:
         stale = {}
         for name in self.data_names:
             variable = pm_mod.named_vars.get(name, None)
-            if variable is None:
+            get_value = getattr(variable, "get_value", None)
+            if get_value is None:
                 continue
-            found = variable.get_value(borrow=True).shape[0]
+            found = get_value(borrow=True).shape[0]
             if found != n_timesteps:
                 stale[name] = found
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -91,9 +91,9 @@ def _validate_property(props, property_name, expected_type):
         )
 
 
-def _statespace_likelihood(model: Model) -> Variable | None:
+def _has_statespace_graph(model: Model) -> bool:
     """
-    Return the observation likelihood a state space build put into ``model``, if it holds one.
+    Return whether a state space build has already put an observation likelihood into ``model``.
 
     A variable named ``obs`` is only ours if a Kalman filter produced it, so a user's own variable
     of that name is never mistaken for a previous build.
@@ -105,13 +105,13 @@ def _statespace_likelihood(model: Model) -> Variable | None:
 
     Returns
     -------
-    likelihood : TensorVariable or None
-        The observation likelihood, or None if the model holds no state space graph.
+    has_graph : bool
+        True if the model already holds a state space graph.
     """
     likelihood = model.named_vars.get(OBSERVED_LIKELIHOOD_NAME, None)
     if likelihood is None or likelihood.owner is None:
-        return None
-    return likelihood if isinstance(likelihood.owner.op, KalmanFilterRV) else None
+        return False
+    return isinstance(likelihood.owner.op, KalmanFilterRV)
 
 
 class PyMCStateSpace:
@@ -992,7 +992,7 @@ class PyMCStateSpace:
             missing_fill_value=self.missing_fill_value,
         )
 
-        if _statespace_likelihood(pm_mod) is not None:
+        if _has_statespace_graph(pm_mod):
             self._reenter_statespace_graph(filled_values, index)
             return
 
@@ -1007,13 +1007,13 @@ class PyMCStateSpace:
         matrices = self._insert_random_variables()
         matrices = self._insert_data_variables(matrices)
 
-        data = add_data_to_active_model(filled_values, index)
+        data_variable = add_data_to_active_model(filled_values, index)
 
         # Order is important here: only call _insert_data_shape_into_n_timesteps after data has been registered.
-        matrices = self._insert_data_shape_into_n_timesteps(matrices, data)
+        matrices = self._insert_data_shape_into_n_timesteps(matrices, data_variable)
 
         kalman_filter, _ = self.make_filters()
-        filter_outputs = kalman_filter.build_graph(pt.as_tensor_variable(data), *matrices)
+        filter_outputs = kalman_filter.build_graph(pt.as_tensor_variable(data_variable), *matrices)
 
         logp = filter_outputs.pop(-1)
         *_, observed_states = filter_outputs[:3]
@@ -1027,7 +1027,7 @@ class PyMCStateSpace:
             mus=observed_states,
             covs=observed_covariances,
             logp=logp,
-            observed=data,
+            observed=data_variable,
             dims=obs_dims,
         )
 

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1049,6 +1049,10 @@ class PyMCStateSpace:
         index : pandas Index or numpy array
             Time index of the new data.
         """
+        # Raises unless the model holds this template's parameters, so a template whose
+        # specification has changed cannot silently inherit the graph another one built.
+        self._insert_random_variables()
+
         self._verify_exogenous_data_spans(len(filled_values))
 
         update_data_in_active_model(filled_values, index)

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -937,64 +937,21 @@ class PyMCStateSpace:
     def build_statespace_graph(
         self,
         data: np.ndarray | pd.DataFrame | pt.TensorVariable,
-        missing_fill_value: float | None = None,
-        cov_jitter: float | None = None,
-        mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
     ) -> None:
         """
         Given a parameter vector `theta`, constructs the full computational graph describing the state space model and
         the associated log probability of the data. Hidden states and log probabilities are computed via the Kalman
         Filter.
 
+        The filter is configured with the ``cov_jitter`` and ``missing_fill_value`` given to the model constructor,
+        which are also what post-estimation graphs use.
+
         Parameters
         ----------
         data : numpy array, pandas DataFrame, or pytensor tensor
             The observed data used to fit the state space model. It can be a NumPy array, a Pandas DataFrame,
             or a Pytensor tensor variable.
-
-        missing_fill_value: float, optional
-            A value to mask in missing values. NaN values in the data need to be filled with an arbitrary value to
-            avoid triggering PyMC's automatic imputation machinery (missing values are instead filled by treating them
-            as hidden states during Kalman filtering).
-
-            In general this never needs to be set. But if by a wild coincidence your data includes the value -9999.0,
-            you will need to change the missing_fill_value to something else, to avoid incorrectly mark in
-            data as missing.
-
-            Overrides the value given to the model constructor, which is also what post-estimation graphs use.
-            Default None, meaning the constructor's value is kept.
-
-        cov_jitter: float, optional
-            The Kalman filter is known to be numerically unstable, especially at half precision. This value is added to
-            the diagonal of every covariance matrix -- predicted, filtered, and smoothed -- at every step, to ensure
-            all matrices are strictly positive semi-definite.
-
-            Obviously, if this can be zero, that's best. In general:
-                - Having measurement error makes Kalman Filters more robust. A large source of numerical errors come
-                  from the Filtered and Smoothed covariance matrices having a zero in the (0, 0) position, which always
-                  occurs when there is no measurement error. You can lower this value in the presence of measurement
-                  error.
-
-                - The Univariate Filter is more robust than other filters, and can tolerate a lower jitter value
-
-            Overrides the value given to the model constructor, which is also what post-estimation graphs use.
-            Default None, meaning the constructor's value is kept.
-
-        mvn_method: str, default "svd"
-            Method used to invert the covariance matrix when calculating the pdf of a multivariate normal
-            (or when generating samples). One of "cholesky", "eigh", or "svd". "cholesky" is fastest, but least robust
-            to ill-conditioned matrices, while "svd" is slow but extremely robust.
-
-            In general, if your model has measurement error, "cholesky" will be safe to use. Otherwise, "svd" is
-            recommended. "eigh" can also be tried if sampling with "svd" is very slow, but it is not as robust as "svd".
-
         """
-        # Recorded on the model so post-estimation graphs are filtered the same way the fit was.
-        if cov_jitter is not None:
-            self.cov_jitter = cov_jitter
-        if missing_fill_value is not None:
-            self.missing_fill_value = missing_fill_value
-
         pm_mod = modelcontext(None)
 
         matrices = self._insert_random_variables()
@@ -1029,7 +986,6 @@ class PyMCStateSpace:
             logp=logp,
             observed=data,
             dims=obs_dims,
-            method=mvn_method,
         )
 
         self._register_additional_statespace_variables()

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -19,6 +19,7 @@ from rich.table import Table
 from xarray import DataTree
 
 from pymc_extras.statespace.core import dummy_graph, forecast, forward_sampling, irf
+from pymc_extras.statespace.core.fit_recovery import coords_from_idata, dims_from_idata
 from pymc_extras.statespace.core.properties import (
     Coord,
     CoordInfo,
@@ -1086,17 +1087,40 @@ class PyMCStateSpace:
         likelihood is registered. The base implementation registers nothing.
         """
 
-    def _build_dummy_graph(self) -> None:
-        return dummy_graph.build_dummy_graph(self)
+    def _build_dummy_graph(self, idata: DataTree, group: str = "posterior") -> None:
+        """Register a ``pm.Flat`` stand-in for every model parameter, shaped as it was fit.
+
+        Parameters
+        ----------
+        idata : DataTree
+            Inference data from the fit, supplying the shapes and dims to recover.
+        group : str, optional
+            Group holding the sampled parameters. Default ``"posterior"``.
+        """
+        return dummy_graph.build_dummy_graph(
+            self,
+            coords=coords_from_idata(self, idata, "observed_data"),
+            dims=dims_from_idata(self, idata, group),
+        )
 
     def _kalman_filter_outputs_from_dummy_graph(
         self,
-        data: pt.TensorLike | None = None,
+        data: pt.TensorLike,
+        *,
+        coords: dict[str, Sequence],
+        dims: dict[str, list[str]],
+        exog: dict[str, dict],
         data_dims: str | tuple[str] | list[str] | None = None,
         scenario: dict[str, pd.DataFrame] | pd.DataFrame | None = None,
     ) -> tuple[list[pt.TensorVariable], list[tuple[pt.TensorVariable, pt.TensorVariable]]]:
         return dummy_graph.kalman_filter_outputs_from_dummy_graph(
-            self, data=data, data_dims=data_dims, scenario=scenario
+            self,
+            data,
+            coords=coords,
+            dims=dims,
+            exog=exog,
+            data_dims=data_dims,
+            scenario=scenario,
         )
 
     def sample_conditional_prior(
@@ -1416,16 +1440,17 @@ class PyMCStateSpace:
             verbose=verbose,
         )
 
-    def _get_fit_time_index(self) -> pd.RangeIndex | pd.DatetimeIndex:
-        return forecast._get_fit_time_index(self)
+    def _get_fit_time_index(self, idata: DataTree) -> pd.RangeIndex | pd.DatetimeIndex:
+        return forecast._get_fit_time_index(self, idata)
 
     def _validate_scenario_data(
         self,
         scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
+        coords: dict[str, Sequence],
         name: str | None = None,
         verbose=True,
     ):
-        return forecast._validate_scenario_data(self, scenario, name=name, verbose=verbose)
+        return forecast._validate_scenario_data(self, scenario, coords, name=name, verbose=verbose)
 
     @staticmethod
     def _build_forecast_index(
@@ -1449,15 +1474,18 @@ class PyMCStateSpace:
         self,
         scenario: pd.DataFrame | np.ndarray | dict[str, pd.DataFrame | np.ndarray] | None,
         forecast_index: pd.RangeIndex | pd.DatetimeIndex,
+        coords: dict[str, Sequence],
         name=None,
     ):
-        return forecast._finalize_scenario_initialization(self, scenario, forecast_index, name=name)
+        return forecast._finalize_scenario_initialization(
+            self, scenario, forecast_index, coords, name=name
+        )
 
     def _build_forecast_model(
-        self, time_index, t0, forecast_index, scenario, filter_output, mvn_method
+        self, idata, group, time_index, t0, forecast_index, scenario, filter_output, mvn_method
     ):
         return forecast._build_forecast_model(
-            self, time_index, t0, forecast_index, scenario, filter_output, mvn_method
+            self, idata, group, time_index, t0, forecast_index, scenario, filter_output, mvn_method
         )
 
     def forecast(

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -54,8 +54,15 @@ from pymc_extras.statespace.utils.constants import (
     JITTER_DEFAULT,
     MISSING_FILL,
     OBS_STATE_DIM,
+    OBSERVED_DATA_NAME,
+    OBSERVED_LIKELIHOOD_NAME,
+    TIME_DIM,
 )
-from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
+from pymc_extras.statespace.utils.data_tools import (
+    add_data_to_active_model,
+    prepare_data_for_pymc,
+    update_data_in_active_model,
+)
 
 _log = logging.getLogger("pymc.experimental.statespace")
 
@@ -82,6 +89,29 @@ def _validate_property(props, property_name, expected_type):
             f"All elements of the {property_name} property must be instances of "
             f"{expected_type.__name__}."
         )
+
+
+def _statespace_likelihood(model: Model) -> Variable | None:
+    """
+    Return the observation likelihood a state space build put into ``model``, if it holds one.
+
+    A variable named ``obs`` is only ours if a Kalman filter produced it, so a user's own variable
+    of that name is never mistaken for a previous build.
+
+    Parameters
+    ----------
+    model : Model
+        PyMC model to inspect.
+
+    Returns
+    -------
+    likelihood : TensorVariable or None
+        The observation likelihood, or None if the model holds no state space graph.
+    """
+    likelihood = model.named_vars.get(OBSERVED_LIKELIHOOD_NAME, None)
+    if likelihood is None or likelihood.owner is None:
+        return None
+    return likelihood if isinstance(likelihood.owner.op, KalmanFilterRV) else None
 
 
 class PyMCStateSpace:
@@ -954,17 +984,30 @@ class PyMCStateSpace:
         """
         pm_mod = modelcontext(None)
 
-        matrices = self._insert_random_variables()
-        matrices = self._insert_data_variables(matrices)
-
         obs_coords = pm_mod.coords.get(OBS_STATE_DIM, None)
-
-        data, nan_mask = register_data_with_pymc(
+        filled_values, index, _ = prepare_data_for_pymc(
             data,
             n_obs=self.ssm.k_endog,
             obs_coords=obs_coords,
             missing_fill_value=self.missing_fill_value,
         )
+
+        if _statespace_likelihood(pm_mod) is not None:
+            self._reenter_statespace_graph(filled_values, index)
+            return
+
+        for name in (OBSERVED_DATA_NAME, OBSERVED_LIKELIHOOD_NAME):
+            if name in pm_mod.named_vars:
+                raise ValueError(
+                    f"The model already contains a variable named {name!r} that this state space "
+                    f"model did not create. Rename it, or build the state space graph into a "
+                    f"model that does not use that name."
+                )
+
+        matrices = self._insert_random_variables()
+        matrices = self._insert_data_variables(matrices)
+
+        data = add_data_to_active_model(filled_values, index)
 
         # Order is important here: only call _insert_data_shape_into_n_timesteps after data has been registered.
         matrices = self._insert_data_shape_into_n_timesteps(matrices, data)
@@ -980,7 +1023,7 @@ class PyMCStateSpace:
         obs_dims = obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
 
         SequenceMvNormal(
-            "obs",
+            OBSERVED_LIKELIHOOD_NAME,
             mus=observed_states,
             covs=observed_covariances,
             logp=logp,
@@ -989,6 +1032,64 @@ class PyMCStateSpace:
         )
 
         self._register_additional_statespace_variables()
+
+    def _reenter_statespace_graph(
+        self, filled_values: np.ndarray, index: pd.Index | np.ndarray
+    ) -> None:
+        """
+        Point an already-built model at new data.
+
+        The filter graph is left as the first build made it, so re-entry cannot change how the
+        model is constructed -- only which observations it is fit against.
+
+        Parameters
+        ----------
+        filled_values : numpy array
+            New data, with missing values already filled.
+        index : pandas Index or numpy array
+            Time index of the new data.
+        """
+        self._verify_exogenous_data_spans(len(filled_values))
+
+        update_data_in_active_model(filled_values, index)
+
+    def _verify_exogenous_data_spans(self, n_timesteps: int) -> None:
+        """
+        Raise unless every exogenous data variable in the active model spans ``n_timesteps``.
+
+        Exogenous data belongs to the user, so re-entry cannot resize it. Left stale it desyncs
+        from the observed data and the filter fails much later, when the log probability is built.
+
+        Parameters
+        ----------
+        n_timesteps : int
+            Number of time steps in the observed data about to be written.
+
+        Raises
+        ------
+        ValueError
+            If any exogenous data variable spans a different number of time steps.
+        """
+        pm_mod = modelcontext(None)
+
+        stale = {}
+        for name in self.data_names:
+            variable = pm_mod.named_vars.get(name, None)
+            if variable is None:
+                continue
+            found = variable.get_value(borrow=True).shape[0]
+            if found != n_timesteps:
+                stale[name] = found
+
+        if not stale:
+            return
+
+        described = ", ".join(f"{name} ({found} steps)" for name, found in sorted(stale.items()))
+        raise ValueError(
+            f"The new observed data spans {n_timesteps} time steps, but the model's exogenous "
+            f"data still spans a different number: {described}. Update it with pm.set_data, "
+            f"passing new {TIME_DIM!r} coords, before rebuilding."
+        )
 
     def make_filters(self) -> tuple[BaseFilter, KalmanSmoother]:
         """

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1472,6 +1472,7 @@ class PyMCStateSpace:
         random_seed: RandomState | None = None,
         verbose: bool = True,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+        group: str = "posterior",
         **kwargs,
     ) -> DataTree:
         """
@@ -1536,6 +1537,11 @@ class PyMCStateSpace:
             In general, if your model has measurement error, "cholesky" will be safe to use. Otherwise, "svd" is
             recommended. "eigh" can also be tried if sampling with "svd" is very slow, but it is not as robust as "svd".
 
+        group: str, default "posterior"
+            Inference data group to draw parameters from, either "prior" or "posterior". Pass the whole
+            ``idata`` and name the group rather than passing a single group: recovering the time index
+            needs the observed data, which a lone group does not carry.
+
         kwargs:
             Additional keyword arguments are passed to pymc.sample_posterior_predictive
 
@@ -1564,6 +1570,7 @@ class PyMCStateSpace:
             random_seed=random_seed,
             verbose=verbose,
             mvn_method=mvn_method,
+            group=group,
             **kwargs,
         )
 
@@ -1578,6 +1585,7 @@ class PyMCStateSpace:
         orthogonalize_shocks: bool = False,
         random_seed: RandomState | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+        group: str = "posterior",
         **kwargs,
     ):
         """
@@ -1662,5 +1670,6 @@ class PyMCStateSpace:
             orthogonalize_shocks=orthogonalize_shocks,
             random_seed=random_seed,
             mvn_method=mvn_method,
+            group=group,
             **kwargs,
         )

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -257,11 +257,6 @@ class PyMCStateSpace:
         cov_jitter: float = JITTER_DEFAULT,
         missing_fill_value: float = MISSING_FILL,
     ):
-        self._fit_coords: dict[str, Sequence[str]] | None = None
-        self._fit_dims: dict[str, Sequence[str]] | None = None
-        self._fit_data: pt.TensorVariable | None = None
-        self._fit_exog_data: dict[str, dict] = {}
-
         self._needs_exog_data = None
         self._tensor_variable_info = SymbolicVariableInfo()
         self._tensor_data_info = SymbolicDataInfo()
@@ -821,19 +816,6 @@ class PyMCStateSpace:
         """
         raise NotImplementedError("The make_symbolic_statespace method has not been implemented!")
 
-    def _save_exogenous_data_info(self):
-        """
-        Store exogenous data required by posterior sampling functions
-        """
-        pymc_mod = modelcontext(None)
-        for data_name in self.data_names:
-            data = pymc_mod[data_name]
-            self._fit_exog_data[data_name] = {
-                "name": data_name,
-                "value": data.get_value(),
-                "dims": pymc_mod.named_vars_to_dims.get(data_name, None),
-            }
-
     def _insert_random_variables(self) -> list[pt.TensorVariable]:
         """
         Replace pytensor symbolic variables with PyMC random variables.
@@ -1016,11 +998,9 @@ class PyMCStateSpace:
         pm_mod = modelcontext(None)
 
         matrices = self._insert_random_variables()
-        self._save_exogenous_data_info()
         matrices = self._insert_data_variables(matrices)
 
         obs_coords = pm_mod.coords.get(OBS_STATE_DIM, None)
-        self._fit_data = data
 
         data, nan_mask = register_data_with_pymc(
             data,
@@ -1053,9 +1033,6 @@ class PyMCStateSpace:
         )
 
         self._register_additional_statespace_variables()
-
-        self._fit_coords = pm_mod.coords.copy()
-        self._fit_dims = pm_mod.named_vars_to_dims.copy()
 
     def make_filters(self) -> tuple[BaseFilter, KalmanSmoother]:
         """

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -18,6 +18,8 @@ EXOG_STATE_DIM = "exogenous"
 EXOG_COEF_STATE_DIM = "exogenous_coefficient"
 NON_EXOG_STATE_DIM = "non_exogenous_state"
 
+OBSERVED_DATA_NAME = "data"
+
 MISSING_FILL = -9999.0
 JITTER_DEFAULT = 1e-8 if pytensor.config.floatX.endswith("64") else 1e-6
 

--- a/pymc_extras/statespace/utils/constants.py
+++ b/pymc_extras/statespace/utils/constants.py
@@ -19,6 +19,7 @@ EXOG_COEF_STATE_DIM = "exogenous_coefficient"
 NON_EXOG_STATE_DIM = "non_exogenous_state"
 
 OBSERVED_DATA_NAME = "data"
+OBSERVED_LIKELIHOOD_NAME = "obs"
 
 MISSING_FILL = -9999.0
 JITTER_DEFAULT = 1e-8 if pytensor.config.floatX.endswith("64") else 1e-6

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -12,6 +12,7 @@ from pytensor.tensor.sharedvar import TensorSharedVariable
 from pymc_extras.statespace.utils.constants import (
     MISSING_FILL,
     OBS_STATE_DIM,
+    OBSERVED_DATA_NAME,
     TIME_DIM,
 )
 
@@ -149,7 +150,7 @@ def add_data_to_active_model(values, index, data_dims=None):
     else:
         data_shape = (None, values.shape[-1])
 
-    data = pm.Data("data", values, dims=data_dims, shape=data_shape)
+    data = pm.Data(OBSERVED_DATA_NAME, values, dims=data_dims, shape=data_shape)
 
     return data
 

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -181,7 +181,30 @@ def mask_missing_values_in_data(values, missing_fill_value=None):
     return filled_values, nan_mask
 
 
-def register_data_with_pymc(data, n_obs, obs_coords, missing_fill_value=None, data_dims=None):
+def prepare_data_for_pymc(data, n_obs, obs_coords, missing_fill_value=None):
+    """
+    Validate observed data and fill its missing values with a sentinel.
+
+    Parameters
+    ----------
+    data : pytensor tensor, numpy array, or pandas DataFrame or Series
+        Observed data to prepare.
+    n_obs : int
+        Number of observed states the model expects.
+    obs_coords : sequence of str, optional
+        Names of the observed states, used to check the columns of a DataFrame.
+    missing_fill_value : float, optional
+        Value substituted for missing observations. Default None, meaning the package default.
+
+    Returns
+    -------
+    filled_values : numpy array
+        Data with missing values replaced by the sentinel.
+    index : pandas Index or numpy array
+        Time index of the data.
+    nan_mask : numpy array
+        Boolean mask that is True where the data was missing.
+    """
     if isinstance(data, pt.TensorVariable | TensorSharedVariable):
         values, index = preprocess_tensor_data(data, n_obs, obs_coords)
     elif isinstance(data, np.ndarray):
@@ -192,6 +215,14 @@ def register_data_with_pymc(data, n_obs, obs_coords, missing_fill_value=None, da
         raise ValueError("Data should be one of pytensor tensor, numpy array, or pandas dataframe")
 
     filled_values, nan_mask = mask_missing_values_in_data(values, missing_fill_value)
+
+    return filled_values, index, nan_mask
+
+
+def register_data_with_pymc(data, n_obs, obs_coords, missing_fill_value=None, data_dims=None):
+    filled_values, index, nan_mask = prepare_data_for_pymc(
+        data, n_obs, obs_coords, missing_fill_value
+    )
     data_variable = add_data_to_active_model(filled_values, index, data_dims)
 
     return data_variable, nan_mask

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -155,6 +155,37 @@ def add_data_to_active_model(values, index, data_dims=None):
     return data
 
 
+def update_data_in_active_model(values, index, data_dims=None):
+    """
+    Point the active model's observed data variable at new values.
+
+    Parameters
+    ----------
+    values : numpy array
+        Data to write, with missing values already filled.
+    index : pandas Index or numpy array
+        Time index of the data, written to the time coordinate.
+    data_dims : sequence of str, optional
+        Dims of the observed data variable. Default None, meaning the package defaults.
+
+    Returns
+    -------
+    data : TensorVariable
+        The model's observed data variable.
+    """
+    pymc_mod = modelcontext(None)
+    if data_dims is None:
+        data_dims = [TIME_DIM, OBS_STATE_DIM]
+    time_dim = data_dims[0]
+
+    if isinstance(index, pd.Index):
+        index = index.rename(time_dim)
+
+    pymc_mod.set_data(OBSERVED_DATA_NAME, values, coords={time_dim: index})
+
+    return pymc_mod[OBSERVED_DATA_NAME]
+
+
 def mask_missing_values_in_data(values, missing_fill_value=None):
     if missing_fill_value is None:
         missing_fill_value = MISSING_FILL

--- a/tests/statespace/core/test_fit_recovery.py
+++ b/tests/statespace/core/test_fit_recovery.py
@@ -1,0 +1,268 @@
+import numpy as np
+import pandas as pd
+import pymc as pm
+import pytensor
+import pytensor.tensor as pt
+import pytest
+
+import pymc_extras.statespace.models.structural as st
+
+from pymc_extras.statespace.core.fit_recovery import (
+    coords_from_idata,
+    data_from_idata,
+    dims_from_idata,
+    exog_from_idata,
+)
+from pymc_extras.statespace.utils.constants import MISSING_FILL
+
+floatX = pytensor.config.floatX
+
+
+@pytest.fixture(scope="module")
+def exog_fit():
+    """A fitted model with exogenous data, its inference data, and what it was fit on."""
+    rng = np.random.default_rng(0)
+    index = pd.date_range("2020-01-01", periods=40, freq="D")
+    data = pd.DataFrame(rng.normal(size=(40, 1)).astype(floatX), columns=["y"], index=index)
+    exog = pd.DataFrame(rng.normal(size=(40, 2)).astype(floatX), columns=["a", "b"], index=index)
+
+    mod = (
+        st.LevelTrend(order=2, innovations_order=1)
+        + st.Regression(name="exog", state_names=["a", "b"], innovations=False)
+    ).build(verbose=False)
+
+    with pm.Model(coords=mod.coords):
+        pm.Normal("initial_level_trend", dims=["state_level_trend"])
+        pm.Deterministic("P0", pt.eye(mod.k_states, dtype=floatX))
+        pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+        pm.Normal("beta_exog", dims=["state_exog"])
+        pm.Data("data_exog", exog.values)
+        mod.build_statespace_graph(data)
+        idata = pm.sample_prior_predictive(draws=5, random_seed=1)
+
+    return mod, idata, data, exog
+
+
+def test_recovered_coords_cover_every_dim_the_model_uses(exog_fit):
+    """Template and idata are complements, so together they cover the whole system."""
+    mod, idata, data, _ = exog_fit
+
+    recovered = coords_from_idata(mod, idata, "observed_data")
+
+    assert set(mod.coords) <= set(recovered)
+    assert len(recovered["time"]) == len(data)
+
+
+def test_time_comes_only_from_the_idata(exog_fit):
+    """The template cannot know the dataset's time index."""
+    mod, idata, data, _ = exog_fit
+
+    assert "time" not in mod.coords
+    assert len(coords_from_idata(mod, idata, "observed_data")["time"]) == len(data)
+
+
+def test_recovered_time_keeps_its_timestamps(exog_fit):
+    """``_get_fit_time_index`` tests ``isinstance(time[0], pd.Timestamp)`` to recover the freq.
+
+    A datetime coord read straight off the idata is ``datetime64``, which fails that test and
+    silently costs the forecast index its frequency.
+    """
+    mod, idata, *_ = exog_fit
+
+    time = coords_from_idata(mod, idata, "observed_data")["time"]
+
+    assert isinstance(time[0], pd.Timestamp)
+    assert pd.DatetimeIndex(time).inferred_freq == "D"
+
+
+@pytest.mark.parametrize("dim", ["shock", "shock_aux", "observed_state_aux"])
+def test_matrix_dims_come_only_from_the_template(exog_fit, dim):
+    """These are attached to no variable, so no idata group carries them.
+
+    They are the dims ``MATRIX_DIMS`` needs for R, Q and H; recovering from the idata alone
+    would leave those matrices correctly shaped with their dims silently dropped.
+    """
+    mod, idata, *_ = exog_fit
+
+    assert dim not in {name for group in idata.groups for name in idata[group].coords}
+    assert dim in coords_from_idata(mod, idata, "observed_data")
+
+
+def test_a_merged_forecast_does_not_redefine_the_fit_time(exog_fit):
+    """xarray only aligns a group against its ancestors, so sibling groups may disagree.
+
+    Merging a forecast back into the idata is ordinary, and it lands a shorter ``time`` in a
+    group that sorts after ``observed_data``.
+    """
+    mod, idata, *_ = exog_fit
+    merged = idata.copy()
+    merged["/forecast"] = idata["/observed_data"].dataset.isel(time=slice(0, 3))
+
+    assert len(merged["/forecast"].coords["time"]) == 3
+    assert len(coords_from_idata(mod, merged, "observed_data")["time"]) == 40
+
+
+@pytest.mark.parametrize(
+    ("recover", "group"),
+    [(coords_from_idata, "posterior"), (dims_from_idata, "posterior_predictive")],
+    ids=["coords", "dims"],
+)
+def test_a_missing_group_names_what_is_there(exog_fit, recover, group):
+    """A trimmed idata should say what it holds, not recover a silently incomplete answer."""
+    mod, idata, *_ = exog_fit
+
+    with pytest.raises(ValueError, match=f"no {group!r} group"):
+        recover(mod, idata, group)
+
+
+def test_explicit_coords_win(exog_fit):
+    """The override exists for idata that carries no time index of its own."""
+    mod, idata, *_ = exog_fit
+
+    recovered = coords_from_idata(mod, idata, "observed_data", coords={"time": np.arange(7)})
+
+    assert len(recovered["time"]) == 7
+
+
+def test_recovered_dims_match_the_fit(exog_fit):
+    """Only the parameters are recovered -- they are all ``build_dummy_graph`` asks about."""
+    mod, idata, *_ = exog_fit
+
+    recovered = dims_from_idata(mod, idata, "prior")
+
+    assert recovered == {
+        "initial_level_trend": ["state_level_trend"],
+        "sigma_level_trend": ["shock_level_trend"],
+        "beta_exog": ["state_exog"],
+    }
+
+
+def test_generated_dims_are_dropped(exog_fit):
+    """``P0`` is registered without dims, so PyMC generates P0_dim_0 and P0_dim_1 for it."""
+    mod, idata, *_ = exog_fit
+
+    assert "P0_dim_0" in idata["/prior"].coords
+    assert "P0" not in dims_from_idata(mod, idata, "prior")
+
+
+def test_a_user_dim_that_only_resembles_the_generated_form_survives():
+    """Only ``{name}_dim_{integer}`` is dropped, not every dim whose name looks like it."""
+    rng = np.random.default_rng(0)
+    data = pd.DataFrame(
+        rng.normal(size=(12, 1)).astype(floatX),
+        columns=["y"],
+        index=pd.date_range("2020-01-01", periods=12, freq="D"),
+    )
+    mod = st.LevelTrend(order=2, innovations_order=1).build(verbose=False)
+
+    with pm.Model(coords=mod.coords | {"initial_level_trend_dim_zero": ["a", "b"]}):
+        pm.Normal("initial_level_trend", dims=["initial_level_trend_dim_zero"])
+        pm.Deterministic("P0", pt.eye(mod.k_states, dtype=floatX))
+        pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+        mod.build_statespace_graph(data)
+        idata = pm.sample_prior_predictive(draws=3, random_seed=1)
+
+    recovered = dims_from_idata(mod, idata, "prior")
+
+    assert recovered["initial_level_trend"] == ["initial_level_trend_dim_zero"]
+
+
+def test_recovered_data_matches_the_fit(exog_fit):
+    """Values and index round-trip; the sentinel stands where the fit saw ``nan``."""
+    mod, idata, data, exog = exog_fit
+
+    recovered = data_from_idata(idata, "constant_data")
+
+    assert recovered.shape == data.shape
+    assert recovered.index.equals(data.index)
+    assert recovered.index.freq == data.index.freq
+    np.testing.assert_allclose(recovered.values, data.values)
+
+
+def test_recovered_exog_matches_the_fit(exog_fit):
+    """The fixture registers its exogenous data without dims, so none should be recovered."""
+    mod, idata, data, exog = exog_fit
+
+    recovered = exog_from_idata(mod, idata, "constant_data")
+
+    assert recovered.keys() == {"data_exog"}
+    entry = recovered["data_exog"]
+    assert entry["name"] == "data_exog"
+    assert entry["dims"] is None
+    np.testing.assert_allclose(entry["value"], exog.values)
+
+
+def test_recovered_exog_keeps_declared_dims():
+    """Dims the user did give survive, unlike the generated ones."""
+    rng = np.random.default_rng(0)
+    index = pd.date_range("2020-01-01", periods=15, freq="D")
+    data = pd.DataFrame(rng.normal(size=(15, 1)).astype(floatX), columns=["y"], index=index)
+    exog = pd.DataFrame(rng.normal(size=(15, 2)).astype(floatX), columns=["a", "b"], index=index)
+
+    mod = (
+        st.LevelTrend(order=2, innovations_order=1)
+        + st.Regression(name="exog", state_names=["a", "b"], innovations=False)
+    ).build(verbose=False)
+
+    with pm.Model(coords=mod.coords):
+        pm.Normal("initial_level_trend", dims=["state_level_trend"])
+        pm.Deterministic("P0", pt.eye(mod.k_states, dtype=floatX))
+        pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+        pm.Normal("beta_exog", dims=["state_exog"])
+        pm.Data("data_exog", exog.values, dims=["time", "state_exog"])
+        mod.build_statespace_graph(data)
+        idata = pm.sample_prior_predictive(draws=3, random_seed=1)
+
+    recovered = exog_from_idata(mod, idata, "constant_data")
+
+    assert recovered["data_exog"]["dims"] == ["time", "state_exog"]
+
+
+def test_recovered_exog_can_be_registered(exog_fit):
+    """The result is ``pm.Data`` keywords, so it must splat straight back into a model."""
+    mod, idata, data, exog = exog_fit
+    recovered = exog_from_idata(mod, idata, "constant_data")
+
+    with pm.Model(coords=coords_from_idata(mod, idata, "observed_data")):
+        registered = {name: pm.Data(**entry) for name, entry in recovered.items()}
+
+    assert registered["data_exog"].get_value().shape == exog.shape
+
+
+def test_missing_observed_data_names_what_the_group_holds(exog_fit):
+    mod, idata, *_ = exog_fit
+
+    with pytest.raises(ValueError, match="holds no 'data' variable"):
+        data_from_idata(idata, "prior")
+
+
+@pytest.mark.filterwarnings("ignore:Provided data contains missing values")
+def test_recovered_data_carries_the_sentinel_where_the_fit_saw_nan():
+    """The substitution happens before the data is recorded, so ``nan`` cannot come back.
+
+    That is only safe because the filter derives its missing mask from the sentinel rather than
+    from ``nan``, which this pins by filtering both and comparing the log-likelihood. Only the
+    raw fit warns about imputation, since the recovered frame has no ``nan`` left to impute.
+    """
+    rng = np.random.default_rng(0)
+    index = pd.date_range("2020-01-01", periods=25, freq="D")
+    values = rng.normal(size=(25, 1)).astype(floatX)
+    values[[3, 11, 12]] = np.nan
+    raw = pd.DataFrame(values, columns=["y"], index=index)
+
+    def fit_and_score(frame):
+        mod = st.LevelTrend(order=2, innovations_order=1).build(verbose=False)
+        with pm.Model(coords=mod.coords) as pymc_mod:
+            pm.Normal("initial_level_trend", dims=["state_level_trend"])
+            pm.Deterministic("P0", pt.eye(mod.k_states, dtype=floatX))
+            pm.Exponential("sigma_level_trend", 1, dims=["shock_level_trend"])
+            mod.build_statespace_graph(frame)
+            idata = pm.sample_prior_predictive(draws=3, random_seed=1)
+            return idata, pymc_mod.compile_logp()(pymc_mod.initial_point())
+
+    idata, raw_logp = fit_and_score(raw)
+    recovered = data_from_idata(idata, "constant_data")
+
+    assert np.isnan(recovered.values).sum() == 0
+    assert (recovered.values[[3, 11, 12]] == MISSING_FILL).all()
+    assert fit_and_score(recovered)[1] == raw_logp

--- a/tests/statespace/core/test_fit_recovery.py
+++ b/tests/statespace/core/test_fit_recovery.py
@@ -12,6 +12,7 @@ from pymc_extras.statespace.core.fit_recovery import (
     data_from_idata,
     dims_from_idata,
     exog_from_idata,
+    verify_group,
 )
 from pymc_extras.statespace.utils.constants import MISSING_FILL
 
@@ -234,6 +235,13 @@ def test_missing_observed_data_names_what_the_group_holds(exog_fit):
 
     with pytest.raises(ValueError, match="holds no 'data' variable"):
         data_from_idata(idata, "prior")
+
+
+@pytest.mark.parametrize("group", ["posterior_predictive", "observed_data", "Posterior", ""])
+def test_verify_group_rejects_groups_parameters_cannot_come_from(group):
+    """It guards the public ``group=`` argument, so it must reject near-misses too."""
+    with pytest.raises(ValueError, match='must be one of "prior" or "posterior"'):
+        verify_group(group)
 
 
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values")

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -669,7 +669,9 @@ def test_forecast_valid_index(exog_pymc_mod, exog_ss_mod, exog_data):
     }
 
     # Generate the forecast
-    forecasts = exog_ss_mod.forecast(idata.prior, scenario=scenario, use_scenario_index=True)
+    forecasts = exog_ss_mod.forecast(
+        idata, scenario=scenario, use_scenario_index=True, group="prior"
+    )
     assert "forecast_latent" in forecasts
     assert "forecast_observed" in forecasts
 

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -4,10 +4,12 @@ import numpy as np
 import pandas as pd
 import pymc as pm
 import pytest
+import xarray as xr
 
 from numpy.testing import assert_allclose
 from pytensor.compile import SharedVariable
 from pytensor.graph.traversal import graph_inputs
+from xarray import DataTree
 
 from tests.statespace.test_utilities import (
     load_nile_test_data,
@@ -17,15 +19,15 @@ from tests.statespace.test_utilities import (
 nile = load_nile_test_data()
 
 
-def _make_time_idx(mod, use_datetime_index=True):
+def _make_time_idx(use_datetime_index=True):
+    """Return a time index and the smallest idata that records it, as a fit would."""
     if use_datetime_index:
-        mod._fit_coords["time"] = nile.index
         time_idx = nile.index
     else:
-        mod._fit_coords["time"] = nile.reset_index().index
         time_idx = pd.RangeIndex(start=0, stop=nile.shape[0], step=1)
 
-    return time_idx
+    idata = DataTree.from_dict({"observed_data": xr.Dataset(coords={"time": time_idx})})
+    return time_idx, idata
 
 
 @pytest.mark.parametrize("use_datetime_index", [True, False])
@@ -34,12 +36,12 @@ def test_bad_forecast_arguments(use_datetime_index, caplog):
         k_endog=1, k_posdef=1, k_states=2, filter_type="standard", verbose=False
     )
 
-    # Not-fit model raises
-    ss_mod._fit_coords = dict()
+    # Inference data with no time coord raises
+    empty = DataTree.from_dict({"observed_data": xr.Dataset()})
     with pytest.raises(ValueError, match=r"Has this model been fit?"):
-        ss_mod._get_fit_time_index()
+        ss_mod._get_fit_time_index(empty)
 
-    time_idx = _make_time_idx(ss_mod, use_datetime_index)
+    time_idx, time_idata = _make_time_idx(use_datetime_index)
 
     # Start value not in time index
     match = (
@@ -84,8 +86,7 @@ def test_forecast_index(use_datetime_index):
     ss_mod = make_statespace_mod(
         k_endog=1, k_posdef=1, k_states=2, filter_type="standard", verbose=False
     )
-    ss_mod._fit_coords = dict()
-    time_idx = _make_time_idx(ss_mod, use_datetime_index)
+    time_idx, _ = _make_time_idx(use_datetime_index)
 
     # From start and end
     start = time_idx[-1]
@@ -155,10 +156,10 @@ def test_validate_scenario(data_type):
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(features_a=["column_1"])
+    coords = dict(features_a=["column_1"])
 
     scenario = data_type(np.zeros(10))
-    scenario = ss_mod._validate_scenario_data(scenario)
+    scenario = ss_mod._validate_scenario_data(scenario, coords)
 
     # Lists and tuples are cast to 2d arrays
     if data_type in [tuple, list]:
@@ -167,7 +168,7 @@ def test_validate_scenario(data_type):
 
     # A one-item dictionary should also work
     scenario = {"a": scenario}
-    ss_mod._validate_scenario_data(scenario)
+    ss_mod._validate_scenario_data(scenario, coords)
 
     # Now data has to be a dictionary
     data_info.update({"b": {"shape": (None, 1), "dims": ("time", "features_b")}})
@@ -179,10 +180,10 @@ def test_validate_scenario(data_type):
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(features_a=["column_1"], features_b=["column_1"])
+    coords = dict(features_a=["column_1"], features_b=["column_1"])
 
     scenario = {"a": data_type(np.zeros(10)), "b": data_type(np.zeros(10))}
-    ss_mod._validate_scenario_data(scenario)
+    ss_mod._validate_scenario_data(scenario, coords)
 
     # Mixed data types
     data_info.update({"a": {"shape": (None, 10), "dims": ("time", "features_a")}})
@@ -194,16 +195,14 @@ def test_validate_scenario(data_type):
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(
-        features_a=[f"column_{i}" for i in range(10)], features_b=["column_1"]
-    )
+    coords = dict(features_a=[f"column_{i}" for i in range(10)], features_b=["column_1"])
 
     scenario = {
-        "a": pd.DataFrame(np.zeros((10, 10)), columns=ss_mod._fit_coords["features_a"]),
+        "a": pd.DataFrame(np.zeros((10, 10)), columns=coords["features_a"]),
         "b": data_type(np.arange(10)),
     }
 
-    ss_mod._validate_scenario_data(scenario)
+    ss_mod._validate_scenario_data(scenario, coords)
 
 
 @pytest.mark.parametrize(
@@ -226,15 +225,17 @@ def test_finalize_scenario_single(data_type, use_datetime_index):
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(features_a=["column_1"])
+    coords = dict(features_a=["column_1"])
 
-    time_idx = _make_time_idx(ss_mod, use_datetime_index)
+    time_idx, _ = _make_time_idx(use_datetime_index)
 
     scenario = data_type(np.zeros((10,)))
 
-    scenario = ss_mod._validate_scenario_data(scenario)
+    scenario = ss_mod._validate_scenario_data(scenario, coords)
     t0, forecast_idx = ss_mod._build_forecast_index(time_idx, start=time_idx[-1], periods=10)
-    scenario = ss_mod._finalize_scenario_initialization(scenario, forecast_index=forecast_idx)
+    scenario = ss_mod._finalize_scenario_initialization(
+        scenario, forecast_index=forecast_idx, coords=coords
+    )
 
     assert isinstance(scenario, pd.DataFrame)
     assert scenario.index.equals(forecast_idx)
@@ -261,8 +262,8 @@ def test_finalize_scenario_dict(data_type, use_datetime_index, use_scenario_inde
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(features_a=["column_1"], features_b=["column_1", "column_2"])
-    time_idx = _make_time_idx(ss_mod, use_datetime_index)
+    coords = dict(features_a=["column_1"], features_b=["column_1", "column_2"])
+    time_idx, _ = _make_time_idx(use_datetime_index)
 
     initial_index = (
         pd.date_range(start=time_idx[-1], periods=10, freq=time_idx.freq)
@@ -278,12 +279,10 @@ def test_finalize_scenario_dict(data_type, use_datetime_index, use_scenario_inde
 
     scenario = {
         "a": data_type(np.zeros((10,))),
-        "b": pd.DataFrame(
-            np.zeros((10, 2)), columns=ss_mod._fit_coords["features_b"], index=initial_index
-        ),
+        "b": pd.DataFrame(np.zeros((10, 2)), columns=coords["features_b"], index=initial_index),
     }
 
-    scenario = ss_mod._validate_scenario_data(scenario)
+    scenario = ss_mod._validate_scenario_data(scenario, coords)
 
     if use_scenario_index and data_type not in [np.array, list, tuple]:
         t0, forecast_idx = ss_mod._build_forecast_index(
@@ -296,7 +295,9 @@ def test_finalize_scenario_dict(data_type, use_datetime_index, use_scenario_inde
     else:
         t0, forecast_idx = ss_mod._build_forecast_index(time_idx, start=time_idx[-1], periods=10)
 
-    scenario = ss_mod._finalize_scenario_initialization(scenario, forecast_index=forecast_idx)
+    scenario = ss_mod._finalize_scenario_initialization(
+        scenario, forecast_index=forecast_idx, coords=coords
+    )
 
     assert list(scenario.keys()) == ["a", "b"]
     assert all(isinstance(value, pd.DataFrame) for value in scenario.values())
@@ -313,14 +314,14 @@ def test_invalid_scenarios():
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(features_a=["column_1", "column_2"])
+    coords = dict(features_a=["column_1", "column_2"])
 
     # Omitting the data raises
     with pytest.raises(
         ValueError,
         match=r"This model was fit using exogenous data. Forecasting cannot be performed",
     ):
-        ss_mod._validate_scenario_data(None)
+        ss_mod._validate_scenario_data(None, coords)
 
     # Giving a list, tuple, or Series when a matrix of data is expected should always raise
     with pytest.raises(
@@ -328,15 +329,15 @@ def test_invalid_scenarios():
         match=r"Scenario data for variable 'a' has the wrong number of columns. Expected 2, got 1",
     ):
         for data_type in [list, tuple, pd.Series]:
-            ss_mod._validate_scenario_data(data_type(np.zeros(10)))
-            ss_mod._validate_scenario_data({"a": data_type(np.zeros(10))})
+            ss_mod._validate_scenario_data(data_type(np.zeros(10)), coords)
+            ss_mod._validate_scenario_data({"a": data_type(np.zeros(10))}, coords)
 
     # Providing irrevelant data raises
     with pytest.raises(
         ValueError,
         match="Scenario data provided for variable 'jk lol', which is not an exogenous variable",
     ):
-        ss_mod._validate_scenario_data({"jk lol": np.zeros(10)})
+        ss_mod._validate_scenario_data({"jk lol": np.zeros(10)}, coords)
 
     # Incorrect 2nd dimension of a non-dataframe
     with pytest.raises(
@@ -344,19 +345,19 @@ def test_invalid_scenarios():
         match=r"Scenario data for variable 'a' has the wrong number of columns. Expected 2, got 1",
     ):
         scenario = np.zeros(10).tolist()
-        ss_mod._validate_scenario_data(scenario)
-        ss_mod._validate_scenario_data(tuple(scenario))
+        ss_mod._validate_scenario_data(scenario, coords)
+        ss_mod._validate_scenario_data(tuple(scenario), coords)
 
         scenario = {"a": np.zeros(10).tolist()}
-        ss_mod._validate_scenario_data(scenario)
-        ss_mod._validate_scenario_data({"a": tuple(scenario["a"])})
+        ss_mod._validate_scenario_data(scenario, coords)
+        ss_mod._validate_scenario_data({"a": tuple(scenario["a"])}, coords)
 
     # If a data frame is provided, it needs to have all columns
     with pytest.raises(
         ValueError, match="Scenario data for variable 'a' is missing the following column: column_2"
     ):
         scenario = pd.DataFrame(np.zeros((10, 1)), columns=["column_1"])
-        ss_mod._validate_scenario_data(scenario)
+        ss_mod._validate_scenario_data(scenario, coords)
 
     # Extra columns also raises
     with pytest.raises(
@@ -367,7 +368,7 @@ def test_invalid_scenarios():
         scenario = pd.DataFrame(
             np.zeros((10, 4)), columns=["column_1", "column_2", "column_3", "column_4"]
         )
-        ss_mod._validate_scenario_data(scenario)
+        ss_mod._validate_scenario_data(scenario, coords)
 
     # Wrong number of time steps raises
     data_info = {
@@ -382,18 +383,16 @@ def test_invalid_scenarios():
         verbose=False,
         data_info=data_info,
     )
-    ss_mod._fit_coords = dict(
-        features_a=["column_1", "column_2"], features_b=["column_1", "column_2"]
-    )
+    coords = dict(features_a=["column_1", "column_2"], features_b=["column_1", "column_2"])
 
     with pytest.raises(
         ValueError, match="Scenario data must have the same number of time steps for all variables"
     ):
         scenario = {
-            "a": pd.DataFrame(np.zeros((10, 2)), columns=ss_mod._fit_coords["features_a"]),
-            "b": pd.DataFrame(np.zeros((11, 2)), columns=ss_mod._fit_coords["features_b"]),
+            "a": pd.DataFrame(np.zeros((10, 2)), columns=coords["features_a"]),
+            "b": pd.DataFrame(np.zeros((11, 2)), columns=coords["features_b"]),
         }
-        ss_mod._validate_scenario_data(scenario)
+        ss_mod._validate_scenario_data(scenario, coords)
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data.")
@@ -448,7 +447,7 @@ def test_invalid_scenarios():
 def test_forecast(filter_output, mod_name, idata_name, start, end, periods, rng, request):
     mod = request.getfixturevalue(mod_name)
     idata = request.getfixturevalue(idata_name)
-    time_idx = mod._get_fit_time_index()
+    time_idx = mod._get_fit_time_index(idata)
     is_datetime = isinstance(time_idx, pd.DatetimeIndex)
 
     if isinstance(start, str):
@@ -570,7 +569,7 @@ def test_build_forecast_model(rng, exog_ss_mod, exog_pymc_mod, exog_data, idata_
     )
     scenario.set_index("date", inplace=True)
 
-    time_index = exog_ss_mod._get_fit_time_index()
+    time_index = exog_ss_mod._get_fit_time_index(idata_exog)
     t0, forecast_index = exog_ss_mod._build_forecast_index(
         time_index=time_index,
         start=exog_data.index[-1],
@@ -586,6 +585,8 @@ def test_build_forecast_model(rng, exog_ss_mod, exog_pymc_mod, exog_data, idata_
     ).posterior_predictive
 
     test_forecast_model = exog_ss_mod._build_forecast_model(
+        idata=idata_exog,
+        group="posterior",
         time_index=time_index,
         t0=t0,
         forecast_index=forecast_index,

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -74,7 +74,9 @@ def test_build_statespace_graph_warns_if_data_has_nans():
 
 def test_build_statespace_graph_raises_if_data_has_missing_fill():
     # Breaks tests if it uses the session fixtures because we can't call build_statespace_graph over and over
-    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=0).build(verbose=False)
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=0).build(
+        verbose=False, missing_fill_value=1.0
+    )
 
     with pm.Model() as pymc_mod:
         initial_trend = pm.Normal("initial_trend", shape=(1,))
@@ -82,7 +84,7 @@ def test_build_statespace_graph_raises_if_data_has_missing_fill():
         with pytest.raises(ValueError, match=r"Provided data contains the value 1.0"):
             data = np.ones((10, 1), dtype=floatX)
             data[3] = np.nan
-            ss_mod.build_statespace_graph(data=data, missing_fill_value=1.0)
+            ss_mod.build_statespace_graph(data=data)
 
 
 def test_param_dims_coords(ss_mod_multi_component):
@@ -133,20 +135,27 @@ def test_filter_config_defaults_to_the_documented_values():
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
-def test_filter_config_is_overridable_at_build():
-    """A build-time argument overrides the model's filter settings; others are left alone."""
+def test_filter_config_survives_building_into_several_models():
+    """Filter settings belong to the model, so building again cannot repoint them."""
     ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(
         verbose=False, cov_jitter=1e-4, missing_fill_value=-1234.0
     )
 
-    with pm.Model(coords=ss_mod.coords):
-        pm.Normal("initial_trend", shape=(1,))
-        pm.Deterministic("P0", pt.eye(1, dtype=floatX))
-        pm.Exponential("sigma_trend", 1, shape=(1,))
-        ss_mod.build_statespace_graph(data=np.zeros((20, 1), dtype=floatX), cov_jitter=1e-2)
+    for n_obs in (20, 25):
+        with pm.Model(coords=ss_mod.coords):
+            pm.Normal("initial_trend", shape=(1,))
+            pm.Deterministic("P0", pt.eye(1, dtype=floatX))
+            pm.Exponential("sigma_trend", 1, shape=(1,))
+            ss_mod.build_statespace_graph(data=np.zeros((n_obs, 1), dtype=floatX))
 
-    assert ss_mod.cov_jitter == 1e-2
+    assert ss_mod.cov_jitter == 1e-4
     assert ss_mod.missing_fill_value == -1234.0
+
+    # Post-estimation reads these off the model, so they have to describe every graph it built.
+    kalman_filter, kalman_smoother = ss_mod.make_filters()
+    assert kalman_filter.cov_jitter == 1e-4
+    assert kalman_filter.missing_fill_value == -1234.0
+    assert kalman_smoother.cov_jitter == 1e-4
 
 
 @pytest.mark.parametrize(

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -226,6 +226,113 @@ def test_register_additional_statespace_variables_hook():
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_rebuild_updates_data():
+    """Re-running the build cell points the model at the new data instead of raising."""
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)
+
+    with pm.Model(coords=ss_mod.coords) as rebuilt:
+        pm.Normal("initial_trend", dims=["state_trend"])
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX) * 1e6, dims=["state", "state_aux"])
+        pm.Exponential("sigma_trend", 1, dims=["shock_trend"])
+        ss_mod.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+        ss_mod.build_statespace_graph(np.arange(17, dtype=floatX)[:, None])
+
+    with pm.Model(coords=ss_mod.coords) as built_once:
+        pm.Normal("initial_trend", dims=["state_trend"])
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX) * 1e6, dims=["state", "state_aux"])
+        pm.Exponential("sigma_trend", 1, dims=["shock_trend"])
+        ss_mod.build_statespace_graph(np.arange(17, dtype=floatX)[:, None])
+
+    assert rebuilt["data"].get_value().shape == (17, 1)
+    assert len(rebuilt.coords["time"]) == 17
+
+    # The updated graph has to filter all 17 observations, not the 10 it was built with.
+    assert_allclose(
+        rebuilt.compile_logp()(rebuilt.initial_point()),
+        built_once.compile_logp()(built_once.initial_point()),
+    )
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+@pytest.mark.parametrize("name", ["data", "obs"], ids=["data", "obs"])
+def test_build_into_model_owning_reserved_name_raises(name):
+    """A user's own variable is not mistaken for a previous build, or silently overwritten."""
+    ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)
+
+    with pm.Model(coords=ss_mod.coords):
+        pm.Normal("initial_trend", dims=["state_trend"])
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX) * 1e6, dims=["state", "state_aux"])
+        pm.Exponential("sigma_trend", 1, dims=["shock_trend"])
+        pm.Normal(name, observed=np.zeros((10, 1)))
+
+        with pytest.raises(ValueError, match="did not create"):
+            ss_mod.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_rebuild_does_not_duplicate_subclass_variables():
+    """Nodes a subclass registers through the hook do not collide when the build is re-run."""
+
+    class SubclassStateSpace(PyMCStateSpace):
+        def make_symbolic_graph(self):
+            rho = self.make_and_register_variable("rho", ())
+            self.ssm["transition", 0, 0] = rho
+            self.ssm["design", 0, 0] = 1.0
+            self.ssm["selection", 0, 0] = 1.0
+            self.ssm["state_cov", 0, 0] = 1.0
+            self.ssm["initial_state_cov", 0, 0] = 1.0
+
+        @property
+        def param_names(self):
+            return ["rho"]
+
+        def _register_additional_statespace_variables(self):
+            pm.Deterministic("subclass_det", pm.modelcontext(None)["data"].sum())
+            pm.Potential("subclass_check", pt.zeros(()))
+
+    ss_mod = SubclassStateSpace(
+        k_endog=1, k_states=1, k_posdef=1, filter_type="standard", verbose=False
+    )
+
+    with pm.Model() as pymc_mod:
+        pm.Normal("rho")
+        ss_mod.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+        ss_mod.build_statespace_graph(np.arange(12, dtype=floatX)[:, None])
+
+    assert [x.name for x in pymc_mod.deterministics].count("subclass_det") == 1
+    assert [x.name for x in pymc_mod.potentials].count("subclass_check") == 1
+    assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_rebuild_with_stale_exogenous_data_raises():
+    """Exogenous data belongs to the user, so re-entry refuses to desync it from the observations."""
+    ss_mod = (
+        st.LevelTrend(name="trend", order=1, innovations_order=1)
+        + st.Regression(state_names=["x1"], name="exog", innovations=False)
+    ).build(verbose=False)
+
+    with pm.Model(coords=ss_mod.coords) as pymc_mod:
+        pm.Normal("initial_trend", dims=["state_trend"])
+        pm.Normal("beta_exog", dims=["state_exog"])
+        pm.Deterministic("P0", pt.eye(2, dtype=floatX) * 1e6, dims=["state", "state_aux"])
+        pm.Exponential("sigma_trend", 1, dims=["shock_trend"])
+        pm.Data("data_exog", np.ones((10, 1), dtype=floatX), dims=["time", "state_exog"])
+        ss_mod.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
+        with pytest.raises(ValueError, match="exogenous data still spans a different number"):
+            ss_mod.build_statespace_graph(np.arange(17, dtype=floatX)[:, None])
+
+        # Updating the exogenous data first is what the error asks for, and it lets the rebuild in.
+        pm.set_data({"data_exog": np.ones((17, 1), dtype=floatX)}, coords={"time": np.arange(17)})
+        ss_mod.build_statespace_graph(np.arange(17, dtype=floatX)[:, None])
+
+    assert pymc_mod["data"].get_value().shape == (17, 1)
+    assert pymc_mod["data_exog"].get_value().shape == (17, 1)
+    assert np.isfinite(pymc_mod.compile_logp()(pymc_mod.initial_point()))
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
 def test_statespace_model_survives_pickling():
     """A statespace model holds no PyMC-model references, so it round-trips and still builds."""
     ss_mod = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -254,6 +254,26 @@ def test_rebuild_updates_data():
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_rebuild_with_a_different_specification_raises():
+    """Re-entry must not let a changed model specification inherit the graph already built."""
+    built = st.LevelTrend(name="trend", order=1, innovations_order=1).build(verbose=False)
+    respecified = (
+        st.LevelTrend(name="trend", order=1, innovations_order=1)
+        + st.MeasurementError(name="obs_err")
+    ).build(verbose=False)
+
+    with pm.Model(coords=built.coords):
+        pm.Normal("initial_trend", dims=["state_trend"])
+        pm.Deterministic("P0", pt.eye(1, dtype=floatX) * 1e6, dims=["state", "state_aux"])
+        pm.Exponential("sigma_trend", 1, dims=["shock_trend"])
+        built.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
+        # The respecified model needs a parameter the graph in this model knows nothing about.
+        with pytest.raises(ValueError, match="sigma_obs_err"):
+            respecified.build_statespace_graph(np.arange(10, dtype=floatX)[:, None])
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
 @pytest.mark.parametrize("name", ["data", "obs"], ids=["data", "obs"])
 def test_build_into_model_owning_reserved_name_raises(name):
     """A user's own variable is not mistaken for a previous build, or silently overwritten."""

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -12,6 +12,7 @@ from numpy.testing import assert_allclose, assert_array_less
 from pymc.testing import mock_sample_setup_and_teardown
 
 from pymc_extras.statespace import BayesianSARIMAX
+from pymc_extras.statespace.core.fit_recovery import exog_from_idata
 from pymc_extras.statespace.models.utilities import (
     make_harvey_state_names,
     make_SARIMA_transition_matrix,
@@ -477,7 +478,9 @@ def test_SARIMA_with_exogenous(rng, mock_sample):
         100,
         2,
     )
-    np.testing.assert_allclose(ss_mod._fit_exog_data["exogenous_data"]["value"], data_val)
+    np.testing.assert_allclose(
+        exog_from_idata(ss_mod, idata, "constant_data")["exogenous_data"]["value"], data_val
+    )
 
 
 def test_sarimax_workflow(mock_sample):

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -218,13 +218,13 @@ ids = ["from-posterior-cov", "scalar_shock_size", "array_shock_size", "user-cov"
 @pytest.mark.parametrize("parameters", parameters, ids=ids)
 @pytest.mark.skipif(floatX == "float32", reason="Impulse covariance not PSD if float32")
 def test_impulse_response(parameters, varma_mod, idata, rng):
-    irf = varma_mod.impulse_response_function(idata.prior, random_seed=rng, **parameters)
+    irf = varma_mod.impulse_response_function(idata, random_seed=rng, group="prior", **parameters)
 
     assert np.isfinite(irf.irf.values).all()
 
 
 def test_forecast(varma_mod, idata, rng):
-    forecast = varma_mod.forecast(idata.prior, periods=10, random_seed=rng)
+    forecast = varma_mod.forecast(idata, periods=10, random_seed=rng, group="prior")
 
     assert np.isfinite(forecast.forecast_latent.values).all()
     assert np.isfinite(forecast.forecast_observed.values).all()
@@ -509,11 +509,12 @@ class TestVARMAXWithExogenous:
             match=r"This model was fit using exogenous data. Forecasting cannot be performed "
             r"without providing scenario data",
         ):
-            mod.forecast(prior.prior, periods=10, random_seed=rng)
+            mod.forecast(prior, periods=10, random_seed=rng, group="prior")
 
         forecast = mod.forecast(
-            prior.prior,
+            prior,
             periods=10,
+            group="prior",
             random_seed=rng,
             scenario={
                 "exogenous_data": pd.DataFrame(


### PR DESCRIPTION
`PyMCStateSpace` cached four things about the fit on itself — the coords, the parameter dims, the observed data and the exogenous data — and every post-estimation method read them back. That made the object single-use: building the same template into a second model silently repointed all four, so an idata sampled from the first model was left paired with a template that had forgotten it. Nothing raised.

Post-estimation now reconstructs what it needs from the template plus the idata it was already handed, and the four attributes are gone. The two sources turn out to be exact complements: the structural coords reach only the template, since they're attached to no sampled or observed variable, and the time axis reaches only the idata.

With no fit state left to protect, re-running `build_statespace_graph` updates the observed data instead of failing on a duplicate `data` name — the re-executed notebook cell this started from. It still raises if the template's parameters aren't in the model, so editing the specification and re-running the cell can't silently inherit the graph that's already there. It no longer accepts `cov_jitter`, `missing_fill_value` or `mvn_method`. The first two are constructor-only now, because a build-time override was written back onto the template and repointed the settings post-estimation reads.

`forecast` and `impulse_response_function` gained a `group` argument, so pass the whole idata and name the group rather than passing `idata.prior`:

```python
forecast = ss_mod.forecast(idata, periods=10, group="prior")
```

A lone group carries no observed data, so there's nothing to recover the time index from.
