### PR TITLE
Fix end and start argument handling in forecast

### DIFF
--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -558,11 +558,12 @@ def forecast(
 
     time_index = ss_mod._get_fit_time_index(idata)
 
-    if start is None and verbose:
-        _log.warning(
-            "No start date provided. Using the last date in the data index. To silence this warning, "
-            "explicitly pass a start date or set verbose = False"
-        )
+    if start is None:
+        if verbose:
+            _log.warning(
+                "No start date provided. Using the last date in the data index. To silence this "
+                "warning, explicitly pass a start date or set verbose = False"
+            )
         start = time_index[-1]
 
     if ss_mod._needs_exog_data and not isinstance(scenario, dict):

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -346,7 +346,8 @@ def _build_forecast_index(
             if start < 0:
                 start = time_index[start]
             if end is not None:
-                forecast_index = pd.RangeIndex(start, end, step=1, dtype="int")
+                # end is inclusive, matching the datetime branch; the start is popped off below.
+                forecast_index = pd.RangeIndex(start, end + 1, step=1, dtype="int")
             if periods is not None:
                 forecast_index = pd.RangeIndex(start, start + periods + 1, step=1, dtype="int")
 

--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -346,7 +346,8 @@ def _build_forecast_index(
             if start < 0:
                 start = time_index[start]
             if end is not None:
-                # end is inclusive, matching the datetime branch; the start is popped off below.
+                # RangeIndex excludes its stop where date_range includes its end, so add one
+                # to give `end` the same meaning on both index types.
                 forecast_index = pd.RangeIndex(start, end + 1, step=1, dtype="int")
             if periods is not None:
                 forecast_index = pd.RangeIndex(start, start + periods + 1, step=1, dtype="int")

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -420,6 +420,26 @@ def test_invalid_scenarios():
 
 
 @pytest.mark.filterwarnings("ignore:No time index found on the supplied data.")
+@pytest.mark.parametrize("verbose", [True, False], ids=["verbose", "quiet"])
+def test_forecast_defaults_start_regardless_of_verbosity(
+    ss_mod_no_exog, idata_no_exog, rng, caplog, verbose
+):
+    """Silencing the warning must not also silence the default it announces."""
+    time_index = ss_mod_no_exog._get_fit_time_index(idata_no_exog)
+
+    forecast_idata = ss_mod_no_exog.forecast(
+        idata_no_exog, periods=10, verbose=verbose, random_seed=rng
+    )
+
+    forecast_index = forecast_idata.coords["time"].values
+    assert forecast_index.shape == (10,)
+    assert forecast_index[0] == time_index[-1] + 1
+
+    announced = any("No start date provided" in message for message in caplog.messages)
+    assert announced == verbose
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data.")
 @pytest.mark.parametrize("filter_output", ["predicted", "filtered", "smoothed"])
 @pytest.mark.parametrize(
     "mod_name, idata_name, start, end, periods",

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -139,11 +139,7 @@ def test_forecast_index(use_datetime_index):
 
 @pytest.mark.parametrize("use_datetime_index", [True, False])
 def test_end_is_inclusive_for_both_index_types(use_datetime_index):
-    """`end` names the last forecast period, whichever index the model was fit on.
-
-    A datetime index reaches it through pd.date_range and an integer one through pd.RangeIndex,
-    and those disagree about their endpoints, so the horizon is pinned against `periods`.
-    """
+    """`end` names the last forecast period, whichever index the model was fit on."""
     horizon = 5
     ss_mod = make_statespace_mod(
         k_endog=1, k_posdef=1, k_states=2, filter_type="standard", verbose=False
@@ -156,7 +152,7 @@ def test_end_is_inclusive_for_both_index_types(use_datetime_index):
     _, from_end = ss_mod._build_forecast_index(time_idx, start=start, end=start + horizon * step)
     _, from_periods = ss_mod._build_forecast_index(time_idx, start=start, periods=horizon)
 
-    assert_index_equal(pd.Index(from_end), pd.Index(from_periods))
+    assert_index_equal(from_end, from_periods)
     assert from_end[-1] == start + horizon * step
 
 

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -7,6 +7,7 @@ import pytest
 import xarray as xr
 
 from numpy.testing import assert_allclose
+from pandas.testing import assert_index_equal
 from pytensor.compile import SharedVariable
 from pytensor.graph.traversal import graph_inputs
 from xarray import DataTree
@@ -90,7 +91,7 @@ def test_forecast_index(use_datetime_index):
 
     # From start and end
     start = time_idx[-1]
-    delta = pd.DateOffset(years=10) if use_datetime_index else 11
+    delta = pd.DateOffset(years=10) if use_datetime_index else 10
     end = start + delta
 
     x0_index, forecast_idx = ss_mod._build_forecast_index(time_idx, start=start, end=end)
@@ -134,6 +135,29 @@ def test_forecast_index(use_datetime_index):
     assert x0_index == (forecast_idx[0] - delta)
     assert forecast_idx.shape == (10,)
     assert forecast_idx.equals(scenario["a"].index)
+
+
+@pytest.mark.parametrize("use_datetime_index", [True, False])
+def test_end_is_inclusive_for_both_index_types(use_datetime_index):
+    """`end` names the last forecast period, whichever index the model was fit on.
+
+    A datetime index reaches it through pd.date_range and an integer one through pd.RangeIndex,
+    and those disagree about their endpoints, so the horizon is pinned against `periods`.
+    """
+    horizon = 5
+    ss_mod = make_statespace_mod(
+        k_endog=1, k_posdef=1, k_states=2, filter_type="standard", verbose=False
+    )
+    time_idx, _ = _make_time_idx(use_datetime_index)
+
+    start = time_idx[-1]
+    step = time_idx.freq if use_datetime_index else 1
+
+    _, from_end = ss_mod._build_forecast_index(time_idx, start=start, end=start + horizon * step)
+    _, from_periods = ss_mod._build_forecast_index(time_idx, start=start, periods=horizon)
+
+    assert_index_equal(pd.Index(from_end), pd.Index(from_periods))
+    assert from_end[-1] == start + horizon * step
 
 
 @pytest.mark.parametrize(
@@ -403,7 +427,7 @@ def test_invalid_scenarios():
         ("ss_mod_no_exog", "idata_no_exog", None, None, 10),
         ("ss_mod_no_exog", "idata_no_exog", -1, None, 10),
         ("ss_mod_no_exog", "idata_no_exog", 10, None, 10),
-        ("ss_mod_no_exog", "idata_no_exog", 10, 21, None),
+        ("ss_mod_no_exog", "idata_no_exog", 10, 20, None),
         ("ss_mod_no_exog_dt", "idata_no_exog_dt", None, None, 10),
         ("ss_mod_no_exog_dt", "idata_no_exog_dt", -1, None, 10),
         ("ss_mod_no_exog_dt", "idata_no_exog_dt", 10, None, 10),
@@ -413,7 +437,7 @@ def test_invalid_scenarios():
         ("ss_mod_no_exog_mv", "idata_no_exog_mv", None, None, 10),
         ("ss_mod_no_exog_mv", "idata_no_exog_mv", -1, None, 10),
         ("ss_mod_no_exog_mv", "idata_no_exog_mv", 10, None, 10),
-        ("ss_mod_no_exog_mv", "idata_no_exog_mv", 10, 21, None),
+        ("ss_mod_no_exog_mv", "idata_no_exog_mv", 10, 20, None),
         ("ss_mod_no_exog_mv", "idata_no_exog_mv_dt", None, None, 10),
         ("ss_mod_no_exog_mv", "idata_no_exog_mv_dt", -1, None, 10),
         ("ss_mod_no_exog_mv", "idata_no_exog_mv_dt", 10, None, 10),


### PR DESCRIPTION
Two bugs in how `forecast` resolves its horizon. `end` meant different things depending on the model's time index — inclusive on a datetime index via `pd.date_range`, exclusive on an integer one via `pd.RangeIndex` — so the same call returned one fewer period on an integer index. `periods` was already consistent across both, and agrees with the datetime `end` behavior, so the integer branch is what moved.

Separately, `start` was only defaulted inside the branch that logs the "no start date provided" warning. Passing `verbose=False`, which the warning itself recommends, left `start` as `None` and forecasting died further down on a `TypeError` about comparing `None` to an int.

The `end` change alters existing behavior: anyone passing `end` on a range-indexed model now gets one more forecast period than before. Three existing test cases had the old semantics baked into them, asking for `end=21` on integer indices against a ten-step `end` on datetime ones, and those are corrected here.
