### PR TITLE
Fix AttributeError raised when a placeholder is registered twice

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -715,7 +715,7 @@ class PyMCStateSpace:
         if name in self._tensor_variable_info:
             raise ValueError(
                 f"{name} is already a registered placeholder variable with shape "
-                f"{self._tensor_variable_info[name].type.shape}"
+                f"{self._tensor_variable_info[name].symbolic_variable.type.shape}"
             )
 
         placeholder = pt.tensor(name, shape=shape, dtype=dtype)
@@ -755,7 +755,7 @@ class PyMCStateSpace:
         if name in self._tensor_data_info:
             raise ValueError(
                 f"{name} is already a registered placeholder variable with shape "
-                f"{self._tensor_data_info[name].type.shape}"
+                f"{self._tensor_data_info[name].symbolic_data.type.shape}"
             )
 
         placeholder = pt.tensor(name, shape=shape, dtype=dtype)

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -53,6 +53,43 @@ def test_base_class_raises():
         )
 
 
+@pytest.mark.parametrize(
+    "registrar, info_attribute",
+    [
+        ("make_and_register_variable", "_tensor_variable_info"),
+        ("make_and_register_data", "_tensor_data_info"),
+    ],
+    ids=["variable", "data"],
+)
+def test_registering_a_placeholder_twice_reports_the_existing_shape(registrar, info_attribute):
+    """The duplicate-registration error names the shape already registered under that name."""
+
+    class SubclassStateSpace(PyMCStateSpace):
+        def make_symbolic_graph(self):
+            pass
+
+        @property
+        def param_names(self):
+            return ["rho"]
+
+        @property
+        def data_names(self):
+            return ["rho"]
+
+    ss_mod = SubclassStateSpace(
+        k_endog=1, k_states=1, k_posdef=1, filter_type="standard", verbose=False
+    )
+    register = getattr(ss_mod, registrar)
+    register("rho", (3,))
+
+    with pytest.raises(ValueError, match=r"already a registered placeholder variable with shape"):
+        register("rho", (3,))
+
+    # The message reads the shape off the registered placeholder, not off the info wrapper.
+    with pytest.raises(ValueError, match=r"\(3,\)"):
+        register("rho", (3,))
+
+
 def test_update_raises_if_missing_variables(ss_mod):
     with pm.Model() as mod:
         rho = pm.Normal("rho")


### PR DESCRIPTION
`make_and_register_variable` and `make_and_register_data` are supposed to raise `ValueError` when a name is registered twice, naming the shape already registered under it. They read the shape off the `SymbolicVariable`/`SymbolicData` wrapper instead of the tensor inside it, and those dataclasses have no `type`, so you got `AttributeError: 'SymbolicVariable' object has no attribute 'type'` instead of the message.

`Component` has near-copies of both methods with this right, so the original fix landed on one of the two.
