### PR TITLE
fix: keep tensor parameters wired in create_likelihood_variable

### DIFF
--- a/pymc_extras/prior.py
+++ b/pymc_extras/prior.py
@@ -1432,9 +1432,11 @@ class Prior:
         if "mu" in self.parameters:
             raise MuAlreadyExistsError(self)
 
+        # Rebind the original parameters instead of keeping the deep copies. A
+        # deep copy of a pytensor variable is a detached clone, so a pm.Data
+        # parameter would stop tracking pm.set_data updates.
         distribution = self.deepcopy()
-        distribution.parameters["mu"] = mu
-        distribution.parameters["observed"] = observed
+        distribution.parameters = {**self.parameters, "mu": mu, "observed": observed}
         return distribution.create_variable(name, xdist=xdist)
 
 
@@ -1678,8 +1680,10 @@ class Censored:
         if "mu" in self.distribution.parameters:
             raise MuAlreadyExistsError(self.distribution)
 
+        # See the note in Prior.create_likelihood_variable: the deep copies of
+        # the parameters have to be replaced by the originals.
         distribution = self.distribution.deepcopy()
-        distribution.parameters["mu"] = mu
+        distribution.parameters = {**self.distribution.parameters, "mu": mu}
         dist = distribution.create_variable(name, xdist=xdist)
         _remove_random_variable(var=dist)
 

--- a/tests/test_prior.py
+++ b/tests/test_prior.py
@@ -599,6 +599,24 @@ def test_create_likelihood_variable() -> None:
     assert "data_sigma" in model
 
 
+def test_create_likelihood_variable_keeps_data_parameter() -> None:
+    """A pm.Data parameter has to stay wired, so pm.set_data reaches the likelihood."""
+    with pm.Model(coords={"T": range(3)}) as model:
+        sigma = pm.Data("sigma", 2.0)
+        Prior("Normal", sigma=sigma, dims="T").create_likelihood_variable(
+            "y", mu=np.zeros(3), observed=np.ones(3)
+        )
+
+    logp = model.compile_fn(model.logp(vars=[model["y"]], sum=True))
+    point = model.initial_point()
+
+    before = logp(point)
+    with model:
+        pm.set_data({"sigma": 50.0})
+
+    assert logp(point) != before
+
+
 def test_create_likelihood_variable_already_has_mu() -> None:
     distribution = Prior("Normal", mu=Prior("Normal"), sigma=Prior("HalfNormal"))
 
@@ -1188,6 +1206,24 @@ class TestCensored:
 
         point = {}
         np.testing.assert_allclose(logp(point), expected_logp(point))
+
+    def test_censored_likelihood_keeps_data_parameter(self) -> None:
+        """A pm.Data parameter has to stay wired, so pm.set_data reaches the likelihood."""
+        with pm.Model(coords={"T": range(3)}) as model:
+            sigma = pm.Data("sigma", 2.0)
+            normal = Prior("Normal", sigma=sigma, dims="T")
+            Censored(normal, lower=0).create_likelihood_variable(
+                "y", mu=np.zeros(3), observed=np.ones(3)
+            )
+
+        logp = model.compile_fn(model.logp(vars=[model["y"]], sum=True))
+        point = model.initial_point()
+
+        before = logp(point)
+        with model:
+            pm.set_data({"sigma": 50.0})
+
+        assert logp(point) != before
 
     def test_censored_with_tensor_variable(self) -> None:
         normal = Prior("Normal", dims="channel")


### PR DESCRIPTION
`Prior.create_likelihood_variable` opens with `self.deepcopy()`, and `Prior.__deepcopy__` rebuilds with `**copy.deepcopy(self.parameters)`. A `pm.Data` parameter comes out as a second shared variable holding the same value, so the likelihood is wired to the clone and `pm.set_data` never reaches it. No error and no warning, the logp just does not move.

The copy is there to keep `mu` and `observed` off the caller's prior. Rebinding the original parameter objects onto the copy keeps that property without cloning the graph.

`Censored.create_likelihood_variable` has the same pattern, so it is fixed too.

Reproduction from #764, logp before and after `pm.set_data({"sigma": 50.0})`:

```
main:  -5.211257141293855 -> -5.211257141293855
patch: -5.211257141293855 -> -14.493484615898456
```

A free RV passed as a parameter was detached the same way, but that path already failed at compile time with `Random variables detected in the logp graph`, so shared variables were the silent case.

One regression test per path, both fail on main.

Left out here: `__deepcopy__` also drops `core_dims`, so `dist == dist.deepcopy()` is False when `core_dims` is set. Separate issue?

Closes #764
