### PR TITLE
Fix use_data_time_dim in unconditional sampling

### DIFF
--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -267,16 +267,18 @@ def _sample_unconditional(
     fit_dims = dims_from_idata(ss_mod, idata, group)
     temp_coords = fit_coords.copy()
 
-    if not use_data_time_dim and steps is not None:
-        temp_coords.update({TIME_DIM: np.arange(1 + steps, dtype="int")})
-        steps = len(temp_coords[TIME_DIM]) - 1
-    elif steps is not None:
-        n_dimsteps = len(temp_coords[TIME_DIM])
-        if n_dimsteps != steps:
+    if use_data_time_dim:
+        # A trajectory of n steps spans n + 1 timesteps, the initial state plus one per step.
+        data_steps = len(temp_coords[TIME_DIM]) - 1
+        if steps is not None and steps != data_steps:
             raise ValueError(
-                f"Length of time dimension does not match specified number of steps, expected"
-                f" {n_dimsteps} steps, or steps=None."
+                f"steps={steps} does not match the time dimension in idata, which spans "
+                f"{data_steps} steps. Pass steps={data_steps}, or steps=None to take it from "
+                "the data."
             )
+        steps = data_steps
+    elif steps is not None:
+        temp_coords[TIME_DIM] = np.arange(1 + steps, dtype="int")
     else:
         steps = len(temp_coords[TIME_DIM]) - 1
 

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -5,7 +5,7 @@ import pandas as pd
 import pymc as pm
 import pytest
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_equal
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
 from pymc_extras.statespace.utils.constants import (
@@ -38,6 +38,55 @@ def test_sampling_methods(group, kind, ss_mod, idata, rng):
         for output in ["latent", "observed"]:
             assert f"{group}_{output}" in test_idata
             assert not np.any(np.isnan(test_idata[f"{group}_{output}"].values))
+
+
+@pytest.mark.parametrize("group", ["posterior", "prior"])
+class TestUseDataTimeDim:
+    """Unconditional sampling over the time dimension the model was fit on.
+
+    A trajectory of n steps spans n + 1 timesteps, so the steps a caller passes and the length of
+    the fit time dimension are off by one from each other.
+    """
+
+    @staticmethod
+    def fit_steps(idata):
+        return len(idata.observed_data.coords[TIME_DIM]) - 1
+
+    def test_keeps_the_fit_time_index(self, ss_mod, idata, rng, group):
+        """The flag decides the labels, not the span: the fit index rather than a plain range."""
+        sample = getattr(ss_mod, f"sample_unconditional_{group}")
+        steps = self.fit_steps(idata)
+
+        from_data = sample(idata, steps=steps, use_data_time_dim=True, random_seed=rng)
+        from_range = sample(idata, steps=steps, use_data_time_dim=False, random_seed=rng)
+
+        assert_array_equal(
+            from_data[f"{group}_latent"].coords[TIME_DIM].values,
+            idata.observed_data.coords[TIME_DIM].values,
+        )
+        assert_array_equal(
+            from_range[f"{group}_latent"].coords[TIME_DIM].values, np.arange(steps + 1)
+        )
+        assert from_data[f"{group}_latent"].sizes[TIME_DIM] == steps + 1
+        assert from_range[f"{group}_latent"].sizes[TIME_DIM] == steps + 1
+
+    def test_explicit_steps_agreeing_with_data_is_accepted(self, ss_mod, idata, rng, group):
+        sample = getattr(ss_mod, f"sample_unconditional_{group}")
+        implicit = sample(idata, use_data_time_dim=True, random_seed=rng)
+        explicit = sample(
+            idata, steps=self.fit_steps(idata), use_data_time_dim=True, random_seed=rng
+        )
+
+        assert_array_equal(
+            implicit[f"{group}_latent"].coords[TIME_DIM].values,
+            explicit[f"{group}_latent"].coords[TIME_DIM].values,
+        )
+
+    def test_conflicting_steps_raises(self, ss_mod, idata, rng, group):
+        with pytest.raises(ValueError, match="does not match the time dimension in idata"):
+            getattr(ss_mod, f"sample_unconditional_{group}")(
+                idata, steps=self.fit_steps(idata) + 5, use_data_time_dim=True, random_seed=rng
+            )
 
 
 @pytest.mark.filterwarnings("ignore:Provided data contains missing values")

--- a/tests/statespace/models/structural/test_core.py
+++ b/tests/statespace/models/structural/test_core.py
@@ -12,7 +12,11 @@ from pytensor.graph.traversal import explicit_graph_inputs
 from scipy import linalg
 
 from pymc_extras.statespace.models import structural as st
-from tests.statespace.test_utilities import unpack_symbolic_matrices_with_params
+from pymc_extras.statespace.utils.constants import MATRIX_NAMES
+from tests.statespace.test_utilities import (
+    simulate_from_numpy_model,
+    unpack_symbolic_matrices_with_params,
+)
 
 floatX = config.floatX
 ATOL = 1e-8 if floatX.endswith("64") else 1e-4
@@ -97,6 +101,32 @@ def test_add_components_multiple_observed():
 
     for property in ["param_names", "shock_names", "param_info", "coords", "param_dims"]:
         assert [x in getattr(mod, property) for x in getattr(ll, property)]
+
+
+def test_simulate_multiple_observed_with_measurement_error(rng):
+    """Measurement error reaches only the series it was given a variance for."""
+    steps = 100
+    mod = (
+        st.LevelTrend(order=1, innovations_order=1, observed_state_names=["noisy", "clean"])
+        + st.MeasurementError(name="obs", observed_state_names=["noisy", "clean"])
+    ).build(verbose=False)
+
+    params = {
+        "initial_level_trend": np.zeros((2, 1), dtype=floatX),
+        "sigma_level_trend": np.ones((2, 1), dtype=floatX),
+        "sigma_obs": np.array([3.0, 0.0], dtype=floatX),
+        "P0": np.eye(mod.k_states, dtype=floatX),
+    }
+
+    latent, observed = simulate_from_numpy_model(mod, rng, params, steps=steps)
+    matrices = dict(zip(MATRIX_NAMES, unpack_symbolic_matrices_with_params(mod, params, steps)))
+    noiseless = latent @ np.atleast_2d(matrices["Z"]).T
+
+    assert_allclose(observed[:, 1], noiseless[:, 1], atol=ATOL, rtol=RTOL)
+
+    # Scale, not just presence: a variance applied as a standard deviation would still be non-zero.
+    residual = observed[:, 0] - noiseless[:, 0]
+    assert_allclose(residual.std(), params["sigma_obs"][0], rtol=0.2)
 
 
 @pytest.mark.skipif(floatX.endswith("32"), reason="Prior covariance not PSD at half-precision")

--- a/tests/statespace/test_utilities.py
+++ b/tests/statespace/test_utilities.py
@@ -274,7 +274,7 @@ def simulate_from_numpy_model(mod, rng, param_dict, data_dict=None, steps=100):
     y[0] = (Z @ x0).squeeze() if Z.ndim == 2 else (Z[0] @ x0).squeeze()
 
     if not np.allclose(H, 0):
-        y[0] += rng.multivariate_normal(mean=np.zeros(1), cov=H).squeeze()
+        y[0] += rng.multivariate_normal(mean=np.zeros(k_endog), cov=H).squeeze()
 
     for t in range(1, steps):
         if k_posdef > 0:
@@ -284,7 +284,7 @@ def simulate_from_numpy_model(mod, rng, param_dict, data_dict=None, steps=100):
             innov = 0
 
         if not np.allclose(H, 0):
-            error = rng.multivariate_normal(mean=np.zeros(1), cov=H)
+            error = rng.multivariate_normal(mean=np.zeros(k_endog), cov=H)
         else:
             error = 0
 


### PR DESCRIPTION
`sample_unconditional_prior` and `sample_unconditional_posterior` take a `use_data_time_dim` flag that's meant to reuse the time index the model was fit on. It never worked alongside an explicit `steps`. The branches disagreed over whether that time dimension holds `steps` or `steps + 1` entries, so the value the guard demanded crashed downstream on a coord length mismatch, and the value that would actually have worked got rejected by the guard. `steps` is now derived from the data rather than validated against it.

Second, unrelated fix: the numpy simulation helper in the test utilities hardcoded a length-1 mean vector, so no multivariate model with measurement error could be simulated at all. That's why the multivariate structural paths have so little coverage.
