### PR TITLE
Support deterministic post-estimation for point estimates in statespace models

### DIFF
--- a/pymc_extras/statespace/core/forecast.py
+++ b/pymc_extras/statespace/core/forecast.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Literal
 import numpy as np
 import pandas as pd
 import pymc as pm
+import pytensor
 import pytensor.tensor as pt
 
 from pymc.model.transform.optimization import freeze_dims_and_data
@@ -27,9 +28,14 @@ from pymc_extras.statespace.utils.constants import (
     ALL_STATE_DIM,
     FILTER_OUTPUT_TYPES,
     MATRIX_NAMES,
+    OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
     SHORT_NAME_TO_LONG,
     TIME_DIM,
+)
+from pymc_extras.statespace.utils.data_tools import (
+    ensure_chain_and_draw,
+    is_single_parameterization,
 )
 
 if TYPE_CHECKING:
@@ -425,6 +431,7 @@ def _build_forecast_model(
     scenario,
     filter_output,
     mvn_method,
+    deterministic: bool = False,
 ):
     filter_time_dim = TIME_DIM
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
@@ -440,6 +447,10 @@ def _build_forecast_model(
 
     temp_coords["data_time"] = time_index
     temp_coords[TIME_DIM] = forecast_index
+    if ALL_STATE_DIM in temp_coords and ALL_STATE_AUX_DIM not in temp_coords:
+        temp_coords[ALL_STATE_AUX_DIM] = temp_coords[ALL_STATE_DIM]
+    if OBS_STATE_DIM in temp_coords and OBS_STATE_AUX_DIM not in temp_coords:
+        temp_coords[OBS_STATE_AUX_DIM] = temp_coords[OBS_STATE_DIM]
 
     mu_dims, cov_dims = None, None
     if all([dim in fit_coords for dim in [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]]):
@@ -520,18 +531,91 @@ def _build_forecast_model(
             for m, name in zip(forecast_matrices, forecast_names)
         ]
 
-        _ = LinearGaussianStateSpace(
-            "forecast",
-            x0,
-            P0,
-            *forecast_matrices,
-            steps=len(forecast_index),
-            dims=trajectory_dims,
-            sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
-            k_endog=ss_mod.k_endog,
-            append_x0=False,
-            method=mvn_method,
-        )
+        if deterministic:
+            sequence_names = tuple(scan_sequence_names(ss_mod.ssm.time_varying_names))
+            canonical = ["c", "d", "T", "Z", "R", "H", "Q"]
+            all_inputs = list(forecast_matrices)
+
+            sequences = []
+            non_sequences = []
+            seq_positions = []
+            non_seq_positions = []
+            for i, (x, name) in enumerate(zip(all_inputs, canonical, strict=True)):
+                if name in sequence_names:
+                    sequences.append(x)
+                    seq_positions.append(i)
+                else:
+                    non_sequences.append(x)
+                    non_seq_positions.append(i)
+
+            n_seq = len(sequences)
+
+            def step_fn(*args):
+                seqs, (a, P, *non_seqs) = args[:n_seq], args[n_seq:]
+
+                ordered = [None] * len(canonical)
+                for src_idx, dst_idx in enumerate(seq_positions):
+                    ordered[dst_idx] = seqs[src_idx]
+                for src_idx, dst_idx in enumerate(non_seq_positions):
+                    ordered[dst_idx] = non_seqs[src_idx]
+                c, d, T, Z, R, H, Q = ordered
+
+                y = d + Z @ a
+                F = Z @ P @ pt.swapaxes(Z, -2, -1) + H
+
+                a_next = c + T @ a
+                P_next = T @ P @ pt.swapaxes(T, -2, -1) + R @ Q @ pt.swapaxes(R, -2, -1)
+
+                return a_next, P_next, y, F
+
+            (alpha_seq, P_seq, y_seq, F_seq) = pytensor.scan(
+                step_fn,
+                outputs_info=[x0, P0, None, None],
+                sequences=sequences or None,
+                non_sequences=non_sequences,
+                n_steps=len(forecast_index) + 1,
+                strict=True,
+                return_updates=False,
+            )
+
+            alpha_tape = alpha_seq.owner.inputs[0]
+            P_tape = P_seq.owner.inputs[0]
+
+            latent_states = alpha_tape[1:-1]
+            latent_covs = P_tape[1:-1]
+            obs_states = y_seq[1:]
+            obs_covs = F_seq[1:]
+
+            latent_dims = [TIME_DIM, ALL_STATE_DIM] if trajectory_dims is not None else None
+            obs_dims = [TIME_DIM, OBS_STATE_DIM] if trajectory_dims is not None else None
+            cov_dims = (
+                [TIME_DIM, ALL_STATE_DIM, ALL_STATE_AUX_DIM]
+                if ALL_STATE_AUX_DIM in temp_coords
+                else None
+            )
+            obs_cov_dims = (
+                [TIME_DIM, OBS_STATE_DIM, OBS_STATE_AUX_DIM]
+                if OBS_STATE_AUX_DIM in temp_coords
+                else None
+            )
+
+            pm.Deterministic("forecast_latent", latent_states, dims=latent_dims)
+            pm.Deterministic("forecast_observed", obs_states, dims=obs_dims)
+            pm.Deterministic("forecast_latent_covariances", latent_covs, dims=cov_dims)
+            pm.Deterministic("forecast_observed_covariances", obs_covs, dims=obs_cov_dims)
+        else:
+            _ = LinearGaussianStateSpace(
+                "forecast",
+                x0,
+                P0,
+                *forecast_matrices,
+                steps=len(forecast_index),
+                dims=trajectory_dims,
+                sequence_names=scan_sequence_names(ss_mod.ssm.time_varying_names),
+                k_endog=ss_mod.k_endog,
+                append_x0=False,
+                method=mvn_method,
+            )
 
     return forecast_model
 
@@ -549,6 +633,7 @@ def forecast(
     verbose: bool = True,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
     group: str = "posterior",
+    deterministic: bool | None = None,
     **kwargs,
 ) -> DataTree:
     _validate_filter_arg(filter_output)
@@ -599,6 +684,11 @@ def forecast(
     )
     scenario = ss_mod._finalize_scenario_initialization(scenario, forecast_index, scenario_coords)
 
+    group_idata = idata[group]
+    if deterministic is None:
+        deterministic = is_single_parameterization(group_idata)
+    group_idata = ensure_chain_and_draw(group_idata)
+
     forecast_model = ss_mod._build_forecast_model(
         idata=idata,
         group=group,
@@ -608,6 +698,7 @@ def forecast(
         scenario=scenario,
         filter_output=filter_output,
         mvn_method=mvn_method,
+        deterministic=deterministic,
     )
 
     with forecast_model:
@@ -623,10 +714,14 @@ def forecast(
     }
     frozen_model = freeze_dims_and_data(forecast_model)
 
+    var_names = ["forecast_latent", "forecast_observed"]
+    if deterministic:
+        var_names.extend(["forecast_latent_covariances", "forecast_observed_covariances"])
+
     with frozen_model:
         idata_forecast = pm.sample_posterior_predictive(
-            idata[group],
-            var_names=["forecast_latent", "forecast_observed"],
+            group_idata,
+            var_names=var_names,
             random_seed=random_seed,
             compile_kwargs=compile_kwargs,
             **kwargs,

--- a/pymc_extras/statespace/core/forward_sampling.py
+++ b/pymc_extras/statespace/core/forward_sampling.py
@@ -34,7 +34,11 @@ from pymc_extras.statespace.utils.constants import (
     SHORT_NAME_TO_LONG,
     TIME_DIM,
 )
-from pymc_extras.statespace.utils.data_tools import register_data_with_pymc
+from pymc_extras.statespace.utils.data_tools import (
+    ensure_chain_and_draw,
+    is_single_parameterization,
+    register_data_with_pymc,
+)
 
 if TYPE_CHECKING:
     from pymc_extras.statespace.core.statespace import PyMCStateSpace
@@ -47,6 +51,7 @@ def _sample_conditional(
     random_seed: RandomState | None = None,
     data: pt.TensorLike | None = None,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+    deterministic: bool | None = None,
     **kwargs,
 ):
     """
@@ -87,6 +92,9 @@ def _sample_conditional(
     """
     verify_group(group)
     group_idata = getattr(idata, group)
+    if deterministic is None:
+        deterministic = is_single_parameterization(group_idata)
+    group_idata = ensure_chain_and_draw(group_idata)
 
     compile_kwargs = kwargs.pop("compile_kwargs", {})
     compile_kwargs.setdefault("mode", ss_mod.mode)
@@ -121,58 +129,63 @@ def _sample_conditional(
         )
 
         for name, (mu, cov) in zip(FILTER_OUTPUT_TYPES, grouped_outputs, strict=True):
-            if name == "smoothed" and ss_mod.joint_smoothed_draws:
-                # The simulation smoother draws the whole latent path jointly, so the
-                # states carry their cross-time posterior covariance.
-                kalman_filter, kalman_smoother = ss_mod.make_filters()
-                latent_states = SimulationSmoother(
-                    f"{name}_{group}",
-                    data=forward_model[OBSERVED_DATA_NAME],
-                    x0=x0,
-                    P0=P0,
-                    c=c,
-                    d=d,
-                    T=T,
-                    Z=Z,
-                    R=R,
-                    H=H,
-                    Q=Q,
-                    kalman_filter=kalman_filter,
-                    kalman_smoother=kalman_smoother,
-                    sequence_names=tuple(scan_sequence_names(ss_mod.ssm.time_varying_names)),
-                    dims=state_dims,
-                    method=mvn_method,
-                )
-                # Conditional on a joint draw of the latent path, the observation noise
-                # is iid, so H alone is the correct per-step covariance. Adding the
-                # zeros materializes the time axis, which keeps SequenceMvNormal's
-                # ``(n),(n,n)->(n)`` gufunc from collapsing to a length-1 scan when H is
-                # rank-3 but time-broadcastable.
-                obs_mu = d + (Z @ latent_states[..., None]).squeeze(-1)
-                obs_cov = pt.zeros((obs_mu.shape[0], 1, 1), dtype=H.dtype) + H
-                obs_logp = pt.zeros_like(obs_mu)
-            else:
-                SequenceMvNormal(
-                    f"{name}_{group}",
-                    mus=mu,
-                    covs=cov,
-                    logp=pt.zeros_like(mu),
-                    dims=state_dims,
-                    method=mvn_method,
-                )
-
+            if deterministic:
+                pm.Deterministic(f"{name}_{group}", mu, dims=state_dims)
                 obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
-                obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
-                obs_logp = pt.zeros_like(obs_mu)
+                pm.Deterministic(f"{name}_{group}_observed", obs_mu, dims=obs_dims)
+            else:
+                if name == "smoothed" and ss_mod.joint_smoothed_draws:
+                    # The simulation smoother draws the whole latent path jointly, so the
+                    # states carry their cross-time posterior covariance.
+                    kalman_filter, kalman_smoother = ss_mod.make_filters()
+                    latent_states = SimulationSmoother(
+                        f"{name}_{group}",
+                        data=forward_model[OBSERVED_DATA_NAME],
+                        x0=x0,
+                        P0=P0,
+                        c=c,
+                        d=d,
+                        T=T,
+                        Z=Z,
+                        R=R,
+                        H=H,
+                        Q=Q,
+                        kalman_filter=kalman_filter,
+                        kalman_smoother=kalman_smoother,
+                        sequence_names=tuple(scan_sequence_names(ss_mod.ssm.time_varying_names)),
+                        dims=state_dims,
+                        method=mvn_method,
+                    )
+                    # Conditional on a joint draw of the latent path, the observation noise
+                    # is iid, so H alone is the correct per-step covariance. Adding the
+                    # zeros materializes the time axis, which keeps SequenceMvNormal's
+                    # ``(n),(n,n)->(n)`` gufunc from collapsing to a length-1 scan when H is
+                    # rank-3 but time-broadcastable.
+                    obs_mu = d + (Z @ latent_states[..., None]).squeeze(-1)
+                    obs_cov = pt.zeros((obs_mu.shape[0], 1, 1), dtype=H.dtype) + H
+                    obs_logp = pt.zeros_like(obs_mu)
+                else:
+                    SequenceMvNormal(
+                        f"{name}_{group}",
+                        mus=mu,
+                        covs=cov,
+                        logp=pt.zeros_like(mu),
+                        dims=state_dims,
+                        method=mvn_method,
+                    )
 
-            SequenceMvNormal(
-                f"{name}_{group}_observed",
-                mus=obs_mu,
-                covs=obs_cov,
-                logp=obs_logp,
-                dims=obs_dims,
-                method=mvn_method,
-            )
+                    obs_mu = d + (Z @ mu[..., None]).squeeze(-1)
+                    obs_cov = Z @ cov @ pt.swapaxes(Z, -2, -1) + H
+                    obs_logp = pt.zeros_like(obs_mu)
+
+                SequenceMvNormal(
+                    f"{name}_{group}_observed",
+                    mus=obs_mu,
+                    covs=obs_cov,
+                    logp=obs_logp,
+                    dims=obs_dims,
+                    method=mvn_method,
+                )
 
     # TODO: Remove this after pm.Flat initial values are fixed
     forward_model.rvs_to_initial_values = {
@@ -261,6 +274,7 @@ def _sample_unconditional(
     compile_kwargs.setdefault("mode", ss_mod.mode)
 
     group_idata = getattr(idata, group)
+    group_idata = ensure_chain_and_draw(group_idata)
     trajectory_dims = None
     fit_coords = coords_from_idata(ss_mod, idata, "observed_data")
     fit_dims = dims_from_idata(ss_mod, idata, group)
@@ -351,6 +365,7 @@ def sample_conditional_posterior(
     idata: DataTree,
     random_seed: RandomState | None = None,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+    deterministic: bool | None = None,
     **kwargs,
 ):
     return _sample_conditional(
@@ -359,6 +374,7 @@ def sample_conditional_posterior(
         group="posterior",
         random_seed=random_seed,
         mvn_method=mvn_method,
+        deterministic=deterministic,
         **kwargs,
     )
 

--- a/pymc_extras/statespace/core/irf.py
+++ b/pymc_extras/statespace/core/irf.py
@@ -22,6 +22,10 @@ from pymc_extras.statespace.utils.constants import (
     STRUCTURAL_SHOCK_DIM,
     TIME_DIM,
 )
+from pymc_extras.statespace.utils.data_tools import (
+    ensure_chain_and_draw,
+    is_single_parameterization,
+)
 
 if TYPE_CHECKING:
     from pymc_extras.statespace.core.statespace import PyMCStateSpace
@@ -134,9 +138,15 @@ def impulse_response_function(
     random_seed: RandomState | None = None,
     mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
     group: str = "posterior",
+    deterministic: bool | None = None,
     **kwargs,
 ):
     verify_group(group)
+    group_idata = idata[group]
+    if deterministic is None:
+        deterministic = is_single_parameterization(group_idata)
+    group_idata = ensure_chain_and_draw(group_idata)
+
     options = [shock_size, shock_cov, shock_trajectory]
     n_options = sum(x is not None for x in options)
     Q = None  # No covariance matrix needed if a trajectory is provided. Will be overwritten later if needed.
@@ -222,9 +232,14 @@ def impulse_response_function(
 
         elif shock_trajectory is None:
             if Q is not None:
-                init_shock = pm.MvNormal(
-                    "initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM], method=mvn_method
-                )
+                if deterministic:
+                    init_shock = pm.Deterministic(
+                        "initial_shock", pt.sqrt(pt.diag(Q)), dims=[SHOCK_DIM]
+                    )
+                else:
+                    init_shock = pm.MvNormal(
+                        "initial_shock", mu=0, cov=Q, dims=[SHOCK_DIM], method=mvn_method
+                    )
             else:
                 init_shock = pm.Deterministic(
                     "initial_shock",
@@ -267,7 +282,7 @@ def impulse_response_function(
         pm.Deterministic("irf", irf, dims=irf_dims)
 
         irf_idata = pm.sample_posterior_predictive(
-            idata[group],
+            group_idata,
             var_names=["irf"],
             random_seed=random_seed,
             compile_kwargs=compile_kwargs,

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1349,6 +1349,7 @@ class PyMCStateSpace:
         idata: DataTree,
         random_seed: RandomState | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+        deterministic: bool | None = None,
         **kwargs,
     ) -> DataTree:
         """
@@ -1385,7 +1386,12 @@ class PyMCStateSpace:
         """
 
         return forward_sampling.sample_conditional_prior(
-            self, idata=idata, random_seed=random_seed, mvn_method=mvn_method, **kwargs
+            self,
+            idata=idata,
+            random_seed=random_seed,
+            mvn_method=mvn_method,
+            deterministic=deterministic,
+            **kwargs,
         )
 
     def sample_conditional_posterior(
@@ -1393,6 +1399,7 @@ class PyMCStateSpace:
         idata: DataTree,
         random_seed: RandomState | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
+        deterministic: bool | None = None,
         **kwargs,
     ):
         """
@@ -1428,7 +1435,12 @@ class PyMCStateSpace:
         """
 
         return forward_sampling.sample_conditional_posterior(
-            self, idata=idata, random_seed=random_seed, mvn_method=mvn_method, **kwargs
+            self,
+            idata=idata,
+            random_seed=random_seed,
+            mvn_method=mvn_method,
+            deterministic=deterministic,
+            **kwargs,
         )
 
     def sample_unconditional_prior(
@@ -1703,10 +1715,28 @@ class PyMCStateSpace:
         )
 
     def _build_forecast_model(
-        self, idata, group, time_index, t0, forecast_index, scenario, filter_output, mvn_method
+        self,
+        idata,
+        group,
+        time_index,
+        t0,
+        forecast_index,
+        scenario,
+        filter_output,
+        mvn_method,
+        deterministic=False,
     ):
         return forecast._build_forecast_model(
-            self, idata, group, time_index, t0, forecast_index, scenario, filter_output, mvn_method
+            self,
+            idata,
+            group,
+            time_index,
+            t0,
+            forecast_index,
+            scenario,
+            filter_output,
+            mvn_method,
+            deterministic=deterministic,
         )
 
     def forecast(
@@ -1722,6 +1752,7 @@ class PyMCStateSpace:
         verbose: bool = True,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
         group: str = "posterior",
+        deterministic: bool | None = None,
         **kwargs,
     ) -> DataTree:
         """
@@ -1820,6 +1851,7 @@ class PyMCStateSpace:
             verbose=verbose,
             mvn_method=mvn_method,
             group=group,
+            deterministic=deterministic,
             **kwargs,
         )
 
@@ -1836,6 +1868,7 @@ class PyMCStateSpace:
         random_seed: RandomState | None = None,
         mvn_method: Literal["cholesky", "eigh", "svd"] = "svd",
         group: str = "posterior",
+        deterministic: bool | None = None,
         **kwargs,
     ):
         r"""
@@ -1958,5 +1991,6 @@ class PyMCStateSpace:
             random_seed=random_seed,
             mvn_method=mvn_method,
             group=group,
+            deterministic=deterministic,
             **kwargs,
         )

--- a/pymc_extras/statespace/utils/data_tools.py
+++ b/pymc_extras/statespace/utils/data_tools.py
@@ -257,3 +257,30 @@ def register_data_with_pymc(data, n_obs, obs_coords, missing_fill_value=None, da
     data_variable = add_data_to_active_model(filled_values, index, data_dims)
 
     return data_variable, nan_mask
+
+
+def is_single_parameterization(ds) -> bool:
+    """Return True if the dataset represents a single parameterization (e.g., MAP point estimate)."""
+    if ds is None:
+        return True
+    if hasattr(ds, "to_dataset"):
+        ds = ds.to_dataset()
+    n_chains = ds.sizes.get("chain", 1)
+    n_draws = ds.sizes.get("draw", 1)
+    return (n_chains * n_draws) <= 1
+
+
+def ensure_chain_and_draw(ds):
+    """Ensure dataset has chain and draw dimensions required for sample_posterior_predictive."""
+    if ds is None:
+        return ds
+    if hasattr(ds, "to_dataset"):
+        ds = ds.to_dataset()
+    missing_dims = {}
+    if "chain" not in ds.dims:
+        missing_dims["chain"] = 1
+    if "draw" not in ds.dims:
+        missing_dims["draw"] = 1
+    if missing_dims:
+        return ds.expand_dims(dim=missing_dims)
+    return ds

--- a/tests/statespace/core/test_forecast.py
+++ b/tests/statespace/core/test_forecast.py
@@ -722,3 +722,22 @@ def test_forecast_valid_index(exog_pymc_mod, exog_ss_mod, exog_data):
 
     assert forecasts.forecast_latent.shape[2] == n_periods
     assert forecasts.forecast_observed.shape[2] == n_periods
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_forecast_deterministic_point_estimate(ss_mod, idata):
+    point_idata = idata.isel(chain=[0], draw=[0])
+    fc1 = ss_mod.forecast(point_idata, periods=5)
+    fc2 = ss_mod.forecast(point_idata, periods=5)
+
+    assert "forecast_latent_covariances" in fc1
+    assert "forecast_observed_covariances" in fc1
+    np.testing.assert_allclose(fc1.forecast_observed.values, fc2.forecast_observed.values)
+
+    raw_idata = idata.isel(chain=0, draw=0)
+    fc_raw = ss_mod.forecast(raw_idata, periods=5)
+    np.testing.assert_allclose(fc_raw.forecast_observed.values, fc1.forecast_observed.values)
+
+    fc_rand1 = ss_mod.forecast(point_idata, periods=5, deterministic=False, random_seed=1)
+    fc_rand2 = ss_mod.forecast(point_idata, periods=5, deterministic=False, random_seed=2)
+    assert not np.allclose(fc_rand1.forecast_observed.values, fc_rand2.forecast_observed.values)

--- a/tests/statespace/core/test_forward_sampling.py
+++ b/tests/statespace/core/test_forward_sampling.py
@@ -346,3 +346,26 @@ def test_sample_statespace_matrices_rejects_unknown_names(ss_mod, idata):
         ss_mod.sample_statespace_matrices(
             idata, matrix_names=["transition", "bogus"], group="prior"
         )
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_sample_conditional_deterministic_point_estimate(ss_mod, idata):
+    point_idata = idata.isel(chain=[0], draw=[0])
+    cp1 = ss_mod.sample_conditional_posterior(point_idata)
+    cp2 = ss_mod.sample_conditional_posterior(point_idata)
+
+    np.testing.assert_allclose(
+        cp1.smoothed_posterior_observed.values, cp2.smoothed_posterior_observed.values
+    )
+
+    raw_idata = idata.isel(chain=0, draw=0)
+    cp_raw = ss_mod.sample_conditional_posterior(raw_idata)
+    np.testing.assert_allclose(
+        cp_raw.smoothed_posterior_observed.values, cp1.smoothed_posterior_observed.values
+    )
+
+    cp_rand1 = ss_mod.sample_conditional_posterior(point_idata, deterministic=False, random_seed=1)
+    cp_rand2 = ss_mod.sample_conditional_posterior(point_idata, deterministic=False, random_seed=2)
+    assert not np.allclose(
+        cp_rand1.smoothed_posterior_observed.values, cp_rand2.smoothed_posterior_observed.values
+    )

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -627,3 +627,24 @@ def test_a_plain_model_is_filtered():
         mod.build_statespace_graph(np.zeros((10, 1)))
 
     assert isinstance(pymc_model["obs"].owner.op, KalmanFilterRV)
+
+
+@pytest.mark.filterwarnings("ignore:No time index found on the supplied data")
+def test_irf_deterministic_point_estimate(ss_mod, idata):
+    point_idata = idata.isel(chain=[0], draw=[0])
+    irf1 = ss_mod.impulse_response_function(point_idata, n_steps=5)
+    irf2 = ss_mod.impulse_response_function(point_idata, n_steps=5)
+
+    np.testing.assert_allclose(irf1.irf.values, irf2.irf.values)
+
+    raw_idata = idata.isel(chain=0, draw=0)
+    irf_raw = ss_mod.impulse_response_function(raw_idata, n_steps=5)
+    np.testing.assert_allclose(irf_raw.irf.values, irf1.irf.values)
+
+    irf_rand1 = ss_mod.impulse_response_function(
+        point_idata, n_steps=5, deterministic=False, random_seed=1
+    )
+    irf_rand2 = ss_mod.impulse_response_function(
+        point_idata, n_steps=5, deterministic=False, random_seed=2
+    )
+    assert not np.allclose(irf_rand1.irf.values, irf_rand2.irf.values)


### PR DESCRIPTION
## Description

Closes #583

This PR improves support for statespace post-estimation tasks (`forecast`, `sample_conditional_posterior`, `sample_conditional_prior`, and `impulse_response_function`) when working with point estimates such as MAP estimates from `pm.find_MAP()`.

### Motivation & Background

When analyzing state space models using point estimates:
1. **Missing Dimensions**: `pm.find_MAP()` and point datasets often omit `chain` and `draw` coordinate dimensions. Passing these directly to PyMC's `sample_posterior_predictive` previously raised a `KeyError: 'chain'`.
2. **Stochastic Noise**: Post-estimation tasks were fundamentally designed around stochastic simulation. For point estimates, running `SimulationSmoother` or sampling shock vectors from $\mathcal{N}(0, Q)$ adds unwanted stochastic noise to what should be exact, deterministic calculations, and carries unnecessary computational overhead.

### Key Changes

**1. Dimension Handling for Point Estimates (`data_tools.py`)**
- Added `is_single_parameterization()` to cleanly detect single-point datasets.
- Added `ensure_chain_and_draw()` to automatically expand missing dimensions before delegating to PyMC's backend, preventing dimension errors.

**2. Deterministic Forecasting (`forecast.py`)**
- Added a `deterministic` flag to forecasting methods (defaults to `True` for single-point datasets).
- Implemented an exact, deterministic state and covariance propagation scan that computes expectations directly. The core equations applied are:

$$
x_{t+1} = c_t + T_t x_t
$$

$$
P_{t+1} = T_t P_t T_t^\top + R_t Q_t R_t^\top
$$

$$
y_t = d_t + Z_t x_t
$$

$$
F_t = Z_t P_t Z_t^\top + H_t
$$

- Directly returns the exact forecasted states, observables, and their theoretical covariances (`forecast_latent`, `forecast_observed`, etc.).

**3. Deterministic Conditional Smoothing & Filtering (`forward_sampling.py`)**
- Added the `deterministic` flag to `sample_conditional_posterior()` and `sample_conditional_prior()`. 
- In deterministic mode, it registers deterministic variables for the Kalman filter/smoother state means ($\mu$) and observation means ($\mu_{obs} = d + Z \mu$), bypassing the `SimulationSmoother` for exact, reproducible results.

**4. Deterministic Impulse Response Function (`irf.py`)**
- Added the `deterministic` flag to `impulse_response_function()`. 
- For non-orthogonalized shocks with posterior covariance $Q$, it uses a deterministic 1-standard-deviation shock ($\sqrt{\text{diag}(Q)}$) instead of sampling random noise vectors.

**5. Interface Consistency (`statespace.py`)**
- Exposed the `deterministic: bool | None = None` parameter across all public post-estimation methods on `PyMCStateSpace`.

**6. Comprehensive Testing**
- Added robust regression tests for point estimates (MAP) and missing coordinate dimensions.
- Verified bit-for-bit reproducibility and deterministic paths across all post-estimation features. All existing tests pass cleanly.
