### PR TITLE
Return fit and optimizer_result groups from fit_advi

### DIFF
--- a/pymc_extras/inference/advi/autoguide.py
+++ b/pymc_extras/inference/advi/autoguide.py
@@ -92,8 +92,7 @@ class AutoGuideModel:
         """Describe the fitted approximation by its mean and its covariance parameterization.
 
         Every guide reports ``mean_vector``, so the family is identifiable from whichever
-        covariance entries accompany it. The mean-field guide reports a marginal standard
-        deviation, exponentiated out of the unconstrained space it optimizes in.
+        covariance entries accompany it. Each guide family implements this.
 
         Parameters
         ----------
@@ -106,12 +105,10 @@ class AutoGuideModel:
             ``mean_vector`` and this family's covariance entries, flattened in the order the
             model's free RVs appear in.
         """
-        locs = [params[p.name].ravel() for p in self.params if p.name.endswith("_loc")]
-        scales = [params[p.name].ravel() for p in self.params if p.name.endswith("_scale")]
-        return {
-            "mean_vector": np.concatenate(locs),
-            "standard_deviation": np.exp(np.concatenate(scales)),
-        }
+        raise NotImplementedError(
+            f"{type(self).__name__} does not report a fitted mean and covariance. Override "
+            "fit_quantities to return 'mean_vector' plus this guide's covariance entries."
+        )
 
     def stochastic_logq(self, path_derivative_gradient: bool = True) -> pt.TensorVariable:
         """Returns a graph representing the logp of the guide model, evaluated under draws from its random variables.
@@ -150,6 +147,22 @@ def _check_continuous_rvs(model: Model, free_rvs: list[Variable]) -> None:
             f"ADVI requires continuous free RVs, but {discrete_rvs} are discrete. "
             "Marginalize them out or use another inference method."
         )
+
+
+@dataclass(frozen=True)
+class AutoDiagonalGuideModel(AutoGuideModel):
+    """Guide model for a mean-field (diagonal normal) ADVI approximation."""
+
+    variable_names: tuple[str, ...]
+
+    def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Report the mean and the marginal standard deviation of each free RV."""
+        locs = [params[f"{name}_loc"].ravel() for name in self.variable_names]
+        scales = [params[f"{name}_scale"].ravel() for name in self.variable_names]
+        return {
+            "mean_vector": np.concatenate(locs),
+            "standard_deviation": np.exp(np.concatenate(scales)),
+        }
 
 
 def AutoDiagonalNormal(model: Model, random_seed=None) -> AutoGuideModel:
@@ -218,7 +231,9 @@ def AutoDiagonalNormal(model: Model, random_seed=None) -> AutoGuideModel:
                 dims=value_dims[rv],
             )
 
-    return AutoGuideModel(guide_model, params_init_values)
+    return AutoDiagonalGuideModel(
+        guide_model, params_init_values, tuple(rv.name for rv in free_rvs)
+    )
 
 
 @dataclass(frozen=True)

--- a/pymc_extras/inference/advi/autoguide.py
+++ b/pymc_extras/inference/advi/autoguide.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from typing import ClassVar
 
 import numpy as np
 import pytensor.tensor as pt
@@ -61,6 +62,9 @@ def get_value_shapes_and_dims(
 
 @dataclass(frozen=True)
 class AutoGuideModel:
+    # Dims of each covariance entry fit_quantities reports, keyed by its name.
+    covariance_dims: ClassVar[dict[str, tuple[str, ...]]] = {}
+
     model: Model
     params_init_values: dict[Variable, np.ndarray]
     name_to_param: dict[str, Variable] = field(init=False)
@@ -153,6 +157,8 @@ def _check_continuous_rvs(model: Model, free_rvs: list[Variable]) -> None:
 class AutoDiagonalGuideModel(AutoGuideModel):
     """Guide model for a mean-field (diagonal normal) ADVI approximation."""
 
+    covariance_dims: ClassVar[dict[str, tuple[str, ...]]] = {"standard_deviation": ("rows",)}
+
     variable_names: tuple[str, ...]
 
     def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
@@ -239,6 +245,8 @@ def AutoDiagonalNormal(model: Model, random_seed=None) -> AutoGuideModel:
 @dataclass(frozen=True)
 class AutoFullRankGuideModel(AutoGuideModel):
     """Guide model for a full-rank (multivariate normal) ADVI approximation."""
+
+    covariance_dims: ClassVar[dict[str, tuple[str, ...]]] = {"cholesky_lower": ("rows", "columns")}
 
     def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Report the mean and the lower-triangular Cholesky factor of the covariance."""
@@ -333,6 +341,11 @@ def AutoMultivariateNormal(model: Model, random_seed=None) -> AutoGuideModel:
 @dataclass(frozen=True)
 class AutoLowRankGuideModel(AutoGuideModel):
     """Guide model for a low-rank-plus-diagonal multivariate normal ADVI approximation."""
+
+    covariance_dims: ClassVar[dict[str, tuple[str, ...]]] = {
+        "cov_factor": ("rows", "factors"),
+        "diagonal_standard_deviation": ("rows",),
+    }
 
     def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         r"""Report the mean and the two terms of the covariance.

--- a/pymc_extras/inference/advi/autoguide.py
+++ b/pymc_extras/inference/advi/autoguide.py
@@ -321,11 +321,16 @@ class AutoLowRankGuideModel(AutoGuideModel):
     """Guide model for a low-rank-plus-diagonal multivariate normal ADVI approximation."""
 
     def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
-        """Report the mean and the factors of ``cov = W @ W.T + diag(d ** 2)``."""
+        r"""Report the mean and the two terms of the covariance.
+
+        The covariance is :math:`W W^{T} + \mathrm{diag}(d^{2})`, so ``cov_factor`` is
+        :math:`W` and ``diagonal_standard_deviation`` is :math:`d` -- a standard deviation,
+        squared before it enters the covariance.
+        """
         return {
             "mean_vector": params["loc"],
             "cov_factor": params["cov_factor"],
-            "cov_diag": np.exp(params["cov_diag_unconstrained"]),
+            "diagonal_standard_deviation": np.exp(params["cov_diag_unconstrained"]),
         }
 
     def stochastic_logq(self, path_derivative_gradient: bool = True) -> pt.TensorVariable:

--- a/pymc_extras/inference/advi/autoguide.py
+++ b/pymc_extras/inference/advi/autoguide.py
@@ -91,10 +91,9 @@ class AutoGuideModel:
     def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
         """Describe the fitted approximation by its mean and its covariance parameterization.
 
-        Every guide reports ``mean_vector``; the rest is whatever that family stores, so the
-        family is identifiable from which entries are present. The mean-field guide keeps a
-        marginal standard deviation per parameter, and reports it exponentiated rather than in
-        the unconstrained space its optimizer works in.
+        Every guide reports ``mean_vector``, so the family is identifiable from whichever
+        covariance entries accompany it. The mean-field guide reports a marginal standard
+        deviation, exponentiated out of the unconstrained space it optimizes in.
 
         Parameters
         ----------

--- a/pymc_extras/inference/advi/autoguide.py
+++ b/pymc_extras/inference/advi/autoguide.py
@@ -88,6 +88,32 @@ class AutoGuideModel:
         """
         return self.model["latent"]
 
+    def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Describe the fitted approximation by its mean and its covariance parameterization.
+
+        Every guide reports ``mean_vector``; the rest is whatever that family stores, so the
+        family is identifiable from which entries are present. The mean-field guide keeps a
+        marginal standard deviation per parameter, and reports it exponentiated rather than in
+        the unconstrained space its optimizer works in.
+
+        Parameters
+        ----------
+        params : dict of str to ndarray
+            Guide parameter values, keyed as in :attr:`params_init_values`.
+
+        Returns
+        -------
+        quantities : dict of str to ndarray
+            ``mean_vector`` and this family's covariance entries, flattened in the order the
+            model's free RVs appear in.
+        """
+        locs = [params[p.name].ravel() for p in self.params if p.name.endswith("_loc")]
+        scales = [params[p.name].ravel() for p in self.params if p.name.endswith("_scale")]
+        return {
+            "mean_vector": np.concatenate(locs),
+            "standard_deviation": np.exp(np.concatenate(scales)),
+        }
+
     def stochastic_logq(self, path_derivative_gradient: bool = True) -> pt.TensorVariable:
         """Returns a graph representing the logp of the guide model, evaluated under draws from its random variables.
 
@@ -200,6 +226,15 @@ def AutoDiagonalNormal(model: Model, random_seed=None) -> AutoGuideModel:
 class AutoFullRankGuideModel(AutoGuideModel):
     """Guide model for a full-rank (multivariate normal) ADVI approximation."""
 
+    def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Report the mean and the lower-triangular Cholesky factor of the covariance."""
+        loc = params["loc"]
+        n_dim = loc.size
+        cholesky = np.zeros((n_dim, n_dim), dtype=loc.dtype)
+        cholesky[np.tril_indices(n_dim)] = params["L_packed"]
+        np.fill_diagonal(cholesky, np.exp(np.diagonal(cholesky)))
+        return {"mean_vector": loc, "cholesky_lower": cholesky}
+
     def stochastic_logq(self, path_derivative_gradient: bool = True) -> pt.TensorVariable:
         """Joint logq of the full-rank guide, derived by logprob inference.
 
@@ -284,6 +319,14 @@ def AutoMultivariateNormal(model: Model, random_seed=None) -> AutoGuideModel:
 @dataclass(frozen=True)
 class AutoLowRankGuideModel(AutoGuideModel):
     """Guide model for a low-rank-plus-diagonal multivariate normal ADVI approximation."""
+
+    def fit_quantities(self, params: dict[str, np.ndarray]) -> dict[str, np.ndarray]:
+        """Report the mean and the factors of ``cov = W @ W.T + diag(d ** 2)``."""
+        return {
+            "mean_vector": params["loc"],
+            "cov_factor": params["cov_factor"],
+            "cov_diag": np.exp(params["cov_diag_unconstrained"]),
+        }
 
     def stochastic_logq(self, path_derivative_gradient: bool = True) -> pt.TensorVariable:
         """Joint logq of the low-rank guide, evaluated in closed form.

--- a/pymc_extras/inference/advi/fit.py
+++ b/pymc_extras/inference/advi/fit.py
@@ -88,5 +88,6 @@ def fit_advi(
         loss_history=state.loss_history,
         step=state.step,
         optimizer_state=state.optimizer_state,
+        parameter_names=list(state.params),
     )
     return idata

--- a/pymc_extras/inference/advi/fit.py
+++ b/pymc_extras/inference/advi/fit.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import numpy as np
-import xarray as xr
 
 from pymc import Model, modelcontext
 from xarray import DataTree
 
+from pymc_extras.inference.advi.idata import (
+    add_fit_to_inference_data,
+    add_optimizer_result_to_inference_data,
+)
 from pymc_extras.inference.advi.optimizers import GradientTransformation
 from pymc_extras.inference.advi.training import Trainer
 
@@ -58,8 +61,8 @@ def fit_advi(
     Returns
     -------
     DataTree
-        Posterior draws from the fitted guide, with the negative loss history in the
-        ``fit`` group (as ``elbo``).
+        Posterior draws from the fitted guide, the guide's mean and covariance in the
+        ``fit`` group, and the ELBO trace and optimizer state in ``optimizer_result``.
     """
     model = modelcontext(model)
 
@@ -79,5 +82,11 @@ def fit_advi(
     )
     state = trainer.fit(n_steps, model=model, random_seed=train_seed)
     idata = trainer.sample_posterior(draws, model=model, random_seed=sampling_seed)
-    idata["fit"] = DataTree(dataset=xr.Dataset({"elbo": ("step", -state.loss_history)}))
+    idata = add_fit_to_inference_data(idata, trainer.guide, state.params, model=model)
+    idata = add_optimizer_result_to_inference_data(
+        idata,
+        loss_history=state.loss_history,
+        step=state.step,
+        optimizer_state=state.optimizer_state,
+    )
     return idata

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -11,7 +11,7 @@ _COVARIANCE_DIMS = {
     "standard_deviation": ("rows",),
     "cholesky_lower": ("rows", "columns"),
     "cov_factor": ("rows", "factors"),
-    "cov_diag": ("rows",),
+    "diagonal_standard_deviation": ("rows",),
 }
 
 
@@ -25,8 +25,8 @@ def add_fit_to_inference_data(
 
     The guide reports the covariance in whatever form it stores, so the group holds a
     marginal standard deviation for a mean-field guide, a Cholesky factor for a full-rank
-    one, and a factor-plus-diagonal pair for a low-rank one. Which entries are present
-    therefore identifies the family.
+    one, and a factor plus a diagonal standard deviation for a low-rank one. Which entries
+    are present therefore identifies the family.
 
     Parameters
     ----------

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -7,6 +7,9 @@ from xarray import DataTree
 from pymc_extras.inference.advi.autoguide import AutoGuideModel
 from pymc_extras.inference.idata_utils import make_unpacked_variable_names
 
+# Dims labelled by the guide parameter they index, as opposed to a bare integer range.
+_PARAMETER_DIMS = ("rows", "columns")
+
 _COVARIANCE_DIMS = {
     "standard_deviation": ("rows",),
     "cholesky_lower": ("rows", "columns"),
@@ -46,22 +49,26 @@ def add_fit_to_inference_data(
         The provided tree, with the ``fit`` group added.
     """
     model = pm.modelcontext(model)
-    quantities = guide.fit_quantities(params)
+    quantities = dict(guide.fit_quantities(params))
+    mean_vector = quantities.pop("mean_vector")
 
     value_names = [model.rvs_to_values[rv].name for rv in model.free_RVs]
     rows = make_unpacked_variable_names(value_names, model)
 
     coords: dict[str, list[str] | np.ndarray] = {"rows": rows}
-    data_vars = {"mean_vector": xr.DataArray(quantities["mean_vector"], dims=["rows"])}
+    data_vars = {"mean_vector": xr.DataArray(mean_vector, dims=["rows"])}
 
     for name, values in quantities.items():
-        if name == "mean_vector":
-            continue
+        if name not in _COVARIANCE_DIMS:
+            raise ValueError(
+                f"{type(guide).__name__} reported an unknown covariance quantity {name!r}. "
+                f"Known quantities are {sorted(_COVARIANCE_DIMS)}."
+            )
         dims = _COVARIANCE_DIMS[name]
-        if "columns" in dims:
-            coords["columns"] = rows
-        if "factors" in dims:
-            coords["factors"] = np.arange(values.shape[1])
+        for axis, dim in enumerate(dims):
+            coords.setdefault(
+                dim, rows if dim in _PARAMETER_DIMS else np.arange(values.shape[axis])
+            )
         data_vars[name] = xr.DataArray(values, dims=list(dims))
 
     idata["fit"] = DataTree(dataset=xr.Dataset(data_vars, coords=coords))
@@ -79,9 +86,8 @@ def add_optimizer_result_to_inference_data(
     """Add the optimization trace and the optimizer's own state to a DataTree.
 
     The group holds both what a reader wants to see and what a resumed run needs: the ELBO
-    over the steps taken so far, and the optimizer's moment buffers and clocks. Each state
-    variable keeps its own name and shape, so restoring one is a lookup rather than an
-    unpacking.
+    over the steps taken so far, and the optimizer's moment buffers and clocks, each keeping
+    its own name and shape.
 
     Parameters
     ----------

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -134,11 +134,6 @@ def add_optimizer_result_to_inference_data(
     -------
     idata : DataTree
         The provided tree, with the ``optimizer_result`` group added.
-
-    Raises
-    ------
-    ValueError
-        If a buffer kind covers only some of the guide's parameters.
     """
     loss_history = np.asarray(loss_history, dtype=float)
 

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pymc as pm
+import xarray as xr
+
+from xarray import DataTree
+
+from pymc_extras.inference.advi.autoguide import AutoGuideModel
+from pymc_extras.inference.idata_utils import make_unpacked_variable_names
+
+_COVARIANCE_DIMS = {
+    "standard_deviation": ("rows",),
+    "cholesky_lower": ("rows", "columns"),
+    "cov_factor": ("rows", "factors"),
+    "cov_diag": ("rows",),
+}
+
+
+def add_fit_to_inference_data(
+    idata: DataTree,
+    guide: AutoGuideModel,
+    params: dict[str, np.ndarray],
+    model: pm.Model | None = None,
+) -> DataTree:
+    """Add the fitted guide's mean and covariance to a DataTree, in the ``fit`` group.
+
+    The guide reports the covariance in whatever form it stores, so the group holds a
+    marginal standard deviation for a mean-field guide, a Cholesky factor for a full-rank
+    one, and a factor-plus-diagonal pair for a low-rank one. Which entries are present
+    therefore identifies the family.
+
+    Parameters
+    ----------
+    idata : DataTree
+        The tree to add the group to.
+    guide : AutoGuideModel
+        The fitted guide.
+    params : dict of str to ndarray
+        Guide parameter values, keyed as in :attr:`AutoGuideModel.params_init_values`.
+    model : Model, optional
+        The PyMC model the guide approximates. If None, the model is taken from the
+        context stack.
+
+    Returns
+    -------
+    idata : DataTree
+        The provided tree, with the ``fit`` group added.
+    """
+    model = pm.modelcontext(model)
+    quantities = guide.fit_quantities(params)
+
+    value_names = [model.rvs_to_values[rv].name for rv in model.free_RVs]
+    rows = make_unpacked_variable_names(value_names, model)
+
+    coords: dict[str, list[str] | np.ndarray] = {"rows": rows}
+    data_vars = {"mean_vector": xr.DataArray(quantities["mean_vector"], dims=["rows"])}
+
+    for name, values in quantities.items():
+        if name == "mean_vector":
+            continue
+        dims = _COVARIANCE_DIMS[name]
+        if "columns" in dims:
+            coords["columns"] = rows
+        if "factors" in dims:
+            coords["factors"] = np.arange(values.shape[1])
+        data_vars[name] = xr.DataArray(values, dims=list(dims))
+
+    idata["fit"] = DataTree(dataset=xr.Dataset(data_vars, coords=coords))
+
+    return idata

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -67,3 +67,50 @@ def add_fit_to_inference_data(
     idata["fit"] = DataTree(dataset=xr.Dataset(data_vars, coords=coords))
 
     return idata
+
+
+def add_optimizer_result_to_inference_data(
+    idata: DataTree,
+    *,
+    loss_history: np.ndarray,
+    step: int,
+    optimizer_state: dict[str, np.ndarray],
+) -> DataTree:
+    """Add the optimization trace and the optimizer's own state to a DataTree.
+
+    The group holds both what a reader wants to see and what a resumed run needs: the ELBO
+    over the steps taken so far, and the optimizer's moment buffers and clocks. Each state
+    variable keeps its own name and shape, so restoring one is a lookup rather than an
+    unpacking.
+
+    Parameters
+    ----------
+    idata : DataTree
+        The tree to add the group to.
+    loss_history : ndarray
+        Negative ELBO at each step taken so far.
+    step : int
+        Total number of optimization steps taken.
+    optimizer_state : dict of str to ndarray
+        The optimizer's shared variable values, keyed by variable name.
+
+    Returns
+    -------
+    idata : DataTree
+        The provided tree, with the ``optimizer_result`` group added.
+    """
+    loss_history = np.asarray(loss_history, dtype=float)
+
+    data_vars = {
+        "elbo": xr.DataArray(-loss_history, dims=["step"]),
+        "step_count": xr.DataArray(np.asarray(step)),
+    }
+    for name, value in optimizer_state.items():
+        value = np.asarray(value)
+        dims = [f"{name}_dim_{axis}" for axis in range(value.ndim)]
+        data_vars[name] = xr.DataArray(value, dims=dims)
+
+    coords = {"step": np.arange(loss_history.size)}
+    idata["optimizer_result"] = DataTree(dataset=xr.Dataset(data_vars, coords=coords))
+
+    return idata

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -14,13 +14,6 @@ from pymc_extras.inference.idata_utils import make_unpacked_variable_names
 # Dims labelled by the guide parameter they index, as opposed to a bare integer range.
 _PARAMETER_DIMS = ("rows", "columns")
 
-_COVARIANCE_DIMS = {
-    "standard_deviation": ("rows",),
-    "cholesky_lower": ("rows", "columns"),
-    "cov_factor": ("rows", "factors"),
-    "diagonal_standard_deviation": ("rows",),
-}
-
 
 def add_fit_to_inference_data(
     idata: DataTree,
@@ -59,16 +52,18 @@ def add_fit_to_inference_data(
     value_names = [model.rvs_to_values[rv].name for rv in model.free_RVs]
     rows = make_unpacked_variable_names(value_names, model)
 
+    covariance_dims = guide.covariance_dims
+    if undeclared := sorted(set(quantities) - set(covariance_dims)):
+        raise ValueError(
+            f"{type(guide).__name__} reported covariance quantities {undeclared} that it "
+            f"declares no dims for. Its covariance_dims names {sorted(covariance_dims)}."
+        )
+
     coords: dict[str, list[str] | np.ndarray] = {"rows": rows}
     data_vars = {"mean_vector": xr.DataArray(mean_vector, dims=["rows"])}
 
     for name, values in quantities.items():
-        if name not in _COVARIANCE_DIMS:
-            raise ValueError(
-                f"{type(guide).__name__} reported an unknown covariance quantity {name!r}. "
-                f"Known quantities are {sorted(_COVARIANCE_DIMS)}."
-            )
-        dims = _COVARIANCE_DIMS[name]
+        dims = covariance_dims[name]
         for axis, dim in enumerate(dims):
             coords.setdefault(
                 dim, rows if dim in _PARAMETER_DIMS else np.arange(values.shape[axis])

--- a/pymc_extras/inference/advi/idata.py
+++ b/pymc_extras/inference/advi/idata.py
@@ -1,7 +1,11 @@
+from collections import defaultdict
+from collections.abc import Sequence
+
 import numpy as np
 import pymc as pm
 import xarray as xr
 
+from pymc.blocking import DictToArrayBijection
 from xarray import DataTree
 
 from pymc_extras.inference.advi.autoguide import AutoGuideModel
@@ -76,18 +80,47 @@ def add_fit_to_inference_data(
     return idata
 
 
+def _split_buffer_name(name: str, parameter_names: Sequence[str]) -> tuple[str | None, str]:
+    """Separate an optimizer buffer's name into the parameter it tracks and its kind.
+
+    A per-parameter buffer is named ``{kind}_{parameter}``, so ``adam_m_theta_loc`` tracks
+    ``theta_loc`` under the kind ``adam_m``. The longest parameter name wins, so a guide
+    holding both ``loc`` and ``theta_loc`` splits unambiguously. A clock such as ``adam_t``
+    tracks no parameter and comes back with ``None``.
+    """
+    for parameter in sorted(parameter_names, key=len, reverse=True):
+        suffix = f"_{parameter}"
+        if name.endswith(suffix):
+            return parameter, name.removesuffix(suffix)
+    return None, name
+
+
+def _unpacked_labels(point_map_info: Sequence[tuple]) -> list[str]:
+    """Label every scalar element of a raveled parameter vector, in C order."""
+    labels = []
+    for name, shape, *_ in point_map_info:
+        if not shape:
+            labels.append(name)
+        else:
+            labels.extend(f"{name}[{','.join(map(str, index))}]" for index in np.ndindex(*shape))
+    return labels
+
+
 def add_optimizer_result_to_inference_data(
     idata: DataTree,
     *,
     loss_history: np.ndarray,
     step: int,
     optimizer_state: dict[str, np.ndarray],
+    parameter_names: Sequence[str],
 ) -> DataTree:
-    """Add the optimization trace and the optimizer's own state to a DataTree.
+    """Add the optimization trace and the optimizer's state to a DataTree.
 
     The group holds both what a reader wants to see and what a resumed run needs: the ELBO
-    over the steps taken so far, and the optimizer's moment buffers and clocks, each keeping
-    its own name and shape.
+    over the steps taken so far, and the optimizer's moment buffers and clocks.
+
+    Ravel each kind's per-parameter buffers into one variable over a labelled ``parameter``
+    dim. Clocks belong to no parameter and stay scalars.
 
     Parameters
     ----------
@@ -99,24 +132,52 @@ def add_optimizer_result_to_inference_data(
         Total number of optimization steps taken.
     optimizer_state : dict of str to ndarray
         The optimizer's shared variable values, keyed by variable name.
+    parameter_names : sequence of str
+        The guide's parameter names, in the order the raveled vectors follow.
 
     Returns
     -------
     idata : DataTree
         The provided tree, with the ``optimizer_result`` group added.
+
+    Raises
+    ------
+    ValueError
+        If a buffer kind covers only some of the guide's parameters.
     """
     loss_history = np.asarray(loss_history, dtype=float)
 
-    data_vars = {
+    buffers_by_kind: dict[str, dict[str, np.ndarray]] = defaultdict(dict)
+    clocks: dict[str, np.ndarray] = {}
+    for name, value in optimizer_state.items():
+        parameter, kind = _split_buffer_name(name, parameter_names)
+        if parameter is None:
+            clocks[kind] = np.asarray(value)
+        else:
+            buffers_by_kind[kind][parameter] = np.asarray(value)
+
+    data_vars: dict[str, xr.DataArray] = {
         "elbo": xr.DataArray(-loss_history, dims=["step"]),
         "step_count": xr.DataArray(np.asarray(step)),
     }
-    for name, value in optimizer_state.items():
-        value = np.asarray(value)
-        dims = [f"{name}_dim_{axis}" for axis in range(value.ndim)]
-        data_vars[name] = xr.DataArray(value, dims=dims)
+    coords: dict[str, np.ndarray | list[str]] = {"step": np.arange(loss_history.size)}
 
-    coords = {"step": np.arange(loss_history.size)}
+    for kind, value in clocks.items():
+        data_vars[kind] = xr.DataArray(value)
+
+    for kind, buffers in buffers_by_kind.items():
+        if set(buffers) != set(parameter_names):
+            missing = sorted(set(parameter_names) - set(buffers))
+            raise ValueError(
+                f"the optimizer's {kind!r} buffers cover only some of the guide's "
+                f"parameters, missing {missing}. Every kind must cover all of them to be "
+                "raveled into one vector."
+            )
+        raveled = DictToArrayBijection.map({name: buffers[name] for name in parameter_names})
+        if "parameter" not in coords:
+            coords["parameter"] = _unpacked_labels(raveled.point_map_info)
+        data_vars[kind] = xr.DataArray(raveled.data, dims=["parameter"])
+
     idata["optimizer_result"] = DataTree(dataset=xr.Dataset(data_vars, coords=coords))
 
     return idata

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -42,6 +42,29 @@ def test_fit_advi_recovers_conjugate_posterior(conjugate_model):
     np.testing.assert_allclose(theta.std(), np.sqrt(post_var), rtol=0.25)
 
 
+def test_fit_advi_returns_fit_and_optimizer_result_groups(conjugate_model):
+    model, post_mean, _ = conjugate_model
+    n_steps = 200
+
+    idata = fit_advi(model=model, n_steps=n_steps, draws=100, random_seed=1)
+
+    assert {"/posterior", "/fit", "/optimizer_result"} <= set(idata.groups)
+
+    fit = idata["fit"].dataset
+    assert set(fit.data_vars) == {"mean_vector", "standard_deviation"}
+    assert list(fit.coords["rows"].values) == ["theta"]
+    # the default guide is mean-field, so the fit group carries the converged mean
+    np.testing.assert_allclose(fit["mean_vector"].values, [post_mean], atol=0.1)
+    assert (fit["standard_deviation"].values > 0).all()
+
+    optimizer_result = idata["optimizer_result"].dataset
+    assert optimizer_result["elbo"].shape == (n_steps,)
+    assert optimizer_result["step_count"].item() == n_steps
+    # the trace ends higher than it starts, since the ELBO is what training maximizes
+    elbo = optimizer_result["elbo"].values
+    assert elbo[-20:].mean() > elbo[:20].mean()
+
+
 def test_fit_advi_random_seed(conjugate_model):
     model, *_ = conjugate_model
 

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -61,15 +61,19 @@ def test_full_rank_fit_group_holds_a_cholesky_factor(model):
 
 def test_low_rank_fit_group_holds_the_factor_and_diagonal(model):
     guide = AutoLowRankMultivariateNormal(model, rank=2, random_seed=0)
+    params = initial_params(guide)
 
-    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
-        "fit"
-    ].dataset
+    fit = add_fit_to_inference_data(DataTree(), guide, params, model=model)["fit"].dataset
 
-    assert set(fit.data_vars) == {"mean_vector", "cov_factor", "cov_diag"}
+    assert set(fit.data_vars) == {"mean_vector", "cov_factor", "diagonal_standard_deviation"}
     assert fit["cov_factor"].dims == ("rows", "factors")
     assert fit["cov_factor"].shape[1] == 2
-    assert (fit["cov_diag"].values > 0).all()
+    # d itself, not d ** 2: the covariance is W @ W.T + diag(d ** 2), so storing the
+    # squared term under a name that says standard deviation would silently mislead
+    np.testing.assert_allclose(
+        fit["diagonal_standard_deviation"].values,
+        np.exp(params["cov_diag_unconstrained"]),
+    )
 
 
 def test_fit_group_rows_are_labelled_in_unconstrained_space(model):

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pymc as pm
+import pytest
+
+from xarray import DataTree
+
+from pymc_extras.inference.advi.autoguide import (
+    AutoDiagonalNormal,
+    AutoLowRankMultivariateNormal,
+    AutoMultivariateNormal,
+)
+from pymc_extras.inference.advi.idata import add_fit_to_inference_data
+
+
+@pytest.fixture
+def model():
+    with pm.Model() as model:
+        pm.Normal("a")
+        pm.HalfNormal("s")
+        pm.Normal("b", shape=2)
+        pm.Normal("y", 0, 1, observed=[1.0, 2.0])
+    return model
+
+
+def initial_params(guide):
+    return {param.name: value for param, value in guide.params_init_values.items()}
+
+
+def test_mean_field_fit_group_holds_a_marginal_standard_deviation(model):
+    guide = AutoDiagonalNormal(model, random_seed=0)
+    params = initial_params(guide)
+
+    fit = add_fit_to_inference_data(DataTree(), guide, params, model=model)["fit"].dataset
+
+    assert set(fit.data_vars) == {"mean_vector", "standard_deviation"}
+    assert fit["mean_vector"].dims == ("rows",)
+    assert fit["standard_deviation"].dims == ("rows",)
+
+    # the guide stores the scale unconstrained; the group reports the standard deviation
+    expected = np.exp(np.concatenate([params["a_scale"].ravel(), params["s_scale"].ravel()]))
+    np.testing.assert_allclose(fit["standard_deviation"].values[:2], expected)
+
+
+def test_full_rank_fit_group_holds_a_cholesky_factor(model):
+    guide = AutoMultivariateNormal(model, random_seed=0)
+
+    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
+        "fit"
+    ].dataset
+
+    assert set(fit.data_vars) == {"mean_vector", "cholesky_lower"}
+    assert fit["cholesky_lower"].dims == ("rows", "columns")
+
+    cholesky = fit["cholesky_lower"].values
+    np.testing.assert_allclose(cholesky, np.tril(cholesky))
+    assert (np.diagonal(cholesky) > 0).all()
+
+
+def test_low_rank_fit_group_holds_the_factor_and_diagonal(model):
+    guide = AutoLowRankMultivariateNormal(model, rank=2, random_seed=0)
+
+    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
+        "fit"
+    ].dataset
+
+    assert set(fit.data_vars) == {"mean_vector", "cov_factor", "cov_diag"}
+    assert fit["cov_factor"].dims == ("rows", "factors")
+    assert fit["cov_factor"].shape[1] == 2
+    assert (fit["cov_diag"].values > 0).all()
+
+
+def test_fit_group_rows_are_labelled_in_unconstrained_space(model):
+    guide = AutoDiagonalNormal(model, random_seed=0)
+
+    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
+        "fit"
+    ].dataset
+
+    # the transformed variable is labelled by its value variable, and the vector one
+    # element per scalar, matching how the Laplace fit group labels its rows
+    assert list(fit.coords["rows"].values) == ["a", "s_log__", "b[0]", "b[1]"]
+
+
+def test_fit_group_holds_only_arrays_every_backend_can_store(model):
+    for guide in (
+        AutoDiagonalNormal(model, random_seed=0),
+        AutoMultivariateNormal(model, random_seed=0),
+        AutoLowRankMultivariateNormal(model, rank=2, random_seed=0),
+    ):
+        fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
+            "fit"
+        ].dataset
+        for name, array in fit.data_vars.items():
+            assert array.dtype.kind in "fiu", f"{name} has non-numeric dtype {array.dtype}"
+        assert fit.attrs == {}
+
+
+def test_mean_field_fit_group_is_linear_in_the_parameter_count():
+    # a dense covariance would be quadratic here, which is the representation the mean-field
+    # guide exists to avoid
+    n_dim = 5_000
+    with pm.Model() as wide_model:
+        pm.Normal("wide", shape=n_dim)
+        pm.Normal("y", 0, 1, observed=[1.0])
+
+    guide = AutoDiagonalNormal(wide_model, random_seed=0)
+    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=wide_model)[
+        "fit"
+    ].dataset
+
+    assert fit["mean_vector"].shape == (n_dim,)
+    assert fit["standard_deviation"].shape == (n_dim,)
+    assert sum(array.size for array in fit.data_vars.values()) == 2 * n_dim

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -90,6 +90,34 @@ def test_fit_group_rows_are_labelled_in_unconstrained_space(model):
     assert list(fit.coords["rows"].values) == ["a", "s_log__", "b[0]", "b[1]"]
 
 
+@pytest.mark.parametrize(
+    "make_guide",
+    [
+        AutoDiagonalNormal,
+        AutoMultivariateNormal,
+        lambda m, random_seed: AutoLowRankMultivariateNormal(m, rank=2, random_seed=random_seed),
+    ],
+    ids=["mean_field", "full_rank", "low_rank"],
+)
+def test_fit_group_mean_vector_element_matches_its_row_label(make_guide):
+    # the mean-field guide concatenates per-RV params in model.free_RVs order while the
+    # multivariate guides ravel in point_map_info order; the rows coord is built from
+    # free_RVs, so a divergence between the two would mislabel every element silently
+    with pm.Model() as model:
+        pm.Normal("a", initval=1.0)
+        pm.HalfNormal("s", initval=np.exp(2.0))
+        pm.Normal("b", shape=2, initval=[3.0, 4.0])
+        pm.Normal("y", 0, 1, observed=[1.0, 2.0])
+
+    guide = make_guide(model, random_seed=0)
+    fit = add_fit_to_inference_data(DataTree(), guide, initial_params(guide), model=model)[
+        "fit"
+    ].dataset
+
+    assert list(fit.coords["rows"].values) == ["a", "s_log__", "b[0]", "b[1]"]
+    np.testing.assert_allclose(fit["mean_vector"].values, [1.0, 2.0, 3.0, 4.0])
+
+
 def test_fit_group_holds_only_arrays_every_backend_can_store(model):
     for guide in (
         AutoDiagonalNormal(model, random_seed=0),

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -9,7 +9,10 @@ from pymc_extras.inference.advi.autoguide import (
     AutoLowRankMultivariateNormal,
     AutoMultivariateNormal,
 )
-from pymc_extras.inference.advi.idata import add_fit_to_inference_data
+from pymc_extras.inference.advi.idata import (
+    add_fit_to_inference_data,
+    add_optimizer_result_to_inference_data,
+)
 
 
 @pytest.fixture
@@ -111,3 +114,51 @@ def test_mean_field_fit_group_is_linear_in_the_parameter_count():
     assert fit["mean_vector"].shape == (n_dim,)
     assert fit["standard_deviation"].shape == (n_dim,)
     assert sum(array.size for array in fit.data_vars.values()) == 2 * n_dim
+
+
+def test_optimizer_result_group_holds_the_trace_and_the_buffers():
+    loss_history = np.array([5.0, 4.0, 3.5])
+    optimizer_state = {
+        "adam_t": np.asarray(3),
+        "adam_m_theta_loc": np.zeros(2),
+        "adam_v_theta_scale": np.ones((2, 3)),
+    }
+
+    idata = add_optimizer_result_to_inference_data(
+        DataTree(), loss_history=loss_history, step=3, optimizer_state=optimizer_state
+    )
+    group = idata["optimizer_result"].dataset
+
+    # the trace is reported as the ELBO, which is the negated loss the optimizer minimizes
+    np.testing.assert_allclose(group["elbo"].values, -loss_history)
+    assert group["elbo"].dims == ("step",)
+    assert group["step_count"].item() == 3
+
+    # every buffer keeps its own name and shape, so restoring one is a lookup
+    assert group["adam_t"].shape == ()
+    assert group["adam_m_theta_loc"].shape == (2,)
+    assert group["adam_v_theta_scale"].shape == (2, 3)
+
+
+def test_optimizer_result_group_survives_an_empty_trace():
+    idata = add_optimizer_result_to_inference_data(
+        DataTree(), loss_history=np.array([]), step=0, optimizer_state={}
+    )
+    group = idata["optimizer_result"].dataset
+
+    assert group["elbo"].shape == (0,)
+    assert group["step_count"].item() == 0
+
+
+def test_optimizer_result_group_holds_only_arrays_every_backend_can_store():
+    idata = add_optimizer_result_to_inference_data(
+        DataTree(),
+        loss_history=np.array([1.0, 2.0]),
+        step=2,
+        optimizer_state={"adam_t": np.asarray(2), "adam_m_x": np.zeros(3)},
+    )
+    group = idata["optimizer_result"].dataset
+
+    for name, array in group.data_vars.items():
+        assert array.dtype.kind in "fiu", f"{name} has non-numeric dtype {array.dtype}"
+    assert group.attrs == {}

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -125,11 +125,17 @@ def test_optimizer_result_group_holds_the_trace_and_the_buffers():
     optimizer_state = {
         "adam_t": np.asarray(3),
         "adam_m_theta_loc": np.zeros(2),
-        "adam_v_theta_scale": np.ones((2, 3)),
+        "adam_v_theta_loc": np.ones(2),
+        "adam_m_theta_scale": np.asarray(0.5),
+        "adam_v_theta_scale": np.asarray(1.5),
     }
 
     idata = add_optimizer_result_to_inference_data(
-        DataTree(), loss_history=loss_history, step=3, optimizer_state=optimizer_state
+        DataTree(),
+        loss_history=loss_history,
+        step=3,
+        optimizer_state=optimizer_state,
+        parameter_names=["theta_loc", "theta_scale"],
     )
     group = idata["optimizer_result"].dataset
 
@@ -138,20 +144,79 @@ def test_optimizer_result_group_holds_the_trace_and_the_buffers():
     assert group["elbo"].dims == ("step",)
     assert group["step_count"].item() == 3
 
-    # every buffer keeps its own name and shape, so restoring one is a lookup
+    # one variable per buffer kind over a labelled parameter dim, not one per buffer, and
+    # the clock stays a scalar because it belongs to no parameter
+    assert set(group.data_vars) == {"elbo", "step_count", "adam_t", "adam_m", "adam_v"}
     assert group["adam_t"].shape == ()
-    assert group["adam_m_theta_loc"].shape == (2,)
-    assert group["adam_v_theta_scale"].shape == (2, 3)
+    assert group["adam_m"].dims == ("parameter",)
+    assert list(group.coords["parameter"].values) == [
+        "theta_loc[0]",
+        "theta_loc[1]",
+        "theta_scale",
+    ]
+    np.testing.assert_allclose(group["adam_m"].values, [0.0, 0.0, 0.5])
+    np.testing.assert_allclose(group["adam_v"].values, [1.0, 1.0, 1.5])
 
 
-def test_optimizer_result_group_survives_an_empty_trace():
+def test_optimizer_result_refuses_a_kind_that_covers_some_parameters():
+    with pytest.raises(ValueError, match="cover only some of the guide's parameters"):
+        add_optimizer_result_to_inference_data(
+            DataTree(),
+            loss_history=np.zeros(1),
+            step=1,
+            optimizer_state={"adam_m_theta_loc": np.zeros(2)},
+            parameter_names=["theta_loc", "theta_scale"],
+        )
+
+
+def test_optimizer_result_splits_a_parameter_whose_name_suffixes_another():
+    # a hierarchical model gives the guide both "beta_loc" and "mu_beta_loc", so
+    # "adam_m_mu_beta_loc" ends with two parameter names and only the longer one is right
     idata = add_optimizer_result_to_inference_data(
-        DataTree(), loss_history=np.array([]), step=0, optimizer_state={}
+        DataTree(),
+        loss_history=np.zeros(1),
+        step=1,
+        optimizer_state={
+            "adam_m_beta_loc": np.full(2, 1.0),
+            "adam_m_mu_beta_loc": np.full(1, 2.0),
+        },
+        parameter_names=["beta_loc", "mu_beta_loc"],
     )
     group = idata["optimizer_result"].dataset
 
-    assert group["elbo"].shape == (0,)
-    assert group["step_count"].item() == 0
+    assert set(group.data_vars) == {"elbo", "step_count", "adam_m"}
+    assert list(group.coords["parameter"].values) == [
+        "beta_loc[0]",
+        "beta_loc[1]",
+        "mu_beta_loc[0]",
+    ]
+    np.testing.assert_allclose(group["adam_m"].values, [1.0, 1.0, 2.0])
+
+
+def test_optimizer_result_parameter_dim_follows_the_guide_order_and_labels_every_element():
+    # the buffers arrive in the optimizer's order, not the guide's, and a full-rank guide
+    # carries a matrix parameter whose elements must line up with their labels
+    idata = add_optimizer_result_to_inference_data(
+        DataTree(),
+        loss_history=np.zeros(1),
+        step=1,
+        optimizer_state={
+            "adam_m_theta_cholesky": np.array([[1.0, 2.0], [3.0, 4.0]]),
+            "adam_m_theta_loc": np.array([5.0, 6.0]),
+        },
+        parameter_names=["theta_loc", "theta_cholesky"],
+    )
+    group = idata["optimizer_result"].dataset
+
+    assert list(group.coords["parameter"].values) == [
+        "theta_loc[0]",
+        "theta_loc[1]",
+        "theta_cholesky[0,0]",
+        "theta_cholesky[0,1]",
+        "theta_cholesky[1,0]",
+        "theta_cholesky[1,1]",
+    ]
+    np.testing.assert_allclose(group["adam_m"].values, [5.0, 6.0, 1.0, 2.0, 3.0, 4.0])
 
 
 def test_optimizer_result_group_holds_only_arrays_every_backend_can_store():
@@ -160,6 +225,7 @@ def test_optimizer_result_group_holds_only_arrays_every_backend_can_store():
         loss_history=np.array([1.0, 2.0]),
         step=2,
         optimizer_state={"adam_t": np.asarray(2), "adam_m_x": np.zeros(3)},
+        parameter_names=["x"],
     )
     group = idata["optimizer_result"].dataset
 

--- a/tests/inference/advi/test_idata.py
+++ b/tests/inference/advi/test_idata.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pymc as pm
+import pytensor.tensor as pt
 import pytest
 
 from xarray import DataTree
 
 from pymc_extras.inference.advi.autoguide import (
     AutoDiagonalNormal,
+    AutoGuideModel,
     AutoLowRankMultivariateNormal,
     AutoMultivariateNormal,
 )
@@ -118,6 +120,21 @@ def test_mean_field_fit_group_is_linear_in_the_parameter_count():
     assert fit["mean_vector"].shape == (n_dim,)
     assert fit["standard_deviation"].shape == (n_dim,)
     assert sum(array.size for array in fit.data_vars.values()) == 2 * n_dim
+
+
+def test_fit_group_refuses_a_guide_that_does_not_report_its_parameterization(model):
+    # this guide names its params like the mean-field one but links the scale through
+    # softplus, so exponentiating its scale would report a plausible, wrong number
+    loc, scale = pt.scalar("a_loc"), pt.scalar("a_scale")
+    with pm.Model() as guide_model:
+        z = pm.Normal("a_z")
+        pm.Deterministic("a", loc + pt.softplus(scale) * z)
+    guide = AutoGuideModel(guide_model, {loc: np.array(0.0), scale: np.array(0.1)})
+
+    with pytest.raises(NotImplementedError, match="does not report a fitted mean"):
+        add_fit_to_inference_data(
+            DataTree(), guide, {"a_loc": np.array(0.0), "a_scale": np.array(0.1)}, model=model
+        )
 
 
 def test_optimizer_result_group_holds_the_trace_and_the_buffers():


### PR DESCRIPTION
`fit_advi` returned a `fit` group holding nothing but an `elbo` vector. It now reports the guide's mean and covariance there, plus an `optimizer_result` group with the trace and the optimizer's state. That's a step toward the idata holding the full optimizer state so a run can be warm-started or restarted from it, and part of a broader effort to remove state from `Trainer`.
