### PR TITLE
Take the dataset size from the stream, not from len(data)

### DIFF
--- a/pymc_extras/inference/advi/objective.py
+++ b/pymc_extras/inference/advi/objective.py
@@ -57,7 +57,7 @@ def get_logp_logq(
     if logp_scalings:
         all_vars = model.free_RVs + model.observed_RVs + model.potentials
         logps = model.logp(vars=all_vars, sum=False)
-        scales = pt.constant([logp_scalings.get(var, 1.0) for var in all_vars])
+        scales = [pt.as_tensor_variable(logp_scalings.get(var, 1.0)) for var in all_vars]
         model_logp = pt.sum([pt.sum(logp) * scale for logp, scale in zip(logps, scales)])
     else:
         model_logp = model.logp()

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -120,6 +120,22 @@ class SVIState:
     loss_history: np.ndarray
 
 
+def _resolve_total_size(data, declared: int | None) -> int | None:
+    """Resolve the dataset row count N for a data stream.
+
+    ``len(data)`` is not consulted: for an iterable of batches it is the number of
+    batches, not of rows (see the DataLoader, whose ``__len__`` follows torch).
+    """
+    advertised = getattr(data, "total_size", None)
+    if declared is not None and advertised is not None and declared != advertised:
+        raise ValueError(
+            f"total_size={declared} was passed to fit, but the data stream advertises "
+            f"total_size={advertised}. One of them is wrong; drop the argument to use "
+            f"the stream's value."
+        )
+    return declared if declared is not None else advertised
+
+
 class Trainer:
     """
     Trainer for stochastic variational inference.
@@ -196,7 +212,7 @@ class Trainer:
         self._guide: AutoGuideModel | None = guide if isinstance(guide, AutoGuideModel) else None
         self._fit_model: Model | None = None
         self._stream_shareds: dict[str, SharedVariable] = {}
-        self._logp_scalings: dict[str, float] = {}
+        self._logp_scalings: dict[str, Any] = {}
         self._step_fn: TrainingFn | None = None
         self._shared_params: dict | None = None
         self._shared_optimizer_state: dict | None = None
@@ -292,7 +308,7 @@ class Trainer:
         first_batch: dict[str, Any],
         observeds: list | None,
         total_size: int | None,
-    ) -> tuple[Model, dict[str, SharedVariable], dict[str, float]]:
+    ) -> tuple[Model, dict[str, SharedVariable], dict[str, Any]]:
         """Bind the model to a data stream, observing the variables named in ``observeds``.
 
         A free RV in ``observeds`` is observed *once* with :func:`pymc.observe`,
@@ -305,19 +321,14 @@ class Trainer:
         log-likelihood of each variable in ``observeds`` is rescaled by
         ``N / batch_rows`` so the minibatch estimate is unbiased for the full-data
         one; variables already carrying their own ``total_size`` in the model are
-        left alone.
+        left alone. The scale is built from the observation's own shape, so it
+        follows the rows each batch actually carries.
 
         Returns the bound model, the shared variables the stream writes into, and the
         per-name likelihood scalings; the caller caches them on the trainer.
         """
         stream_shareds: dict[str, SharedVariable] = {}
-        logp_scalings: dict[str, float] = {}
-
-        def likelihood_scale(name: str) -> float | None:
-            if total_size is None or name not in first_batch:
-                return None
-            value = np.asarray(first_batch[name])
-            return total_size / (value.shape[0] if value.ndim else 1)
+        to_scale: set[str] = set()
 
         to_observe = {}
         for var in observeds or []:
@@ -326,7 +337,7 @@ class Trainer:
             if isinstance(var, SharedVariable):
                 # A pm.Data placeholder: rescale the observed RVs it is the
                 # observation of
-                if (scale := likelihood_scale(name)) is not None:
+                if total_size is not None and name in first_batch:
                     for rv in model.observed_RVs:
                         if isinstance(rv.owner.op, MinibatchRandomVariable):
                             # The model already rescales this likelihood: a total_size
@@ -335,7 +346,7 @@ class Trainer:
                             # N / batch_size factor, so adding ours would scale twice
                             continue
                         if var in ancestors([model.rvs_to_values[rv]]):
-                            logp_scalings[rv.name] = scale
+                            to_scale.add(rv.name)
                 continue
             if name not in first_batch:
                 raise ValueError(
@@ -344,8 +355,8 @@ class Trainer:
                 )
             value = np.asarray(first_batch[name], dtype=var.dtype)
             to_observe[name] = stream_shareds[name] = pytensor.shared(value, name=f"{name}_data")
-            if (scale := likelihood_scale(name)) is not None:
-                logp_scalings[name] = scale
+            if total_size is not None:
+                to_scale.add(name)
         if to_observe:
             model = pm.observe(model, to_observe)
 
@@ -356,18 +367,22 @@ class Trainer:
         # declares the observations via pm.Data.
         if total_size is not None:
             for name in first_batch:
-                if name in logp_scalings:
-                    continue  # already handled via observeds or a free RV above
-                var = model[name]
+                var = model[name] if name in model.named_vars else None
                 if not isinstance(var, SharedVariable):
                     continue
                 for rv in model.observed_RVs:
+                    if rv.name in to_scale:
+                        continue  # already handled via observeds or a free RV above
                     if isinstance(rv.owner.op, MinibatchRandomVariable):
                         continue
                     if var in ancestors([model.rvs_to_values[rv]]):
-                        value = np.asarray(first_batch[name])
-                        scale = total_size / (value.shape[0] if value.ndim else 1)
-                        logp_scalings[rv.name] = scale
+                        to_scale.add(rv.name)
+
+        # Build the scale from the observation's own shape, so a ragged batch is
+        # weighted by the rows it actually carries rather than by the first batch's.
+        logp_scalings = {
+            name: total_size / model.rvs_to_values[model[name]].shape[0] for name in to_scale
+        }
 
         return model, stream_shareds, logp_scalings
 
@@ -394,6 +409,7 @@ class Trainer:
         state: SVIState | None = None,
         model: Model | None = None,
         observeds: list | None = None,
+        total_size: int | None = None,
         random_seed=None,
     ) -> SVIState:
         """
@@ -416,26 +432,31 @@ class Trainer:
             ``set_data`` before the gradient update, so the model trains on one
             batch at a time. The batch axis is assumed to be the first (leftmost)
             axis of each array. Names listed in ``observeds`` may instead refer to
-            free RVs, see below. If the iterable supports ``len``, that is taken
-            as the total dataset row count ``N`` (as for a torch-style dataloader
-            that yields minibatches of a dataset of ``N`` rows).
+            free RVs, see below. If the iterable carries a ``total_size``
+            attribute, that is the dataset row count ``N``; ``len(data)`` is not
+            used for it, since for an iterable of batches ``len`` is the number of
+            batches.
         state : SVIState, optional
             Previous state to resume training from. If None, continues from the
             current state.
         model : Model, optional
             The PyMC model to fit. If None, the model is taken from the context
             stack.
+        total_size : int, optional
+            The dataset row count ``N``. Overrides a ``total_size`` attribute on
+            ``data``, and raises if the two disagree.
         observeds : list of str or variable, optional
             Variables whose entry in the ``data`` dictionaries is an observation.
             A variable that is a ``pm.Data`` placeholder is streamed into as usual;
             one that is instead a random variable is first converted to an observed
             RV with :func:`pymc.observe` (once, before compilation; the values then
             stream through a shared variable). Requires ``data``. When ``N`` is
-            known from ``len(data)``, each observation's log-likelihood is rescaled
-            by ``N / batch_rows``, making the minibatch ELBO an unbiased estimate
-            of the full-data one; without it batches are treated as the full
-            dataset and the posterior will be too wide. Variables that already
-            carry a ``total_size`` in the model are left alone.
+            known, each observation's log-likelihood is rescaled by
+            ``N / batch_rows``, making the minibatch ELBO an unbiased estimate of
+            the full-data one; without it batches are treated as the full dataset
+            and the posterior will be too wide. The row count is read from the
+            batch each step, so batches need not all be the same size. Variables
+            that already carry a ``total_size`` in the model are left alone.
         random_seed : optional
             Seed for the guide draws used to estimate the gradients.
 
@@ -451,10 +472,7 @@ class Trainer:
 
         stream = None
         if data is not None:
-            try:
-                total_size = len(data)
-            except TypeError:
-                total_size = None
+            total_size = _resolve_total_size(data, total_size)
             stream = iter(data)
             first_batch = next(stream, None)
             if first_batch is None:

--- a/pymc_extras/inference/advi/training.py
+++ b/pymc_extras/inference/advi/training.py
@@ -367,7 +367,7 @@ class Trainer:
         # declares the observations via pm.Data.
         if total_size is not None:
             for name in first_batch:
-                var = model[name] if name in model.named_vars else None
+                var = model[name]
                 if not isinstance(var, SharedVariable):
                     continue
                 for rv in model.observed_RVs:

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -337,14 +337,17 @@ def test_fit_after_streaming_refuses_to_reuse_the_last_batch():
     assert not np.allclose(continued.params["theta_loc"], streamed.params["theta_loc"])
 
 
-def test_fit_rescales_likelihood_when_stream_has_len():
+def test_fit_rescales_likelihood_when_stream_reports_total_size():
     rng = np.random.default_rng(0)
     full_data = rng.normal(1.0, 1.0, size=1_000)
 
     class Loader:
-        # A torch-style dataloader: yields minibatches, len is the dataset size N
+        # len is the number of batches, as for a torch DataLoader; the row count
+        # is advertised separately
+        total_size = 1_000
+
         def __len__(self):
-            return full_data.shape[0]
+            return 20
 
         def __iter__(self):
             while True:
@@ -423,3 +426,67 @@ def test_sample_posterior_with_explicit_model_after_streaming():
     np.testing.assert_allclose(theta_draws.mean(), 1.0, atol=0.15)
     # The user's model is untouched
     assert "y" not in [rv.name for rv in model.observed_RVs]
+
+
+def test_fit_ignores_len_as_a_row_count():
+    # len of an iterable of batches is the batch count; using it as N would
+    # scale the likelihood by 30 / 100 instead of 3000 / 100
+    rng = np.random.default_rng(0)
+    y = rng.normal(1.5, 1.0, 3_000)
+    batches = [{"y": y[i : i + 100]} for i in range(0, 3_000, 100)]
+
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 5)
+        data = pm.Data("y", batches[0]["y"])
+        pm.Normal("y_obs", mu, 1.0, observed=data)
+
+    trainer = Trainer()
+    trainer.fit(30, data=batches, model=model, random_seed=1)
+    assert trainer._logp_scalings == {}
+
+    trainer = Trainer()
+    trainer.fit(30, data=batches, model=model, total_size=3_000, random_seed=1)
+    [scale] = trainer._logp_scalings.values()
+    np.testing.assert_allclose(scale.eval(), 30.0)
+
+
+def test_fit_raises_when_total_size_disagrees_with_the_stream():
+    class Loader:
+        total_size = 3_000
+
+        def __iter__(self):
+            while True:
+                yield {"y": np.zeros(100)}
+
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 5)
+        data = pm.Data("y", np.zeros(100))
+        pm.Normal("y_obs", mu, 1.0, observed=data)
+
+    with pytest.raises(ValueError, match="advertises total_size"):
+        Trainer().fit(5, data=Loader(), model=model, total_size=9_999, random_seed=1)
+
+
+def test_fit_scales_each_batch_by_its_own_rows():
+    # the first batch is short; the scale must follow the rows actually streamed
+    rows = [37] + [100] * 29
+
+    class Loader:
+        total_size = 3_000
+
+        def __iter__(self):
+            while True:
+                for n in rows:
+                    yield {"y": np.zeros(n)}
+
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 5)
+        data = pm.Data("y", np.zeros(37))
+        pm.Normal("y_obs", mu, 1.0, observed=data)
+
+    trainer = Trainer()
+    trainer.fit(1, data=Loader(), model=model, random_seed=1)
+    [scale] = trainer._logp_scalings.values()
+    np.testing.assert_allclose(scale.eval(), 3_000 / 37)
+    model.set_data("y", np.zeros(100))
+    np.testing.assert_allclose(scale.eval(), 30.0)

--- a/tests/inference/advi/test_fit.py
+++ b/tests/inference/advi/test_fit.py
@@ -490,3 +490,26 @@ def test_fit_scales_each_batch_by_its_own_rows():
     np.testing.assert_allclose(scale.eval(), 3_000 / 37)
     model.set_data("y", np.zeros(100))
     np.testing.assert_allclose(scale.eval(), 30.0)
+
+
+def test_fit_scales_a_pm_data_variable_named_in_observeds():
+    rng = np.random.default_rng(0)
+    y = rng.normal(1.5, 1.0, 3_000)
+
+    class Loader:
+        total_size = 3_000
+
+        def __iter__(self):
+            while True:
+                for i in range(0, 3_000, 100):
+                    yield {"y": y[i : i + 100]}
+
+    with pm.Model() as model:
+        mu = pm.Normal("mu", 0, 5)
+        data = pm.Data("y", y[:100])
+        pm.Normal("y_obs", mu, 1.0, observed=data)
+
+    trainer = Trainer()
+    trainer.fit(5, data=Loader(), model=model, observeds=["y"], random_seed=1)
+    [scale] = trainer._logp_scalings.values()
+    np.testing.assert_allclose(scale.eval(), 30.0)


### PR DESCRIPTION
Closes #758.

N now comes from an explicit `total_size=` argument to `fit`, or from a `total_size` attribute on the stream. `len(data)` is not consulted, since for an iterable of batches it is the batch count. Passing both and having them disagree raises.

The scale is also built from the observation's shape instead of the first batch's row count, so it follows whatever each batch carries. `MinibatchRandomVariable` does the same thing with `get_scaling(total_size, value.shape)`.

Draft because two things in here are your call, not mine:

- Dropping `len` as a source of N is a behaviour change. Anyone relying on it today gets no scaling instead of wrong scaling. Keeping it as a deprecated fallback would also work, I just went with what the issue said.
- I renamed and rewrote `test_fit_rescales_likelihood_when_stream_has_len`, since its loader returned N from `__len__`.

One gap this does not close: a real `torch.utils.data.DataLoader` has no `total_size` attribute, the row count is `len(loader.dataset)`. So it still gets no scaling here. Adding a `.dataset` fallback is about three lines if you want it, but it goes past what I described in the issue so I left it out.

Also unfixed and separate: the scale uses `shape[0]` without checking it is the batch axis, so a transposed 2-D observation is silently mis-scaled. Happy to file that on its own.

55 passed locally, pre-commit clean.
