### PR TITLE
[FIX] Fix multivariate SquareRootFilter log-likelihood. Targets #744

### DIFF
--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -669,18 +669,15 @@ class SquareRootFilter(BaseFilter):
         P_chol_filtered = B[k_endog:, k_endog:]
 
         def compute_non_degenerate(P_chol_filtered, F_chol, K_F_chol, v):
-            a_filtered = a + K_F_chol @ solve_triangular(F_chol, v, lower=True)
+            scaled_residual = solve_triangular(F_chol, v, lower=True)
+            a_filtered = a + K_F_chol @ scaled_residual
 
-            inner_term = solve_triangular(
-                F_chol, solve_triangular(F_chol, v, lower=True), lower=True
-            )
-
-            loss = (v.T @ inner_term).ravel()
+            loss = pt.dot(scaled_residual, scaled_residual)
 
             # abs necessary because we're not guaranteed a positive diagonal from the schur decomposition
             logdet = 2 * pt.log(pt.abs(pt.diag(F_chol))).sum()
 
-            ll = -0.5 * (k_endog * (MVN_CONST + logdet) + loss)[0]
+            ll = -0.5 * (k_endog * MVN_CONST + logdet + loss)
 
             return [a_filtered, P_chol_filtered, ll]
 

--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -674,10 +674,12 @@ class SquareRootFilter(BaseFilter):
 
             loss = pt.dot(scaled_residual, scaled_residual)
 
+            # Missing dimensions carry only jitter, exclude them from the likelihood.
+            observed = pt.bitwise_not(nan_mask).astype(F_chol.dtype)
             # abs necessary because we're not guaranteed a positive diagonal from the schur decomposition
-            logdet = 2 * pt.log(pt.abs(pt.diag(F_chol))).sum()
+            logdet = 2 * (pt.log(pt.abs(pt.diag(F_chol))) * observed).sum()
 
-            ll = -0.5 * (k_endog * MVN_CONST + logdet + loss)
+            ll = -0.5 * (observed.sum() * MVN_CONST + logdet + loss)
 
             return [a_filtered, P_chol_filtered, ll]
 

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -247,24 +247,6 @@ def test_output_with_multiple_observed(filter_name, rng):
         )
 
 
-def test_square_root_filter_multivariate_log_likelihood(rng):
-    p, m, r, n = 2, 3, 3, 20
-    inputs = make_test_inputs(p, m, r, n, rng)
-
-    univariate_outputs = get_filter_function("UnivariateFilter")(*inputs)
-
-    square_root_inputs = list(inputs)
-    square_root_inputs[2] = np.linalg.cholesky(square_root_inputs[2])
-    square_root_outputs = get_filter_function("CholeskyFilter")(*square_root_inputs)
-
-    assert_allclose(
-        square_root_outputs[-1],
-        univariate_outputs[-1],
-        atol=ATOL,
-        rtol=RTOL,
-    )
-
-
 @pytest.mark.parametrize("filter_name", filter_names)
 @pytest.mark.parametrize("p", [1, 5], ids=["univariate (p=1)", "multivariate (p=5)"])
 def test_missing_data(filter_name, p, rng):
@@ -378,13 +360,7 @@ def get_loglike_function(filter_name: str, obs_cov: str) -> Callable:
     [
         ("StandardFilter", "dense"),
         ("UnivariateFilter", "diagonal"),
-        pytest.param(
-            "CholeskyFilter",
-            "dense",
-            marks=pytest.mark.xfail(
-                reason="SquareRootFilter scales log |F| by k_endog as well, see issue #744"
-            ),
-        ),
+        ("CholeskyFilter", "dense"),
     ],
 )
 def test_loglike_matches_statsmodels(filter_name, obs_cov, rng):

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -247,34 +247,22 @@ def test_output_with_multiple_observed(filter_name, rng):
         )
 
 
-def test_square_root_filter_multivariate_log_likelihood():
-    rng = np.random.default_rng(0)
-    k_states, k_endog, n = 3, 2, 20
+def test_square_root_filter_multivariate_log_likelihood(rng):
+    p, m, r, n = 2, 3, 3, 20
+    inputs = make_test_inputs(p, m, r, n, rng)
 
-    T = np.eye(k_states, dtype=floatX) * 0.9
-    R = np.eye(k_states, dtype=floatX)
-    Q = np.eye(k_states, dtype=floatX) * 0.5
-    Z = rng.normal(size=(k_endog, k_states)).astype(floatX)
-    H = np.eye(k_endog, dtype=floatX) * 0.3
-    a0 = np.zeros(k_states, dtype=floatX)
-    P0 = np.eye(k_states, dtype=floatX)
-    c = np.zeros(k_states, dtype=floatX)
-    d = np.zeros(k_endog, dtype=floatX)
-    data = rng.normal(size=(n, k_endog)).astype(floatX)
+    univariate_outputs = get_filter_function("UnivariateFilter")(*inputs)
 
-    args = [data, a0, np.linalg.cholesky(P0), c, d, T, Z, R, H, Q]
-    outputs = SquareRootFilter().build_graph(*[pt.as_tensor(x) for x in args])
-    y_hat, F, loglike = pytensor.function([], [outputs[2], outputs[5], outputs[-1]])()
+    square_root_inputs = list(inputs)
+    square_root_inputs[2] = np.linalg.cholesky(square_root_inputs[2])
+    square_root_outputs = get_filter_function("CholeskyFilter")(*square_root_inputs)
 
-    residual = data - y_hat
-    solved_residual = np.linalg.solve(F, residual[..., None])[..., 0]
-    sign, logdet = np.linalg.slogdet(F)
-    expected_loglike = -0.5 * (
-        k_endog * np.log(2 * np.pi) + logdet + np.einsum("ni,ni->n", residual, solved_residual)
+    assert_allclose(
+        square_root_outputs[-1],
+        univariate_outputs[-1],
+        atol=ATOL,
+        rtol=RTOL,
     )
-
-    assert np.all(sign > 0)
-    assert_allclose(loglike, expected_loglike, atol=ATOL, rtol=RTOL)
 
 
 @pytest.mark.parametrize("filter_name", filter_names)

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -247,6 +247,36 @@ def test_output_with_multiple_observed(filter_name, rng):
         )
 
 
+def test_square_root_filter_multivariate_log_likelihood():
+    rng = np.random.default_rng(0)
+    k_states, k_endog, n = 3, 2, 20
+
+    T = np.eye(k_states, dtype=floatX) * 0.9
+    R = np.eye(k_states, dtype=floatX)
+    Q = np.eye(k_states, dtype=floatX) * 0.5
+    Z = rng.normal(size=(k_endog, k_states)).astype(floatX)
+    H = np.eye(k_endog, dtype=floatX) * 0.3
+    a0 = np.zeros(k_states, dtype=floatX)
+    P0 = np.eye(k_states, dtype=floatX)
+    c = np.zeros(k_states, dtype=floatX)
+    d = np.zeros(k_endog, dtype=floatX)
+    data = rng.normal(size=(n, k_endog)).astype(floatX)
+
+    args = [data, a0, np.linalg.cholesky(P0), c, d, T, Z, R, H, Q]
+    outputs = SquareRootFilter().build_graph(*[pt.as_tensor(x) for x in args])
+    y_hat, F, loglike = pytensor.function([], [outputs[2], outputs[5], outputs[-1]])()
+
+    residual = data - y_hat
+    solved_residual = np.linalg.solve(F, residual[..., None])[..., 0]
+    sign, logdet = np.linalg.slogdet(F)
+    expected_loglike = -0.5 * (
+        k_endog * np.log(2 * np.pi) + logdet + np.einsum("ni,ni->n", residual, solved_residual)
+    )
+
+    assert np.all(sign > 0)
+    assert_allclose(loglike, expected_loglike, atol=ATOL, rtol=RTOL)
+
+
 @pytest.mark.parametrize("filter_name", filter_names)
 @pytest.mark.parametrize("p", [1, 5], ids=["univariate (p=1)", "multivariate (p=5)"])
 def test_missing_data(filter_name, p, rng):


### PR DESCRIPTION
Fixes the multivariate log-likelihood calculation in SquareRootFilter.
For k_endog > 1implementation had two issues:
    The Mahalanobis term usedCholesky factor, not  v.T @ F^-1 @ v = ||L^-1 v||².
    The log-determinant term was multiplied by k_endog.
My fix reuses the scaled residual L^-1 v from the filtering step to compute the quadratic term and corrects normalization.

Additionally, added a multivariate regression test that compares SquareRootFilter log-likelihood against computed multivariate Gaussian log-density.

For reference, reproducer from #744:
 Before: -41.378252 (expected: -53.142119)
After: -53.142119

Cases of k_endog = 1behavior remains unchanged.

All tests passed on my end.
Closes #744  