### PR TITLE
Warn when n_steps conflicts with the shock trajectory length

### DIFF
--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger("pymc.experimental.statespace")
 
+DEFAULT_IRF_STEPS = 40
+
 
 def _shock_permutation(
     shock_names: list[str], shock_order: list[str | EllipsisType] | None
@@ -122,7 +124,7 @@ def _orthogonal_impulse_matrix(Q: pt.TensorVariable, perm: np.ndarray) -> pt.Ten
 def impulse_response_function(
     ss_mod: "PyMCStateSpace",
     idata,
-    n_steps: int = 40,
+    n_steps: int | None = None,
     use_posterior_cov: bool = True,
     shock_size: float | np.ndarray | None = None,
     shock_cov: np.ndarray | None = None,
@@ -160,20 +162,22 @@ def impulse_response_function(
     if shock_trajectory is not None:
         # Validate the shock trajectory
         n, k = shock_trajectory.shape
-        steps = n
 
         if k != ss_mod.k_posdef:
             raise ValueError(
                 "If shock_trajectory is provided, there must be a trajectory provided for each shock. "
                 f"Model has {ss_mod.k_posdef} shocks, but shock_trajectory has only {k} columns"
             )
-        if steps is not None and steps != n:
+        if n_steps is not None and n_steps != n:
             _log.warning(
-                "Both steps and shock_trajectory were provided but do not agree. Length of "
-                "shock_trajectory will take priority, and steps will be ignored."
+                "Both n_steps and shock_trajectory were provided but do not agree. Length of "
+                "shock_trajectory will take priority, and n_steps will be ignored."
             )
-        n_steps = n  # Overwrite steps with the length of the shock trajectory
+        n_steps = n
         shock_trajectory = pt.as_tensor_variable(shock_trajectory)
+
+    elif n_steps is None:
+        n_steps = DEFAULT_IRF_STEPS
 
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
     fit_dims = dims_from_idata(ss_mod, idata, group)

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -161,19 +161,19 @@ def impulse_response_function(
 
     if shock_trajectory is not None:
         # Validate the shock trajectory
-        n, k = shock_trajectory.shape
+        trajectory_steps, k = shock_trajectory.shape
 
         if k != ss_mod.k_posdef:
             raise ValueError(
                 "If shock_trajectory is provided, there must be a trajectory provided for each shock. "
                 f"Model has {ss_mod.k_posdef} shocks, but shock_trajectory has only {k} columns"
             )
-        if n_steps is not None and n_steps != n:
+        if n_steps is not None and n_steps != trajectory_steps:
             _log.warning(
                 "Both n_steps and shock_trajectory were provided but do not agree. Length of "
                 "shock_trajectory will take priority, and n_steps will be ignored."
             )
-        n_steps = n
+        n_steps = trajectory_steps
         shock_trajectory = pt.as_tensor_variable(shock_trajectory)
 
     elif n_steps is None:

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1645,7 +1645,7 @@ class PyMCStateSpace:
     def impulse_response_function(
         self,
         idata,
-        n_steps: int = 40,
+        n_steps: int | None = None,
         use_posterior_cov: bool = True,
         shock_size: float | np.ndarray | None = None,
         shock_cov: np.ndarray | None = None,
@@ -1669,10 +1669,10 @@ class PyMCStateSpace:
         idata : DataTree
             A DataTree object containing the posterior distribution over model parameters.
 
-        n_steps: int
-            The number of time steps to calculate the impulse response. Default is 40.
-
-            If `shock_trajectory` is provided, the length of the shock trajectory will override this value.
+        n_steps: int, optional
+            The number of time steps to calculate the impulse response. If `shock_trajectory` is
+            provided its length is used instead, and passing a conflicting `n_steps` logs a warning.
+            Default 40.
 
         use_posterior_cov: bool, default=True
             Whether to use the covariance matrix of the posterior distribution to generate the impulse response.

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1669,90 +1669,100 @@ class PyMCStateSpace:
         idata : DataTree
             A DataTree object containing the posterior distribution over model parameters.
 
-        n_steps: int, optional
-            The number of time steps to calculate the impulse response. If `shock_trajectory` is
-            provided its length is used instead, and passing a conflicting `n_steps` logs a warning.
-            Default 40.
+        n_steps : int, optional
+            The number of time steps to calculate the impulse response. If ``shock_trajectory`` is
+            provided its length is used instead, and passing a conflicting ``n_steps`` logs a
+            warning. Default 40.
 
-        use_posterior_cov: bool, default=True
-            Whether to use the covariance matrix of the posterior distribution to generate the impulse response.
+        use_posterior_cov : bool, optional
+            Whether to use the covariance matrix of the posterior distribution to generate the
+            impulse response.
 
-            Only one of `use_posterior_cov`, `shock_cov`, `shock_size`, or `shock_trajectory` can be specified.
+            Only one of ``use_posterior_cov``, ``shock_cov``, ``shock_size``, or
+            ``shock_trajectory`` can be specified. Default True.
 
-        shock_size : Optional[Union[float, np.ndarray]], default=None
-            The size of the shock applied to the system. If specified, it will create a covariance
-            matrix for the shock with diagonal elements equal to `shock_size`. If float, the diagonal will be filled
-            with `shock_size`. If an array, `shock_size` must match the number of shocks in the state space model.
-
-            Only one of `use_posterior_cov`, `shock_cov`, `shock_size`, or `shock_trajectory` can be specified.
-
-        shock_cov : Optional[np.ndarray], default=None
-            A user-specified covariance matrix for the shocks. It should be a 2D numpy array with
-            dimensions (n_shocks, n_shocks), where n_shocks is the number of shocks in the state space model.
-
-            Only one of `use_posterior_cov`, `shock_cov`, `shock_size`, or `shock_trajectory` can be specified.
-
-        shock_trajectory : Optional[np.ndarray], default=None
-            A pre-defined trajectory of shocks applied to the system. It should be a 2D numpy array
-            with dimensions (n, n_shocks), where n is the number of time steps and k_posdef is the
+        shock_size : float or ndarray, optional
+            The size of the shock applied to the system. If specified, it creates a covariance
+            matrix for the shock with diagonal elements equal to ``shock_size``. If float, the
+            diagonal is filled with ``shock_size``. If an array, ``shock_size`` must match the
             number of shocks in the state space model.
 
-            Only one of `use_posterior_cov`, `shock_cov`, `shock_size`, or `shock_trajectory` can be specified.
+            Only one of ``use_posterior_cov``, ``shock_cov``, ``shock_size``, or
+            ``shock_trajectory`` can be specified. Default None.
 
-        orthogonalize_shocks : bool, default=False
-            If True, identify structural shocks by a recursive (Cholesky) scheme and return one impulse
-            response per structural shock. See Notes. Incompatible with `shock_size` and
-            `shock_trajectory`, which each describe a single impulse.
+        shock_cov : ndarray, optional
+            A user-specified covariance matrix for the shocks, with shape (n_shocks, n_shocks),
+            where n_shocks is the number of shocks in the state space model.
+
+            Only one of ``use_posterior_cov``, ``shock_cov``, ``shock_size``, or
+            ``shock_trajectory`` can be specified. Default None.
+
+        shock_trajectory : ndarray, optional
+            A pre-defined trajectory of shocks applied to the system, with shape (n, n_shocks),
+            where n is the number of time steps and n_shocks is the number of shocks in the state
+            space model.
+
+            Only one of ``use_posterior_cov``, ``shock_cov``, ``shock_size``, or
+            ``shock_trajectory`` can be specified. Default None.
+
+        orthogonalize_shocks : bool, optional
+            If True, identify structural shocks by a recursive (Cholesky) scheme and return one
+            impulse response per structural shock. See Notes. Incompatible with ``shock_size`` and
+            ``shock_trajectory``, which each describe a single impulse. Default False.
 
         shock_order : list of str or ellipsis, optional
             Recursive ordering imposed by the Cholesky identification, given as shock names. Earlier
             shocks are the ones allowed to move later shocks contemporaneously. A single ``...``
             entry stands for every shock not named elsewhere, kept in the model's own order, so
             ``["realinv", ...]`` orders investment first and leaves the rest alone. Without an
-            ``...``, every shock must be named. Only valid when `orthogonalize_shocks` is True.
+            ``...``, every shock must be named. Only valid when ``orthogonalize_shocks`` is True.
             Defaults to the model's own shock order.
 
         random_seed : int, RandomState or Generator, optional
             Seed for the random number generator.
 
-        mvn_method: str, default "svd"
-            Method used to invert the covariance matrix when calculating the pdf of a multivariate normal
-            (or when generating samples). One of "cholesky", "eigh", or "svd". "cholesky" is fastest, but least robust
-            to ill-conditioned matrices, while "svd" is slow but extremely robust.
+        mvn_method : str, optional
+            Method used to invert the covariance matrix when calculating the pdf of a multivariate
+            normal (or when generating samples). One of "cholesky", "eigh", or "svd". "cholesky" is
+            fastest, but least robust to ill-conditioned matrices, while "svd" is slow but extremely
+            robust.
 
-            In general, if your model has measurement error, "cholesky" will be safe to use. Otherwise, "svd" is
-            recommended. "eigh" can also be tried if sampling with "svd" is very slow, but it is not as robust as "svd".
+            In general, if your model has measurement error, "cholesky" will be safe to use.
+            Otherwise, "svd" is recommended. "eigh" can also be tried if sampling with "svd" is very
+            slow, but it is not as robust as "svd". Default "svd".
 
-        kwargs:
-            Additional keyword arguments are passed to pymc.sample_posterior_predictive
+        **kwargs
+            Additional keyword arguments are passed to :func:`~pymc.sample_posterior_predictive`.
 
         Returns
         -------
         DataTree
-            A DataTree object containing impulse response function in a variable named "irf", with dims
-            ``(time, state)``, or ``(structural_shock, time, state)`` when `orthogonalize_shocks` is True.
+            A DataTree object containing the impulse response function in a variable named "irf",
+            with dims ``(time, state)``, or ``(structural_shock, time, state)`` when
+            ``orthogonalize_shocks`` is True.
 
         Notes
         -----
-        For models with time-varying transition matrices, the IRF is computed starting at phase 0 of the
-        time-varying cycle. This means the response represents the effect of a shock occurring at the first
-        modeled state, T(0).
+        For models with time-varying transition matrices, the IRF is computed starting at phase 0
+        of the time-varying cycle. This means the response represents the effect of a shock
+        occurring at the first modeled state, :math:`T(0)`.
 
         Reduced-form shocks are correlated whenever the shock covariance :math:`Q` has off-diagonal
         entries, so shocking one of them in isolation describes an event the model itself considers
         unlikely. Setting ``orthogonalize_shocks=True`` instead factors :math:`Q = B B^\top` with
         :math:`B` lower triangular, which imposes a recursive contemporaneous ordering: the first
-        shock in `shock_order` moves every variable within the period, the second moves all but the
-        first, and so on. Column :math:`j` of :math:`B` is the impact of a one-standard-deviation
-        innovation to structural shock :math:`j`, and the returned IRF carries a
-        ``structural_shock`` axis holding one response per shock.
+        shock in ``shock_order`` moves every variable within the period, the second moves all but
+        the first, and so on. Column :math:`j` of :math:`B` is the impact of a
+        one-standard-deviation innovation to structural shock :math:`j`, and the returned IRF
+        carries a ``structural_shock`` axis holding one response per shock.
 
-        The ordering is an identifying assumption, not a detail: permuting `shock_order` yields
+        The ordering is an identifying assumption, not a detail: permuting ``shock_order`` yields
         different impulse responses from the same posterior. A diagonal :math:`Q` is the exception,
         where the factorization only rescales each shock to unit standard deviation.
 
-        An orthogonalized IRF is deterministic given the parameters, so its posterior spread reflects
-        parameter uncertainty alone. The default draws a random impulse per posterior draw instead.
+        An orthogonalized IRF is deterministic given the parameters, so its posterior spread
+        reflects parameter uncertainty alone. The default draws a random impulse per posterior draw
+        instead.
         """
         return irf.impulse_response_function(
             self,

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -13,6 +13,7 @@ from pymc.model.transform.optimization import freeze_dims_and_data
 from pymc.testing import mock_sample_setup_and_teardown
 
 from pymc_extras.statespace import BayesianVARMAX
+from pymc_extras.statespace.core.irf import DEFAULT_IRF_STEPS
 from pymc_extras.statespace.utils.constants import SHORT_NAME_TO_LONG
 from tests.statespace.shared_fixtures import (  # pylint: disable=unused-import
     rng,
@@ -421,41 +422,54 @@ class TestOrthogonalizedImpulseResponse:
             varma_mod.impulse_response_function(idata, n_steps=3, group="prior", **kwargs)
 
 
+# A single unit shock to the first variable at t=3, quiet before and after.
+SHOCK_TRAJECTORY = np.r_[
+    np.zeros((3, 3), dtype=floatX),
+    np.array([[1.0, 0.0, 0.0]]).astype(floatX),
+    np.zeros((6, 3), dtype=floatX),
+]
+
+
 @pytest.mark.skipif(floatX == "float32", reason="Impulse covariance not PSD if float32")
-class TestShockTrajectoryHorizon:
+class TestImpulseResponseHorizon:
     """The trajectory sets the horizon; n_steps is only a default when there is no trajectory."""
 
-    trajectory = np.r_[
-        np.zeros((3, 3), dtype=floatX),
-        np.array([[1.0, 0.0, 0.0]]).astype(floatX),
-        np.zeros((6, 3), dtype=floatX),
-    ]
+    trajectory_length = SHOCK_TRAJECTORY.shape[0]
 
-    def test_trajectory_length_wins(self, varma_mod, idata, rng, caplog):
+    def test_trajectory_length_overrides_n_steps(self, varma_mod, idata, rng, caplog):
         irf = varma_mod.impulse_response_function(
-            idata, n_steps=40, shock_trajectory=self.trajectory, group="prior", random_seed=rng
+            idata, n_steps=40, shock_trajectory=SHOCK_TRAJECTORY, group="prior", random_seed=rng
         )
 
-        assert len(irf.irf.coords["time"]) == self.trajectory.shape[0]
+        assert len(irf.irf.coords["time"]) == self.trajectory_length
         assert any("do not agree" in message for message in caplog.messages)
 
     def test_matching_n_steps_is_quiet(self, varma_mod, idata, rng, caplog):
-        varma_mod.impulse_response_function(
+        irf = varma_mod.impulse_response_function(
             idata,
-            n_steps=self.trajectory.shape[0],
-            shock_trajectory=self.trajectory,
+            n_steps=self.trajectory_length,
+            shock_trajectory=SHOCK_TRAJECTORY,
             group="prior",
             random_seed=rng,
         )
 
+        assert len(irf.irf.coords["time"]) == self.trajectory_length
         assert not any("do not agree" in message for message in caplog.messages)
 
     def test_omitted_n_steps_is_quiet(self, varma_mod, idata, rng, caplog):
-        varma_mod.impulse_response_function(
-            idata, shock_trajectory=self.trajectory, group="prior", random_seed=rng
+        irf = varma_mod.impulse_response_function(
+            idata, shock_trajectory=SHOCK_TRAJECTORY, group="prior", random_seed=rng
         )
 
+        # The trajectory wins over the default, which is longer than it is.
+        assert len(irf.irf.coords["time"]) == self.trajectory_length
         assert not any("do not agree" in message for message in caplog.messages)
+
+    def test_default_applies_without_a_trajectory(self, varma_mod, idata, rng):
+        """Omitting n_steps entirely is the only way the module default is reached."""
+        irf = varma_mod.impulse_response_function(idata, group="prior", random_seed=rng)
+
+        assert len(irf.irf.coords["time"]) == DEFAULT_IRF_STEPS
 
 
 def test_forecast(varma_mod, idata, rng):

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -421,6 +421,43 @@ class TestOrthogonalizedImpulseResponse:
             varma_mod.impulse_response_function(idata, n_steps=3, group="prior", **kwargs)
 
 
+@pytest.mark.skipif(floatX == "float32", reason="Impulse covariance not PSD if float32")
+class TestShockTrajectoryHorizon:
+    """The trajectory sets the horizon; n_steps is only a default when there is no trajectory."""
+
+    trajectory = np.r_[
+        np.zeros((3, 3), dtype=floatX),
+        np.array([[1.0, 0.0, 0.0]]).astype(floatX),
+        np.zeros((6, 3), dtype=floatX),
+    ]
+
+    def test_trajectory_length_wins(self, varma_mod, idata, rng, caplog):
+        irf = varma_mod.impulse_response_function(
+            idata, n_steps=40, shock_trajectory=self.trajectory, group="prior", random_seed=rng
+        )
+
+        assert len(irf.irf.coords["time"]) == self.trajectory.shape[0]
+        assert any("do not agree" in message for message in caplog.messages)
+
+    def test_matching_n_steps_is_quiet(self, varma_mod, idata, rng, caplog):
+        varma_mod.impulse_response_function(
+            idata,
+            n_steps=self.trajectory.shape[0],
+            shock_trajectory=self.trajectory,
+            group="prior",
+            random_seed=rng,
+        )
+
+        assert not any("do not agree" in message for message in caplog.messages)
+
+    def test_omitted_n_steps_is_quiet(self, varma_mod, idata, rng, caplog):
+        varma_mod.impulse_response_function(
+            idata, shock_trajectory=self.trajectory, group="prior", random_seed=rng
+        )
+
+        assert not any("do not agree" in message for message in caplog.messages)
+
+
 def test_forecast(varma_mod, idata, rng):
     forecast = varma_mod.forecast(idata, periods=10, random_seed=rng, group="prior")
 


### PR DESCRIPTION
`impulse_response_function` has a guard that's supposed to warn you when you pass both `n_steps` and a `shock_trajectory` whose lengths disagree, since the trajectory wins and `n_steps` gets dropped. The guard compared the trajectory length against itself, so it never fired and the horizon was silently truncated. `n_steps` now defaults to `None`, so a caller-supplied value can be told apart from the default, and the comparison uses what the caller actually passed.

The function's docstring is rewritten to numpydoc style along the way — human-readable types instead of `Optional[Union[...]]`, defaults in the description rather than on the type line, and literals for parameter cross-references. That's the bulk of the diff and it's cosmetic.

This conflicts with #746, which edits the same docstring block to document its new `shock_order` argument. #746 is the larger change and is already green, so merging it first and rebasing this one is the cheaper order.
