### PR TITLE
Fix three cases where ADVI silently ignored the caller

### DIFF
--- a/pymc_extras/inference/advi/compile.py
+++ b/pymc_extras/inference/advi/compile.py
@@ -1,3 +1,4 @@
+from collections import Counter
 from typing import Protocol
 
 import numpy as np
@@ -80,9 +81,20 @@ def compile_svi_step_fn(
     new_grads, updates = optimizer.pytensor(grads, shared_params)
 
     # The optimizer's own state variables are the update keys that are not the guide
-    # parameters themselves.
-    param_ids = {id(param) for param in shared_params}
-    shared_optimizer_state = {var.name: var for var in updates if id(var) not in param_ids}
+    # parameters themselves. Snapshotting and restoring them keys on the name, so a
+    # duplicate would quietly drop one buffer and resume it from whatever it held.
+    guide_params = set(shared_params)
+    optimizer_state = [var for var in updates if var not in guide_params]
+    duplicated = sorted(
+        {name for name, count in Counter(v.name for v in optimizer_state).items() if count > 1}
+    )
+    if duplicated:
+        raise ValueError(
+            f"The optimizer has more than one state variable named {duplicated}, so its state "
+            "cannot be snapshotted or restored unambiguously. Give each transform in the chain "
+            "state variables with distinct names."
+        )
+    shared_optimizer_state = {var.name: var for var in optimizer_state}
 
     for param, grad in zip(shared_params, new_grads):
         updates[param] = param + grad

--- a/pymc_extras/inference/advi/compile.py
+++ b/pymc_extras/inference/advi/compile.py
@@ -84,17 +84,16 @@ def compile_svi_step_fn(
     # parameters themselves. Snapshotting and restoring them keys on the name, so a
     # duplicate would quietly drop one buffer and resume it from whatever it held.
     guide_params = set(shared_params)
-    optimizer_state = [var for var in updates if var not in guide_params]
-    duplicated = sorted(
-        {name for name, count in Counter(v.name for v in optimizer_state).items() if count > 1}
-    )
-    if duplicated:
+    state_variables = [var for var in updates if var not in guide_params]
+    name_counts = Counter(var.name for var in state_variables)
+    duplicate_names = sorted(name for name, count in name_counts.items() if count > 1)
+    if duplicate_names:
         raise ValueError(
-            f"The optimizer has more than one state variable named {duplicated}, so its state "
-            "cannot be snapshotted or restored unambiguously. Give each transform in the chain "
-            "state variables with distinct names."
+            f"The optimizer has more than one state variable named {duplicate_names}, so its "
+            "state cannot be snapshotted or restored unambiguously. Give each transform in the "
+            "chain state variables with distinct names."
         )
-    shared_optimizer_state = {var.name: var for var in optimizer_state}
+    shared_optimizer_state = {var.name: var for var in state_variables}
 
     for param, grad in zip(shared_params, new_grads):
         updates[param] = param + grad

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -183,7 +183,7 @@ class Trainer:
         compile_kwargs: dict | None = None,
         random_seed=None,
     ):
-        self._optimizer = optimizer
+        self._optimizer = optimizer if optimizer is not None else clipped_adam()
 
         self.compile_kwargs = resolve_backend_compile_kwargs(backend, compile_kwargs)
         self.random_seed = random_seed
@@ -208,12 +208,12 @@ class Trainer:
 
     @property
     def guide(self) -> AutoGuideModel | None:
-        """The guide being fit, once resolved. Compiled in, so it cannot be replaced."""
+        """The guide being fit. Resolved against the model on the first fit, then fixed."""
         return self._guide
 
     @property
-    def optimizer(self) -> GradientTransformation | None:
-        """The optimizer being used. Compiled in, so it cannot be changed after a fit."""
+    def optimizer(self) -> GradientTransformation:
+        """The optimizer driving the updates. Fixed at construction."""
         return self._optimizer
 
     @property
@@ -487,8 +487,6 @@ class Trainer:
         if self._step_fn is None:
             if self._guide is None:
                 self._guide = self._build_guide(model)
-            if self._optimizer is None:
-                self._optimizer = clipped_adam()
             self._step_fn, self._shared_params, self._shared_optimizer_state = (
                 self._compile_step_fn(model, self._guide, self._optimizer)
             )

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -476,9 +476,8 @@ class Trainer:
         elif observeds:
             raise ValueError("observeds requires a data iterator to stream the observations from")
         elif self._fit_model is not None:
-            # The guide and compiled functions belong to the stream-observed model, whose
-            # shared variables still hold the last batch. Continuing without data would
-            # silently retrain on that batch rather than on the full dataset.
+            # The guide and the compiled functions were built against the stream-observed
+            # model, so the original model is no longer the one being trained.
             raise ValueError(
                 "this trainer was bound to a data stream by an earlier fit, so fitting with "
                 "no data would keep training on the last batch it saw. Pass data= to carry "
@@ -616,8 +615,8 @@ class Trainer:
 
         params = {name: np.asarray(value) for name, value in state.params.items()}
         samples = self._sampling_fn(**params)
-        # Name the draws from the same list the sampling function was built from, so the
-        # two cannot drift apart into naming a variable's draws after its sibling.
+        # compile_sampling_fn emits draws in free_RVs order, so name them from that same
+        # list rather than from a second one that only happens to agree with it.
         posterior = {
             rv.name: np.expand_dims(sample, axis=0)
             for rv, sample in zip(fit_model.free_RVs, samples, strict=True)

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -605,12 +605,11 @@ class Trainer:
 
         params = {name: np.asarray(value) for name, value in state.params.items()}
         samples = self._sampling_fn(**params)
+        # Name the draws from the same list the sampling function was built from, so the
+        # two cannot drift apart into naming a variable's draws after its sibling.
         posterior = {
             rv.name: np.expand_dims(sample, axis=0)
-            for rv, sample in zip(
-                (rv for rv in fit_model.rvs_to_values.keys() if rv not in fit_model.observed_RVs),
-                samples,
-            )
+            for rv, sample in zip(fit_model.free_RVs, samples, strict=True)
         }
 
         model_coords, model_dims = coords_and_dims_for_inferencedata(model)

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -465,14 +465,25 @@ class Trainer:
                 )
                 self._fit_model = model
             else:
+                if observeds:
+                    raise ValueError(
+                        "observeds is fixed by the first streamed fit, because the observed "
+                        "model and the compiled step function were built from it. Drop it to "
+                        "keep streaming into the same observed model, or use a new Trainer."
+                    )
                 model = self._fit_model
             self._apply_batch(model, first_batch)
         elif observeds:
             raise ValueError("observeds requires a data iterator to stream the observations from")
         elif self._fit_model is not None:
-            # A previous fit bound this trainer to a stream-observed model; the guide
-            # and compiled functions belong to it, not to the original model
-            model = self._fit_model
+            # The guide and compiled functions belong to the stream-observed model, whose
+            # shared variables still hold the last batch. Continuing without data would
+            # silently retrain on that batch rather than on the full dataset.
+            raise ValueError(
+                "this trainer was bound to a data stream by an earlier fit, so fitting with "
+                "no data would keep training on the last batch it saw. Pass data= to carry "
+                "on streaming, or use a new Trainer to fit the full dataset."
+            )
 
         if self._step_fn is None:
             if self._guide is None:

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -137,6 +137,29 @@ def test_duplicate_optimizer_state_names_are_refused(conjugate_model):
         trainer.fit(10, random_seed=1)
 
 
+def test_posterior_draws_are_named_for_their_own_variable():
+    # distinct shapes, so draws attached to the wrong name would be the wrong shape
+    with pm.Model() as model:
+        pm.Normal("scalar")
+        pm.Normal("pair", shape=2)
+        pm.HalfNormal("positive")
+        pm.Normal("triple", shape=3)
+        pm.Normal("y", 0, 1, observed=[1.0, 0.5])
+
+    trainer = Trainer(random_seed=0)
+    with model:
+        trainer.fit(10, random_seed=1)
+        idata = trainer.sample_posterior(draws=7, random_seed=2)
+
+    posterior = idata["posterior"].dataset
+    assert set(posterior.data_vars) == {"scalar", "pair", "positive", "triple"}
+    assert posterior["scalar"].shape == (1, 7)
+    assert posterior["pair"].shape == (1, 7, 2)
+    assert posterior["triple"].shape == (1, 7, 3)
+    # the transform is applied to the variable that carries it, not to a sibling
+    assert (posterior["positive"].values > 0).all()
+
+
 def test_trainer_state_is_complete_and_honest(conjugate_model):
     model, *_ = conjugate_model
     trainer = Trainer(random_seed=0)

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -14,6 +14,7 @@ from pymc_extras.inference.advi import (
     rmsprop,
     scale_by_adam,
     scale_by_learning_rate,
+    scale_by_schedule,
     sgd,
 )
 from pymc_extras.inference.advi.autoguide import AutoDiagonalNormal, AutoGuideModel
@@ -121,6 +122,19 @@ def test_snapshot_restore_is_optimizer_agnostic(conjugate_model, make_optimizer)
             resumed_state.optimizer_state[name], second.optimizer_state[name]
         )
     np.testing.assert_allclose(resumed_state.loss_history, second.loss_history)
+
+
+def test_duplicate_optimizer_state_names_are_refused(conjugate_model):
+    model, *_ = conjugate_model
+    schedule = linear_onecycle_schedule(transition_steps=100, peak_value=0.01)
+
+    # both stages allocate a step counter named "lr_t", so keying the snapshot by name
+    # would keep one and resume the other from whatever it happened to hold
+    doubled = chain(scale_by_adam(), scale_by_schedule(schedule), scale_by_schedule(schedule))
+
+    trainer = Trainer(optimizer=doubled)
+    with model, pytest.raises(ValueError, match="more than one state variable named"):
+        trainer.fit(10, random_seed=1)
 
 
 def test_trainer_state_is_complete_and_honest(conjugate_model):

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -132,9 +132,10 @@ def test_duplicate_optimizer_state_names_are_refused(conjugate_model):
     # would keep one and resume the other from whatever it happened to hold
     doubled = chain(scale_by_adam(), scale_by_schedule(schedule), scale_by_schedule(schedule))
 
+    # the collision is detected while compiling, before any step is taken
     trainer = Trainer(optimizer=doubled)
     with model, pytest.raises(ValueError, match="more than one state variable named"):
-        trainer.fit(10, random_seed=1)
+        trainer.fit(1)
 
 
 def test_posterior_draws_are_named_for_their_own_variable():
@@ -155,6 +156,7 @@ def test_posterior_draws_are_named_for_their_own_variable():
     assert set(posterior.data_vars) == {"scalar", "pair", "positive", "triple"}
     assert posterior["scalar"].shape == (1, 7)
     assert posterior["pair"].shape == (1, 7, 2)
+    assert posterior["positive"].shape == (1, 7)
     assert posterior["triple"].shape == (1, 7, 3)
     # the transform is applied to the variable that carries it, not to a sibling
     assert (posterior["positive"].values > 0).all()
@@ -298,7 +300,7 @@ def test_fit_after_streaming_refuses_to_reuse_the_last_batch():
 
     trainer = Trainer()
     with model:
-        trainer.fit(10, batches(), observeds=["y"], random_seed=1)
+        streamed = trainer.fit(10, batches(), observeds=["y"], random_seed=1)
 
         # the stream shareds still hold the last batch, so a bare fit would train on it
         with pytest.raises(ValueError, match="keep training on the last batch"):
@@ -308,8 +310,11 @@ def test_fit_after_streaming_refuses_to_reuse_the_last_batch():
         with pytest.raises(ValueError, match="observeds is fixed by the first streamed fit"):
             trainer.fit(10, batches(), observeds=["y"])
 
-        # streaming on without repeating observeds is the supported continuation
-        trainer.fit(10, batches())
+        # streaming on without repeating observeds continues the same run
+        continued = trainer.fit(10, batches())
+
+    assert (streamed.step, continued.step) == (10, 20)
+    assert not np.allclose(continued.params["theta_loc"], streamed.params["theta_loc"])
 
 
 def test_fit_rescales_likelihood_when_stream_has_len():

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -162,6 +162,26 @@ def test_posterior_draws_are_named_for_their_own_variable():
     assert (posterior["positive"].values > 0).all()
 
 
+def test_the_optimizer_is_fixed_at_construction(conjugate_model):
+    model, *_ = conjugate_model
+    supplied = sgd(0.01)
+
+    default = Trainer(random_seed=0)
+    chosen = Trainer(optimizer=supplied, random_seed=0)
+
+    # both are resolved before any fit, so the properties describe the trainer from the start
+    assert chosen.optimizer is supplied
+    assert default.optimizer is not None
+    default_before = default.optimizer
+
+    with model:
+        default.fit(10, random_seed=1)
+        chosen.fit(10, random_seed=1)
+
+    assert chosen.optimizer is supplied
+    assert default.optimizer is default_before
+
+
 def test_trainer_state_is_complete_and_honest(conjugate_model):
     model, *_ = conjugate_model
     trainer = Trainer(random_seed=0)

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -285,6 +285,33 @@ def test_fit_streams_observations_into_free_rv():
     assert "y" not in [rv.name for rv in model.observed_RVs]
 
 
+def test_fit_after_streaming_refuses_to_reuse_the_last_batch():
+    rng = np.random.default_rng(0)
+
+    def batches():
+        while True:
+            yield {"y": rng.normal(1.0, 1.0, size=64)}
+
+    with pm.Model() as model:
+        theta = pm.Normal("theta", 0, 10)
+        pm.Normal("y", theta, 1, shape=(64,))
+
+    trainer = Trainer()
+    with model:
+        trainer.fit(10, batches(), observeds=["y"], random_seed=1)
+
+        # the stream shareds still hold the last batch, so a bare fit would train on it
+        with pytest.raises(ValueError, match="keep training on the last batch"):
+            trainer.fit(10)
+
+        # observeds is baked into the observed model built by the first streamed fit
+        with pytest.raises(ValueError, match="observeds is fixed by the first streamed fit"):
+            trainer.fit(10, batches(), observeds=["y"])
+
+        # streaming on without repeating observeds is the supported continuation
+        trainer.fit(10, batches())
+
+
 def test_fit_rescales_likelihood_when_stream_has_len():
     rng = np.random.default_rng(0)
     full_data = rng.normal(1.0, 1.0, size=1_000)


### PR DESCRIPTION
Three places where ADVI silently did something other than what the caller asked: a dropped optimizer buffer, a stale minibatch, and an ignored `observeds`.
