### PR TITLE
Shape logp placeholders per variable and assert output sets exactly

### DIFF
--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -120,8 +120,6 @@ def _sample_conditional(
         )
 
         for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs, strict=True):
-            dummy_ll = pt.zeros_like(mu)
-
             if name == "smoothed":
                 # The simulation smoother draws the whole latent path jointly, so the
                 # states carry their cross-time posterior covariance.
@@ -157,14 +155,14 @@ def _sample_conditional(
                     f"{name}_{group}",
                     mus=mu,
                     covs=cov,
-                    logp=dummy_ll,
+                    logp=pt.zeros_like(mu),
                     dims=state_dims,
                     method=mvn_method,
                 )
 
                 obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
                 obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
-                obs_logp = dummy_ll
+                obs_logp = pt.zeros_like(obs_mu)
 
             SequenceMvNormal(
                 f"{name}_{group}_observed",

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -9,6 +9,7 @@ from numpy.testing import assert_allclose
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
 from pymc_extras.statespace.utils.constants import (
+    FILTER_OUTPUT_DIMS,
     LONG_MATRIX_NAMES,
     MATRIX_DIMS,
     MATRIX_NAMES,
@@ -112,6 +113,9 @@ def test_sample_filter_outputs(rng, exog_ss_mod, idata_exog):
         idata_exog, filter_output_names=None, group="prior"
     )
 
+    # Iterating the returned vars below cannot notice one that never arrived.
+    assert set(idata_filter_prior.posterior_predictive.data_vars) == set(FILTER_OUTPUT_DIMS)
+
     for name, values in idata_filter_prior.posterior_predictive.data_vars.items():
         assert not np.any(np.isnan(values)), f"{name} contains NaNs"
 
@@ -119,11 +123,9 @@ def test_sample_filter_outputs(rng, exog_ss_mod, idata_exog):
     idata_filter_specific = exog_ss_mod.sample_filter_outputs(
         idata_exog, filter_output_names=specific_outputs
     )
-    missing_outputs = np.setdiff1d(
-        specific_outputs, [x for x in idata_filter_specific.posterior_predictive.data_vars]
-    )
 
-    assert missing_outputs.size == 0
+    # Equality, not containment: the point of the argument is to leave the rest out.
+    assert set(idata_filter_specific.posterior_predictive.data_vars) == set(specific_outputs)
 
     msg = "['filter_covariances', 'filter_states'] not a valid filter output name!"
     incorrect_outputs = ["filter_states", "filter_covariances"]


### PR DESCRIPTION
Two consistency fixes in forward sampling, neither of which changes behavior.

The observed-variable `SequenceMvNormal` in `_sample_conditional` was handed the latent states' logp placeholder, which carries the state shape rather than the observation shape. Nothing evaluates these placeholders so it was inert, but the smoothed branch directly above already built its own correctly and the two disagreed for no reason.

The other half is `test_sample_filter_outputs`, which checked that the outputs it asked for were present but never that the rest were absent. Both of its assertions are set equality now, so ignoring `filter_output_names` entirely would fail.
