### PR TITLE
Fix the normalizing constant in the Kalman filter log-likelihood

### DIFF
--- a/pymc_extras/statespace/filters/kalman_filter.py
+++ b/pymc_extras/statespace/filters/kalman_filter.py
@@ -279,7 +279,7 @@ class BaseFilter(ABC):
 
     def handle_missing_values(
         self, y, Z, H, d
-    ) -> tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, float]:
+    ) -> tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]:
         """
         Handle missing values in the observation data ``y``.
 
@@ -290,8 +290,8 @@ class BaseFilter(ABC):
         :math:`v = y - (Z a + d)` is exactly zero there, so missing observations contribute nothing to the
         state update.
 
-        Return a binary flag tensor ``all_nan_flag`` indicating whether every component of the observation
-        is missing. This flag is used for numerical adjustments in the update method.
+        Return the boolean mask of missing entries as well, so the update step can score only the
+        observed components.
 
         Parameters
         ----------
@@ -321,8 +321,8 @@ class BaseFilter(ABC):
             this masking, missing rows of the innovation become :math:`-d`, injecting a fake observation
             into the state update and inflating the log-likelihood by :math:`d^2 / \\text{jitter}`.
 
-        all_nan_flag : float
-            1 if every component of the observation is missing.
+        nan_mask : TensorVariable
+            Boolean vector that is True at the missing components of the observation.
 
         References
         ----------
@@ -330,7 +330,6 @@ class BaseFilter(ABC):
                2nd ed, Oxford University Press, 2012.
         """
         nan_mask = pt.or_(pt.isnan(y), pt.eq(y, self.missing_fill_value))
-        all_nan_flag = pt.all(nan_mask).astype(pytensor.config.floatX)
         W = pt.diag(pt.bitwise_not(nan_mask).astype(pytensor.config.floatX))
 
         Z_masked = W.dot(Z)
@@ -338,7 +337,7 @@ class BaseFilter(ABC):
         d_masked = W.dot(d)
         y_masked = pt.set_subtensor(y[nan_mask], 0.0)
 
-        return y_masked, Z_masked, H_masked, d_masked, all_nan_flag
+        return y_masked, Z_masked, H_masked, d_masked, nan_mask
 
     @staticmethod
     def predict(a, P, c, T, R, Q) -> tuple[TensorVariable, TensorVariable]:
@@ -392,7 +391,7 @@ class BaseFilter(ABC):
 
     @staticmethod
     def update(
-        a, P, y, d, Z, H, all_nan_flag
+        a, P, y, d, Z, H, nan_mask
     ) -> tuple[TensorVariable, TensorVariable, TensorVariable, TensorVariable, TensorVariable]:
         """
         Perform the update step of the Kalman filter.
@@ -425,8 +424,8 @@ class BaseFilter(ABC):
             The matrix Z.
         H : TensorVariable
             The matrix H.
-        all_nan_flag : TensorVariable
-            A binary flag tensor indicating whether there are any missing values in the observation data.
+        nan_mask : TensorVariable
+            Boolean vector that is True at the missing components of the observation data.
 
         Returns
         -------
@@ -508,12 +507,10 @@ class BaseFilter(ABC):
                2nd ed, Oxford University Press, 2012.
         """
         y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
-        y_masked, Z_masked, H_masked, d_masked, all_nan_flag = self.handle_missing_values(
-            y, Z, H, d
-        )
+        y_masked, Z_masked, H_masked, d_masked, nan_mask = self.handle_missing_values(y, Z, H, d)
 
         a_filtered, P_filtered, obs_mu, obs_cov, ll = self.update(
-            y=y_masked, a=a, d=d_masked, P=P, Z=Z_masked, H=H_masked, all_nan_flag=all_nan_flag
+            y=y_masked, a=a, d=d_masked, P=P, Z=Z_masked, H=H_masked, nan_mask=nan_mask
         )
 
         P_filtered = stabilize(P_filtered, self.cov_jitter)
@@ -529,7 +526,7 @@ class StandardFilter(BaseFilter):
     Basic Kalman Filter
     """
 
-    def update(self, a, P, y, d, Z, H, all_nan_flag):
+    def update(self, a, P, y, d, Z, H, nan_mask):
         """
         Compute one-step forecasts for observed states conditioned on information up to, but not including, the current
         timestep, `y_hat`, along with the forcast covariance matrix, `F`. Marginalize over observed states to obtain
@@ -559,8 +556,8 @@ class StandardFilter(BaseFilter):
         H : TensorVariable
             Observation noise covariance matrix
 
-        all_nan_flag : TensorVariable
-            A flag indicating whether all elements in the data `y` are NaNs.
+        nan_mask : TensorVariable
+            Boolean vector that is True at the missing components of ``y``.
 
         Returns
         -------
@@ -580,7 +577,12 @@ class StandardFilter(BaseFilter):
         PZT = P.dot(Z.mT)
         F = Z.dot(PZT) + stabilize(H, self.cov_jitter)
 
-        F_chol = pt.linalg.cholesky(F, lower=True)
+        # A masked row of F holds only the stabilizing jitter, which log |F| would count as
+        # log(jitter). Put a one there instead; the gain and the innovation are zero on that row.
+        observed = pt.bitwise_not(nan_mask).astype(F.dtype)
+        F_scored = F * pt.outer(observed, observed) + pt.diag(1 - observed)
+
+        F_chol = pt.linalg.cholesky(F_scored, lower=True)
 
         K = pt.linalg.cho_solve((F_chol, True), PZT.mT).mT
         I_KZ = pt.eye(dim_of(a, 0)) - K.dot(Z)
@@ -593,11 +595,9 @@ class StandardFilter(BaseFilter):
 
         F_logdet = 2 * pt.log(pt.diag(F_chol)).sum()
 
-        ll = pt.switch(
-            all_nan_flag,
-            0.0,
-            -0.5 * (MVN_CONST + F_logdet + inner_term).ravel()[0],
-        )
+        # A fully missing observation scores zero: the count, the innovation and the
+        # log-determinant all vanish with it.
+        ll = -0.5 * (observed.sum() * MVN_CONST + F_logdet + inner_term).ravel()[0]
 
         return a_filtered, P_filtered, y_hat, F, ll
 
@@ -633,7 +633,7 @@ class SquareRootFilter(BaseFilter):
 
         return a_hat, P_chol_hat
 
-    def update(self, a, P, y, d, Z, H, all_nan_flag):
+    def update(self, a, P, y, d, Z, H, nan_mask):
         """
         Compute posterior estimates of the hidden state distributions conditioned on the observed data, up to and
         including the present timestep. Also compute the log-likelihood of the data given the one-step forecasts.
@@ -691,7 +691,7 @@ class SquareRootFilter(BaseFilter):
             """
             return [a, P_chol, pt.zeros(())]
 
-        degenerate = pt.eq(all_nan_flag, 1.0)
+        degenerate = pt.all(nan_mask)
         F_chol = pytensor.ifelse(degenerate, pt.eye(*F_chol.shape), F_chol)
         [a_filtered, P_chol_filtered, ll] = pytensor.ifelse(
             degenerate,
@@ -782,10 +782,7 @@ class UnivariateFilter(BaseFilter):
     def kalman_step(self, *args):
         y, a, P, c, d, T, Z, R, H, Q = self.unpack_args(args)
 
-        nan_mask = pt.or_(pt.isnan(y), pt.eq(y, self.missing_fill_value))
-        y_masked, Z_masked, H_masked, d_masked, all_nan_flag = self.handle_missing_values(
-            y, Z, H, d
-        )
+        y_masked, Z_masked, H_masked, d_masked, nan_mask = self.handle_missing_values(y, Z, H, d)
 
         result = pytensor.scan(
             self._univariate_inner_filter_step,
@@ -806,11 +803,7 @@ class UnivariateFilter(BaseFilter):
         P_filtered = stabilize(0.5 * (P_filtered + P_filtered.mT), self.cov_jitter)
         a_hat, P_hat = self.predict(a=a_filtered, P=P_filtered, c=c, T=T, R=R, Q=Q)
 
-        ll = pt.switch(
-            all_nan_flag,
-            0.0,
-            -0.5 * ((pt.neq(ll_inner, 0).sum()) * MVN_CONST + ll_inner.sum()),
-        )
+        ll = -0.5 * (pt.bitwise_not(nan_mask).sum() * MVN_CONST + ll_inner.sum())
 
         return a_filtered, a_hat, obs_mu, P_filtered, P_hat, obs_cov, ll
 
@@ -906,7 +899,7 @@ class ConvergentFilter(StandardFilter):
 
     def _kalman_step(self, y, a, P, c, d, T, Z, R, H, Q):
         a_filt, P_filt, y_hat, F, ll = self.update(
-            a=a, P=P, y=y, d=d, Z=Z, H=H, all_nan_flag=pt.constant(0.0)
+            a=a, P=P, y=y, d=d, Z=Z, H=H, nan_mask=pt.zeros((dim_of(Z, -2),), dtype=bool)
         )
         P_filt = stabilize(P_filt, self.cov_jitter)
         a_hat, P_hat = self.predict(a=a_filt, P=P_filt, c=c, T=T, R=R, Q=Q)
@@ -966,6 +959,8 @@ class ConvergentFilter(StandardFilter):
         k = pt.minimum(a_filt_tr.shape[0], n - 1)
         a_star, P_star = a_hat_tr[k - 1], P_hat_tr[k - 1]
 
+        k_endog = dim_of(Z, -2)
+
         # Tail constants from P*, hoisted so the tail scan body carries no Cholesky or solve.
         F_star = Z @ P_star @ Z.mT + stabilize(H, self.cov_jitter)
         F_chol_star = pt.linalg.cholesky(F_star, lower=True)
@@ -983,7 +978,7 @@ class ConvergentFilter(StandardFilter):
             y_hat = d + Z @ a_prev
             v = y - y_hat
             solved = solve_triangular(F_chol_star, v, lower=True)
-            ll = -0.5 * (MVN_CONST + logdet_F_star + (solved * solved).sum())
+            ll = -0.5 * (k_endog * MVN_CONST + logdet_F_star + (solved * solved).sum())
             a_filt = a_prev + K_star @ v
             return a_filt, T @ a_filt + c, y_hat, ll
 

--- a/tests/statespace/filters/test_kalman_filter.py
+++ b/tests/statespace/filters/test_kalman_filter.py
@@ -29,6 +29,7 @@ from tests.statespace.test_utilities import (
     initialize_filter,
     make_test_inputs,
     nile_test_test_helper,
+    statsmodels_loglike_obs,
 )
 
 floatX = pytensor.config.floatX
@@ -314,6 +315,75 @@ def test_missing_value_with_nondiagonal_obs_cov(filter_name, rng):
             rtol=RTOL,
             err_msg=f"{name} depends on H entries at masked positions",
         )
+
+
+LOGLIKE_TEST_K_ENDOG = 3
+
+
+def loglike_test_matrices(obs_cov: str):
+    """
+    Build the model filtered by :func:`test_loglike_matches_statsmodels`. A dense ``Z`` makes every
+    series load on every state, so a masked row of ``F`` carries cross-covariances that the update
+    has to clear -- the identity default of :func:`make_test_inputs` would hide a regression there.
+    """
+    p = m = r = LOGLIKE_TEST_K_ENDOG
+    _, a0, P0, c, d, T, _, R, _, Q = make_test_inputs(p, m, r, 1, rng=None)
+
+    Z = np.eye(p, m, dtype=floatX) + 0.3
+    H = np.eye(p, dtype=floatX) + (0.4 if obs_cov == "dense" else 0.0)
+
+    return [a0, P0, c, d, T, Z, R, H, Q]
+
+
+@cache
+def get_loglike_function(filter_name: str, obs_cov: str) -> Callable:
+    """Compile the per-timestep log-likelihood alone, which ``get_filter_function`` does not expose."""
+    filter_cls = {
+        "StandardFilter": StandardFilter,
+        "CholeskyFilter": SquareRootFilter,
+        "UnivariateFilter": UnivariateFilter,
+    }[filter_name]
+
+    a0, P0, c, d, T, Z, R, H, Q = loglike_test_matrices(obs_cov)
+    if filter_cls is SquareRootFilter:
+        P0 = np.linalg.cholesky(P0)
+
+    data = pt.tensor(name="data", dtype=floatX, shape=(None, LOGLIKE_TEST_K_ENDOG))
+    matrices = [pt.as_tensor_variable(x) for x in [a0, P0, c, d, T, Z, R, H, Q]]
+    ll_obs = filter_cls().build_graph(data, *matrices)[-1]
+
+    return pytensor.function([data], ll_obs)
+
+
+@pytest.mark.parametrize(
+    ("filter_name", "obs_cov"),
+    [
+        ("StandardFilter", "dense"),
+        ("UnivariateFilter", "diagonal"),
+        pytest.param(
+            "CholeskyFilter",
+            "dense",
+            marks=pytest.mark.xfail(
+                reason="SquareRootFilter scales log |F| by k_endog as well, see issue #744"
+            ),
+        ),
+    ],
+)
+def test_loglike_matches_statsmodels(filter_name, obs_cov, rng):
+    """
+    Each timestep scores the observed components of ``y_t``, so the per-timestep log-likelihood must
+    match statsmodels -- normalizing constant included -- however much of the observation is missing.
+    """
+    n = 20
+    data = rng.normal(size=(n, LOGLIKE_TEST_K_ENDOG)).astype(floatX)
+    data[3, 0] = np.nan
+    data[7, [0, 2]] = np.nan
+    data[11, :] = np.nan
+
+    ll_obs = get_loglike_function(filter_name, obs_cov)(data)
+    expected = statsmodels_loglike_obs(data, *loglike_test_matrices(obs_cov))
+
+    assert_allclose(ll_obs, expected, atol=ATOL, rtol=RTOL)
 
 
 @pytest.mark.parametrize("filter_name", filter_names)

--- a/tests/statespace/test_utilities.py
+++ b/tests/statespace/test_utilities.py
@@ -147,6 +147,24 @@ def get_sm_state_from_output_name(res, name):
         return getattr(sm_states, name[:-1]).reshape(-1, m, m)
 
 
+def statsmodels_loglike_obs(data, a0, P0, c, d, T, Z, R, H, Q):
+    """
+    Filter ``data`` through statsmodels with the given matrices and return its per-timestep
+    log-likelihood, for use as a reference. Missing entries of ``data`` are marked with ``NaN``.
+    """
+    mod = sm.tsa.statespace.MLEModel(data, k_states=T.shape[0], k_posdef=Q.shape[0])
+    mod.ssm["obs_intercept"] = np.expand_dims(d, -1)
+    mod.ssm["design"] = Z
+    mod.ssm["obs_cov"] = H
+    mod.ssm["state_intercept"] = np.expand_dims(c, -1)
+    mod.ssm["transition"] = T
+    mod.ssm["selection"] = R
+    mod.ssm["state_cov"] = Q
+    mod.ssm.initialize_known(a0, P0)
+
+    return mod.ssm.filter().llf_obs
+
+
 def nile_test_test_helper(rng, n_missing=0):
     a0 = np.zeros(2, dtype=floatX)
     P0 = np.eye(2, dtype=floatX) * 1e6


### PR DESCRIPTION
Scale standard scaler logp by the number of observed states to match the actual formula. 

No change to sampler behavior because it was just a normalizing constant. But it will make all the filters comparable and gives us the same answer as statsmodels. Also adds a test that we match statsmodels' implementation. 