### PR TITLE
Evaluate stationary VAR likelihoods without a Kalman filter

### DIFF
--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -1000,7 +1000,7 @@ class PyMCStateSpace:
         )
 
         if _has_statespace_graph(pm_mod):
-            self._reenter_statespace_graph(filled_values, index)
+            self._reenter_statespace_graph(filled_values, index, missing)
             return
 
         for name in (OBSERVED_DATA_NAME, OBSERVED_LIKELIHOOD_NAME):
@@ -1074,7 +1074,7 @@ class PyMCStateSpace:
         )
 
     def _reenter_statespace_graph(
-        self, filled_values: np.ndarray, index: pd.Index | np.ndarray
+        self, filled_values: np.ndarray, index: pd.Index | np.ndarray, missing: np.ndarray
     ) -> None:
         """
         Point an already-built model at new data.
@@ -1088,14 +1088,44 @@ class PyMCStateSpace:
             New data, with missing values already filled.
         index : pandas Index or numpy array
             Time index of the new data.
+        missing : numpy array
+            Boolean mask over the new data, true where an observation is missing.
         """
         # Raises unless the model holds this template's parameters, so a template whose
         # specification has changed cannot silently inherit the graph another one built.
         self._insert_random_variables()
 
         self._verify_exogenous_data_spans(len(filled_values))
+        self._verify_likelihood_accepts_missing(missing)
 
         update_data_in_active_model(filled_values, index)
+
+    def _verify_likelihood_accepts_missing(self, missing: np.ndarray) -> None:
+        """
+        Raise if the built likelihood cannot represent missing values the new data holds.
+
+        Re-entry repoints an existing graph at new data rather than rebuilding it, so a model
+        whose likelihood was chosen against complete data keeps that likelihood however the data
+        changes. Only the Kalman filter marginalizes missing observations; anything else would
+        score the fill sentinel as if it were real.
+
+        Parameters
+        ----------
+        missing : numpy array
+            Boolean mask over the new data, true where an observation is missing.
+        """
+        if not missing.any():
+            return
+
+        likelihood = modelcontext(None)[OBSERVED_LIKELIHOOD_NAME]
+        if isinstance(likelihood.owner.op, KalmanFilterRV):
+            return
+
+        raise ValueError(
+            "The new observed data has missing values, but this model was built against complete "
+            "data and uses a likelihood that cannot marginalize them. Build the model into a "
+            "fresh pm.Model to have the likelihood chosen against the new data."
+        )
 
     def _verify_exogenous_data_spans(self, n_timesteps: int) -> None:
         """

--- a/pymc_extras/statespace/core/statespace.py
+++ b/pymc_extras/statespace/core/statespace.py
@@ -48,6 +48,7 @@ from pymc_extras.statespace.filters import (
 from pymc_extras.statespace.filters.distributions import (
     KalmanFilterRV,
     SequenceMvNormal,
+    StationaryVARRV,
 )
 from pymc_extras.statespace.filters.kalman_filter import BaseFilter
 from pymc_extras.statespace.utils.constants import (
@@ -92,6 +93,11 @@ def _validate_property(props, property_name, expected_type):
         )
 
 
+# Every op a statespace model registers as its observation likelihood. A variable named ``obs``
+# is only ours if one of these produced it, so a user's own variable is never mistaken for it.
+LIKELIHOOD_OPS = (KalmanFilterRV, StationaryVARRV)
+
+
 def _has_statespace_graph(model: Model) -> bool:
     """
     Return whether a state space build has already put an observation likelihood into ``model``.
@@ -112,7 +118,7 @@ def _has_statespace_graph(model: Model) -> bool:
     likelihood = model.named_vars.get(OBSERVED_LIKELIHOOD_NAME, None)
     if likelihood is None or likelihood.owner is None:
         return False
-    return isinstance(likelihood.owner.op, KalmanFilterRV)
+    return isinstance(likelihood.owner.op, LIKELIHOOD_OPS)
 
 
 class PyMCStateSpace:
@@ -565,7 +571,7 @@ class PyMCStateSpace:
         observed = [
             variable
             for variable in pymc_model.observed_RVs
-            if isinstance(variable.owner.op, KalmanFilterRV)
+            if isinstance(variable.owner.op, LIKELIHOOD_OPS)
         ]
         if not observed:
             raise ValueError(
@@ -986,7 +992,7 @@ class PyMCStateSpace:
         pm_mod = modelcontext(None)
 
         obs_coords = pm_mod.coords.get(OBS_STATE_DIM, None)
-        filled_values, index, _ = prepare_data_for_pymc(
+        filled_values, index, missing = prepare_data_for_pymc(
             data,
             n_obs=self.ssm.k_endog,
             obs_coords=obs_coords,
@@ -1013,26 +1019,59 @@ class PyMCStateSpace:
         # Order is important here: only call _insert_data_shape_into_n_timesteps after data has been registered.
         matrices = self._insert_data_shape_into_n_timesteps(matrices, data_variable)
 
+        obs_dims = FILTER_OUTPUT_DIMS["predicted_observed_states"]
+        obs_dims = obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
+
+        self.make_likelihood(data_variable, matrices, obs_dims, missing)
+        self._register_additional_statespace_variables()
+
+    def make_likelihood(
+        self,
+        data: pt.TensorVariable,
+        matrices: list[pt.TensorVariable],
+        dims: tuple[str, ...] | None,
+        missing: np.ndarray,
+    ) -> pt.TensorVariable:
+        """
+        Register the observation likelihood into the active model and return it.
+
+        The default runs this model's Kalman filter over ``data``. A subclass whose observation
+        density has a closed form overrides this to register that instead, deferring to
+        ``super()`` for the configurations its closed form does not cover.
+
+        Parameters
+        ----------
+        data : TensorVariable
+            Observed data, already registered in the active model.
+        matrices : list of TensorVariable
+            The state space matrices, with the model's variables and data substituted in.
+        dims : tuple of str, optional
+            Dims for the likelihood, or None when the model declares no matching coords.
+        missing : numpy array
+            Boolean mask over ``data``, true where an observation was missing. The Kalman filter
+            marginalizes those; a closed form generally cannot, so this is part of what decides
+            whether one applies.
+
+        Returns
+        -------
+        likelihood : TensorVariable
+            The registered observed variable.
+        """
         kalman_filter, _ = self.make_filters()
-        filter_outputs = kalman_filter.build_graph(pt.as_tensor_variable(data_variable), *matrices)
+        filter_outputs = kalman_filter.build_graph(pt.as_tensor_variable(data), *matrices)
 
         logp = filter_outputs.pop(-1)
         *_, observed_states = filter_outputs[:3]
         *_, observed_covariances = filter_outputs[3:]
 
-        obs_dims = FILTER_OUTPUT_DIMS["predicted_observed_states"]
-        obs_dims = obs_dims if all([dim in pm_mod.coords.keys() for dim in obs_dims]) else None
-
-        SequenceMvNormal(
+        return SequenceMvNormal(
             OBSERVED_LIKELIHOOD_NAME,
             mus=observed_states,
             covs=observed_covariances,
             logp=logp,
-            observed=data_variable,
-            dims=obs_dims,
+            observed=data,
+            dims=dims,
         )
-
-        self._register_additional_statespace_variables()
 
     def _reenter_statespace_graph(
         self, filled_values: np.ndarray, index: pd.Index | np.ndarray

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -717,9 +717,13 @@ def _effective_coefficients(coefficients, exog_coefficients, *, order, k_endog):
     Assemble :math:`C = [A_1 \ldots A_p, B, -A_1 B \ldots -A_p B]`.
 
     The residual against the stacked regressors is ``y_t - C @ W_t``, which lets the exogenous
-    case reuse the pure autoregressive trace expression unchanged. With no regressors the
-    trailing blocks are zero-width and :math:`C` reduces to :math:`A`.
+    case reuse the pure autoregressive trace expression unchanged. With no regressors :math:`C`
+    reduces to :math:`A`, and is returned as such: the zero-width blocks are equivalent, but
+    their gradient trips a PyTensor reshape rewrite that then logs a traceback per compile.
     """
+    if exog_coefficients.type.shape[-1] == 0:
+        return coefficients
+
     by_lag = coefficients.reshape((k_endog, order, k_endog)) @ exog_coefficients
 
     return pt.concatenate([coefficients, exog_coefficients, -by_lag.reshape((k_endog, -1))], axis=1)

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -712,6 +712,22 @@ def _lag_matrix(series, *, lags, order, n_rows):
     return series[index].reshape((n_rows, -1))
 
 
+def _stacked_regressors(series, exog, *, order, n_rows):
+    """Lag matrix ``W``, holding the regressors for every timestep from ``order`` onward.
+
+    The density and the predictive moments both contract against this, so they read it from one
+    place. Built differently in each, they would describe different models and nothing would say
+    so.
+    """
+    return pt.concatenate(
+        [
+            _lag_matrix(series, lags=range(1, order + 1), order=order, n_rows=n_rows),
+            _lag_matrix(exog, lags=range(0, order + 1), order=order, n_rows=n_rows),
+        ],
+        axis=1,
+    )
+
+
 def _effective_coefficients(coefficients, exog_coefficients, *, order, k_endog):
     r"""
     Assemble :math:`C = [A_1 \ldots A_p, B, -A_1 B \ldots -A_p B]`.
@@ -780,6 +796,47 @@ def _conditional_logp(
     )
 
 
+def _predictive_moments(coefficients, exog_coefficients, state_cov, exog, endog, *, order, k_endog):
+    """
+    One-step-ahead predictive moments, conditional on ``endog``.
+
+    These equal a Kalman filter's predicted observed states and covariances for the same model.
+
+    Returns
+    -------
+    means : TensorVariable
+        Of shape ``(T, k_endog)``.
+    covariances : TensorVariable
+        Of shape ``(T, k_endog, k_endog)``.
+    """
+    n_rows = endog.shape[0] - order
+    regressors = _stacked_regressors(endog, exog, order=order, n_rows=n_rows)
+    effective = _effective_coefficients(
+        coefficients, exog_coefficients, order=order, k_endog=k_endog
+    )
+
+    factor = _stationary_cholesky(coefficients, state_cov, order=order, k_endog=k_endog)
+    residuals = endog[:order] - exog[:order] @ exog_coefficients.T
+    whitened = pt.linalg.solve_triangular(
+        factor, residuals.reshape((order * k_endog,)), lower=True, b_ndim=1
+    )
+    blocked = factor.reshape((order, k_endog, order, k_endog))
+    diagonal = pt.diagonal(blocked, axis1=0, axis2=2).transpose(2, 0, 1)
+
+    means = pt.concatenate(
+        [
+            endog[:order] - (diagonal @ whitened.reshape((order, k_endog, 1))).squeeze(-1),
+            regressors @ effective.T,
+        ],
+        axis=0,
+    )
+    covariances = pt.concatenate(
+        [diagonal @ diagonal.mT, pt.broadcast_to(state_cov, (n_rows, k_endog, k_endog))], axis=0
+    )
+
+    return means, covariances
+
+
 def _var_order(coefficients):
     """Recover the lag order from the coefficient matrix, which must be statically shaped."""
     k_endog, width = coefficients.type.shape
@@ -800,7 +857,7 @@ def _var_order(coefficients):
 class StationaryVARRV(SymbolicRandomVariable):
     default_output = 1
     _print_name = ("StationaryVAR", "\\operatorname{StationaryVAR}")
-    extended_signature = "(k,l),(k,m),(k,k),(t,m),[rng]->[rng],(t,k)"
+    extended_signature = "(k,l),(k,m),(k,k),(t,m),(t,k),[rng]->[rng],(t,k)"
 
     def update(self, node: Node):
         return {node.inputs[-1]: node.outputs[0]}
@@ -843,10 +900,19 @@ class StationaryVAR(Continuous):
 
     @classmethod
     def dist(
-        cls, coefficients, state_cov, exog=None, exog_coefficients=None, *, steps=None, **kwargs
+        cls,
+        coefficients,
+        state_cov,
+        endog,
+        exog=None,
+        exog_coefficients=None,
+        *,
+        method="svd",
+        **kwargs,
     ):
         coefficients = pt.as_tensor_variable(coefficients)
         state_cov = pt.as_tensor_variable(state_cov)
+        endog = pt.as_tensor_variable(endog)
 
         if (exog is None) != (exog_coefficients is None):
             raise ValueError(
@@ -858,80 +924,67 @@ class StationaryVAR(Continuous):
         _, k_endog = _var_order(coefficients)
 
         if exog is None:
-            if steps is None:
-                raise ValueError("StationaryVAR needs steps when no exogenous data is given.")
-            exog = pt.zeros((steps, 0), dtype=coefficients.dtype)
+            exog = pt.zeros((endog.shape[0], 0), dtype=coefficients.dtype)
             exog_coefficients = pt.zeros((k_endog, 0), dtype=coefficients.dtype)
         else:
             exog = pt.as_tensor_variable(exog)
             exog_coefficients = pt.as_tensor_variable(exog_coefficients)
 
-        return super().dist([coefficients, exog_coefficients, state_cov, exog], **kwargs)
+        return super().dist(
+            [coefficients, exog_coefficients, state_cov, exog, endog], method=method, **kwargs
+        )
 
     @classmethod
-    def rv_op(cls, coefficients, exog_coefficients, state_cov, exog, size=None, rng=None):
+    def rv_op(
+        cls,
+        coefficients,
+        exog_coefficients,
+        state_cov,
+        exog,
+        endog,
+        method="svd",
+        size=None,
+        rng=None,
+    ):
         rng = normalize_rng_param(rng)
         order, k_endog = _var_order(coefficients)
 
         coefficients_, exog_coefficients_ = coefficients.type(), exog_coefficients.type()
-        state_cov_, exog_ = state_cov.type(), exog.type()
+        state_cov_, exog_, endog_ = state_cov.type(), exog.type(), endog.type()
         rng_ = rng.type()
 
-        steps_ = exog_.shape[0]
-        next_rng, standard = pt.random.normal(
-            size=(steps_, k_endog), rng=rng_, return_next_rng=True
+        means, covariances = _predictive_moments(
+            coefficients_,
+            exog_coefficients_,
+            state_cov_,
+            exog_,
+            endog_,
+            order=order,
+            k_endog=k_endog,
         )
-
-        # One draw of standard normals up front leaves the recursion deterministic, so no rng
-        # has to be threaded through the scan.
-        factor = _stationary_cholesky(coefficients_, state_cov_, order=order, k_endog=k_endog)
-        initial = (factor @ standard[:order].reshape((order * k_endog,))).reshape((order, k_endog))
-        innovations = standard[order:] @ pt.linalg.cholesky(state_cov_).T
-
-        def step(innovation, stack):
-            drawn = coefficients_ @ stack + innovation
-
-            return pt.concatenate([drawn, stack[:-k_endog]])
-
-        # The carried state is the lag stack, most recent block first. A multi-tap history would
-        # not do: ``taps=[-1]`` leaves the state an axis larger than it is at every other order.
-        recursed = pytensor.scan(
-            fn=step,
-            sequences=[innovations],
-            outputs_info=[initial[::-1].reshape((order * k_endog,))],
-            strict=True,
-            non_sequences=[],
-            return_updates=False,
+        next_rng, draws = multivariate_normal(
+            mean=means, cov=covariances, rng=rng_, method=method, return_next_rng=True
         )
-
-        latent = pt.concatenate([initial, recursed[:, :k_endog]], axis=0)
-        sequence = latent + exog_ @ exog_coefficients_.T
 
         op = StationaryVARRV(
-            inputs=[coefficients_, exog_coefficients_, state_cov_, exog_, rng_],
-            outputs=[next_rng, sequence],
+            inputs=[coefficients_, exog_coefficients_, state_cov_, exog_, endog_, rng_],
+            outputs=[next_rng, draws],
             ndim_supp=2,
         )
 
-        return op(coefficients, exog_coefficients, state_cov, exog, rng)
+        return op(coefficients, exog_coefficients, state_cov, exog, endog, rng)
 
 
 @_logprob.register(StationaryVARRV)
 def stationary_var_logp(
-    op, values, coefficients, exog_coefficients, state_cov, exog, rng, **kwargs
+    op, values, coefficients, exog_coefficients, state_cov, exog, endog, rng, **kwargs
 ):
     """Exact log-density of a stationary VAR, condensed onto cross-products of the value."""
     (value,) = values
     order, k_endog = _var_order(coefficients)
 
     n_rows = value.shape[0] - order
-    regressors = pt.concatenate(
-        [
-            _lag_matrix(value, lags=range(1, order + 1), order=order, n_rows=n_rows),
-            _lag_matrix(exog, lags=range(0, order + 1), order=order, n_rows=n_rows),
-        ],
-        axis=1,
-    )
+    regressors = _stacked_regressors(value, exog, order=order, n_rows=n_rows)
     response = value[order:]
 
     factor = _stationary_cholesky(coefficients, state_cov, order=order, k_endog=k_endog)

--- a/pymc_extras/statespace/filters/distributions.py
+++ b/pymc_extras/statespace/filters/distributions.py
@@ -8,6 +8,7 @@ from pymc.distributions.shape_utils import get_support_shape_1d
 from pymc.logprob.abstract import _logprob
 from pymc.pytensorf import intX, normalize_rng_param
 from pytensor.graph.basic import Node
+from pytensor.tensor.linalg import solve_discrete_lyapunov
 from pytensor.tensor.random import multivariate_normal
 
 floatX = pytensor.config.floatX
@@ -697,3 +698,259 @@ def simulation_smoother_logp(op, values, *inputs, **kwargs):
     # never scored. Return a zero matching the output's shape so PyMC's logp
     # introspection succeeds.
     return pt.zeros_like(values[0])
+
+
+def _lag_matrix(series, *, lags, order, n_rows):
+    """
+    Stack ``series`` at each of ``lags``, one block of columns per lag.
+
+    Row ``i`` holds the lags of timestep ``order + i``, so blocks taken from different series
+    line up even when they run over different lags.
+    """
+    index = pt.sub.outer(order + pt.arange(n_rows), pt.as_tensor_variable(list(lags)))
+
+    return series[index].reshape((n_rows, -1))
+
+
+def _effective_coefficients(coefficients, exog_coefficients, *, order, k_endog):
+    r"""
+    Assemble :math:`C = [A_1 \ldots A_p, B, -A_1 B \ldots -A_p B]`.
+
+    The residual against the stacked regressors is ``y_t - C @ W_t``, which lets the exogenous
+    case reuse the pure autoregressive trace expression unchanged. With no regressors the
+    trailing blocks are zero-width and :math:`C` reduces to :math:`A`.
+    """
+    by_lag = coefficients.reshape((k_endog, order, k_endog)) @ exog_coefficients
+
+    return pt.concatenate([coefficients, exog_coefficients, -by_lag.reshape((k_endog, -1))], axis=1)
+
+
+def _stationary_cholesky(coefficients, state_cov, *, order, k_endog):
+    """Lower Cholesky factor of the stationary covariance of ``[y_1, ..., y_order]``."""
+    k_states = k_endog * order
+
+    transition = pt.concatenate(
+        [coefficients, pt.pad(pt.eye(k_states - k_endog), [(0, 0), (0, k_endog)])], axis=0
+    )
+    noise = pt.pad(state_cov, [(0, k_states - k_endog)] * 2)
+    covariance = solve_discrete_lyapunov(transition, noise, method="bilinear")
+
+    # The solve gives the covariance of ``[y_t, ..., y_{t-order+1}]``, whose blocks run backwards
+    # in time; the forward stack needs them the other way round.
+    blocked = covariance.reshape((order, k_endog, order, k_endog))
+    forward = pt.flip(blocked, axis=(0, 2)).reshape((k_states, k_states))
+
+    return pt.linalg.cholesky(forward)
+
+
+def _initial_logp(cholesky_factor, residuals, *, order, k_endog):
+    """Log-density of the first ``order`` observations under the stationary distribution."""
+    stacked = residuals.reshape((order * k_endog,))
+    whitened = pt.linalg.solve_triangular(cholesky_factor, stacked, lower=True, b_ndim=1)
+
+    return (
+        -0.5 * order * k_endog * pt.log(2 * pt.pi)
+        - pt.log(pt.diag(cholesky_factor)).sum()
+        - 0.5 * (whitened**2).sum()
+    )
+
+
+def _conditional_logp(
+    effective, state_cov, *, endog_gram, cross_gram, regressor_gram, n_rows, k_endog
+):
+    """Log-density of the observations after the first ``order``, from cross-products alone."""
+    residual_gram = (
+        endog_gram
+        - effective @ cross_gram
+        - cross_gram.T @ effective.T
+        + pt.linalg.matrix_dot(effective, regressor_gram, effective.T)
+    )
+
+    cov_cholesky = pt.linalg.cholesky(state_cov)
+    whitened_gram = pt.linalg.cho_solve((cov_cholesky, True), residual_gram, b_ndim=2)
+
+    return (
+        -0.5 * n_rows * k_endog * pt.log(2 * pt.pi)
+        - n_rows * pt.log(pt.diag(cov_cholesky)).sum()
+        - 0.5 * pt.trace(whitened_gram)
+    )
+
+
+def _var_order(coefficients):
+    """Recover the lag order from the coefficient matrix, which must be statically shaped."""
+    k_endog, width = coefficients.type.shape
+    if k_endog is None or width is None:
+        raise ValueError(
+            "StationaryVAR needs the shape of its coefficient matrix to be known statically, "
+            f"but found {coefficients.type.shape}. Give the variable an explicit shape."
+        )
+    if width % k_endog:
+        raise ValueError(
+            f"StationaryVAR coefficients of shape {coefficients.type.shape} are not a whole "
+            f"number of {k_endog}-column lag blocks."
+        )
+
+    return width // k_endog, k_endog
+
+
+class StationaryVARRV(SymbolicRandomVariable):
+    default_output = 1
+    _print_name = ("StationaryVAR", "\\operatorname{StationaryVAR}")
+    extended_signature = "(k,l),(k,m),(k,k),(t,m),[rng]->[rng],(t,k)"
+
+    def update(self, node: Node):
+        return {node.inputs[-1]: node.outputs[0]}
+
+
+class StationaryVAR(Continuous):
+    r"""
+    A stationary vector autoregression observed without measurement error.
+
+    The joint density factors exactly as
+
+    .. math::
+        p(y_1 \ldots y_T) = p(y_1 \ldots y_p) \prod_{t > p} p(y_t \mid y_{t-1} \ldots y_{t-p})
+
+    The leading factor is the stationary distribution of the companion state. The product has a
+    banded precision matrix, so it collapses onto cross-products of the data against its own
+    lags, whose size depends on the lag structure and not on the number of timesteps.
+
+    Exogenous regressors enter the observation equation, so :math:`\tilde{y}_t = y_t - B x_t`
+    follows the pure autoregression and the density is exactly :math:`\tilde{y}`'s. The
+    banding, and so the density, requires observations free of measurement error, moving
+    average terms, and missing values.
+
+    Parameters
+    ----------
+    coefficients : tensor_like
+        ``A``, of shape ``(k_endog, k_endog * order)``, blocks running lag 1 through ``order``.
+        Its shape must be known statically, since the lag order is read from it.
+    state_cov : tensor_like
+        ``Q``, the innovation covariance, of shape ``(k_endog, k_endog)``.
+    exog : tensor_like, optional
+        Exogenous regressors, of shape ``(steps, k_exog)``.
+    exog_coefficients : tensor_like, optional
+        ``B``, of shape ``(k_endog, k_exog)``. Required when ``exog`` is given.
+    steps : int, optional
+        Number of timesteps to draw. Taken from ``exog`` when that is given.
+    """
+
+    rv_type = StationaryVARRV
+
+    @classmethod
+    def dist(
+        cls, coefficients, state_cov, exog=None, exog_coefficients=None, *, steps=None, **kwargs
+    ):
+        coefficients = pt.as_tensor_variable(coefficients)
+        state_cov = pt.as_tensor_variable(state_cov)
+
+        if (exog is None) != (exog_coefficients is None):
+            raise ValueError(
+                "StationaryVAR needs either both or neither of exog and exog_coefficients, "
+                f"but exog is {'absent' if exog is None else 'present'} and exog_coefficients "
+                f"is {'absent' if exog_coefficients is None else 'present'}."
+            )
+
+        _, k_endog = _var_order(coefficients)
+
+        if exog is None:
+            if steps is None:
+                raise ValueError("StationaryVAR needs steps when no exogenous data is given.")
+            exog = pt.zeros((steps, 0), dtype=coefficients.dtype)
+            exog_coefficients = pt.zeros((k_endog, 0), dtype=coefficients.dtype)
+        else:
+            exog = pt.as_tensor_variable(exog)
+            exog_coefficients = pt.as_tensor_variable(exog_coefficients)
+
+        return super().dist([coefficients, exog_coefficients, state_cov, exog], **kwargs)
+
+    @classmethod
+    def rv_op(cls, coefficients, exog_coefficients, state_cov, exog, size=None, rng=None):
+        rng = normalize_rng_param(rng)
+        order, k_endog = _var_order(coefficients)
+
+        coefficients_, exog_coefficients_ = coefficients.type(), exog_coefficients.type()
+        state_cov_, exog_ = state_cov.type(), exog.type()
+        rng_ = rng.type()
+
+        steps_ = exog_.shape[0]
+        next_rng, standard = pt.random.normal(
+            size=(steps_, k_endog), rng=rng_, return_next_rng=True
+        )
+
+        # One draw of standard normals up front leaves the recursion deterministic, so no rng
+        # has to be threaded through the scan.
+        factor = _stationary_cholesky(coefficients_, state_cov_, order=order, k_endog=k_endog)
+        initial = (factor @ standard[:order].reshape((order * k_endog,))).reshape((order, k_endog))
+        innovations = standard[order:] @ pt.linalg.cholesky(state_cov_).T
+
+        def step(innovation, stack):
+            drawn = coefficients_ @ stack + innovation
+
+            return pt.concatenate([drawn, stack[:-k_endog]])
+
+        # The carried state is the lag stack, most recent block first. A multi-tap history would
+        # not do: ``taps=[-1]`` leaves the state an axis larger than it is at every other order.
+        recursed = pytensor.scan(
+            fn=step,
+            sequences=[innovations],
+            outputs_info=[initial[::-1].reshape((order * k_endog,))],
+            strict=True,
+            non_sequences=[],
+            return_updates=False,
+        )
+
+        latent = pt.concatenate([initial, recursed[:, :k_endog]], axis=0)
+        sequence = latent + exog_ @ exog_coefficients_.T
+
+        op = StationaryVARRV(
+            inputs=[coefficients_, exog_coefficients_, state_cov_, exog_, rng_],
+            outputs=[next_rng, sequence],
+            ndim_supp=2,
+        )
+
+        return op(coefficients, exog_coefficients, state_cov, exog, rng)
+
+
+@_logprob.register(StationaryVARRV)
+def stationary_var_logp(
+    op, values, coefficients, exog_coefficients, state_cov, exog, rng, **kwargs
+):
+    """Exact log-density of a stationary VAR, condensed onto cross-products of the value."""
+    (value,) = values
+    order, k_endog = _var_order(coefficients)
+
+    n_rows = value.shape[0] - order
+    regressors = pt.concatenate(
+        [
+            _lag_matrix(value, lags=range(1, order + 1), order=order, n_rows=n_rows),
+            _lag_matrix(exog, lags=range(0, order + 1), order=order, n_rows=n_rows),
+        ],
+        axis=1,
+    )
+    response = value[order:]
+
+    factor = _stationary_cholesky(coefficients, state_cov, order=order, k_endog=k_endog)
+    residuals = value[:order] - exog[:order] @ exog_coefficients.T
+    initial = _initial_logp(factor, residuals, order=order, k_endog=k_endog)
+
+    effective = _effective_coefficients(
+        coefficients, exog_coefficients, order=order, k_endog=k_endog
+    )
+    conditional = _conditional_logp(
+        effective,
+        state_cov,
+        endog_gram=response.T @ response,
+        cross_gram=regressors.T @ response,
+        regressor_gram=regressors.T @ regressors,
+        n_rows=n_rows,
+        k_endog=k_endog,
+    )
+
+    return check_parameters(
+        initial + conditional,
+        pt.eq(value.shape[0], exog.shape[0]),
+        pt.gt(value.shape[0], order),
+        msg="Observed data and exogenous data must span the same number of timesteps, and the "
+        "series must be longer than the lag order",
+    )

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -527,9 +527,9 @@ class BayesianSARIMAX(PyMCStateSpace):
             OBSERVED_LIKELIHOOD_NAME,
             transition[:, 0][None, :],
             state_cov,
+            data,
             exog=exog,
             exog_coefficients=exog_coefficients,
-            steps=data.shape[0],
             observed=data,
             dims=dims,
         )

--- a/pymc_extras/statespace/models/SARIMAX.py
+++ b/pymc_extras/statespace/models/SARIMAX.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 import numpy as np
 import pytensor.tensor as pt
 
+from pymc.model import modelcontext
 from pytensor.compile.mode import Mode
 from pytensor.tensor.linalg import solve_discrete_lyapunov
 
@@ -14,6 +15,7 @@ from pymc_extras.statespace.core.properties import (
     State,
 )
 from pymc_extras.statespace.core.statespace import PyMCStateSpace, floatX
+from pymc_extras.statespace.filters.distributions import StationaryVAR
 from pymc_extras.statespace.models.utilities import (
     make_harvey_state_names,
     make_SARIMA_transition_matrix,
@@ -27,6 +29,7 @@ from pymc_extras.statespace.utils.constants import (
     JITTER_DEFAULT,
     MA_PARAM_DIM,
     MISSING_FILL,
+    OBSERVED_LIKELIHOOD_NAME,
     SARIMAX_STATE_STRUCTURES,
     SEASONAL_AR_PARAM_DIM,
     SEASONAL_MA_PARAM_DIM,
@@ -495,6 +498,41 @@ class BayesianSARIMAX(PyMCStateSpace):
         P0 = solve_discrete_lyapunov(T, pt.linalg.matrix_dot(R, Q, R.T), method="bilinear")
 
         return x0, P0
+
+    def make_likelihood(self, data, matrices, dims, missing):
+        """
+        Register a :class:`~pymc_extras.statespace.filters.distributions.StationaryVAR`.
+
+        The closed form covers a pure autoregression, seasonal or not, with no measurement error
+        and a stationary initialization -- which also rules out differencing, since the two
+        cannot be combined. Anything else is filtered,
+        including data with missing values, which only the filter marginalizes.
+        """
+        if self.q > 0 or self.Q > 0 or self.p + self.P == 0 or self.measurement_error:
+            return super().make_likelihood(data, matrices, dims, missing)
+        if not self.stationary_initialization or self.state_structure != "fast":
+            return super().make_likelihood(data, matrices, dims, missing)
+        if missing.any():
+            return super().make_likelihood(data, matrices, dims, missing)
+
+        pymc_model = modelcontext(None)
+        *_, transition, _, _, _, state_cov = matrices
+
+        exog = pymc_model["exogenous_data"] if self.k_exog > 0 else None
+        exog_coefficients = pymc_model["beta_exog"][None, :] if self.k_exog > 0 else None
+
+        # For a pure autoregression the Harvey representation carries the expanded multiplicative
+        # AR polynomial in the first column of the transition.
+        return StationaryVAR(
+            OBSERVED_LIKELIHOOD_NAME,
+            transition[:, 0][None, :],
+            state_cov,
+            exog=exog,
+            exog_coefficients=exog_coefficients,
+            steps=data.shape[0],
+            observed=data,
+            dims=dims,
+        )
 
     def make_symbolic_graph(self) -> None:
         p, d, q = self.p, self.d, self.q

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytensor
 import pytensor.tensor as pt
 
+from pymc.model import modelcontext
 from pytensor.compile.mode import Mode
 from pytensor.tensor.linalg import solve_discrete_lyapunov
 
@@ -13,6 +14,7 @@ from pymc_extras.statespace.core.properties import (
     State,
 )
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
+from pymc_extras.statespace.filters.distributions import StationaryVAR
 from pymc_extras.statespace.models.utilities import validate_names
 from pymc_extras.statespace.utils.constants import (
     ALL_STATE_AUX_DIM,
@@ -24,6 +26,7 @@ from pymc_extras.statespace.utils.constants import (
     MISSING_FILL,
     OBS_STATE_AUX_DIM,
     OBS_STATE_DIM,
+    OBSERVED_LIKELIHOOD_NAME,
     SHOCK_AUX_DIM,
     SHOCK_DIM,
     TIME_DIM,
@@ -391,6 +394,66 @@ class BayesianVARMAX(PyMCStateSpace):
 
     def add_default_priors(self):
         raise NotImplementedError
+
+    def make_likelihood(self, data, matrices, dims, missing):
+        """
+        Register a :class:`~pymc_extras.statespace.filters.distributions.StationaryVAR`.
+
+        The closed form covers an autoregression with no moving average terms and no measurement
+        error, initialized at its stationary distribution. Anything else is filtered,
+        including data with missing values, which only the filter marginalizes.
+        """
+        if self.q > 0 or self.p == 0 or self.measurement_error:
+            return super().make_likelihood(data, matrices, dims, missing)
+        if not self.stationary_initialization:
+            return super().make_likelihood(data, matrices, dims, missing)
+        if missing.any():
+            return super().make_likelihood(data, matrices, dims, missing)
+
+        k_endog = self.k_endog
+        *_, transition, _, _, _, state_cov = matrices
+        exog, exog_coefficients = self._exogenous_regression()
+
+        return StationaryVAR(
+            OBSERVED_LIKELIHOOD_NAME,
+            transition[:k_endog, : k_endog * self.p],
+            state_cov,
+            exog=exog,
+            exog_coefficients=exog_coefficients,
+            steps=data.shape[0],
+            observed=data,
+            dims=dims,
+        )
+
+    def _exogenous_regression(self):
+        """
+        Return exogenous data and coefficients whose product is the observation intercept.
+
+        Per-series regressors are laid end to end, against a block coefficient matrix whose
+        off-blocks are structurally zero.
+        """
+        if self.exog_state_names is None:
+            return None, None
+
+        pymc_model = modelcontext(None)
+
+        if isinstance(self.exog_state_names, list):
+            return pymc_model["exogenous_data"], pymc_model["beta_exog"]
+
+        widths = [len(self.exog_state_names.get(name, ())) for name in self.endog_names]
+        coefficients = pt.zeros((self.k_endog, sum(widths)), dtype=floatX)
+        data, offset = [], 0
+
+        for row, (name, width) in enumerate(zip(self.endog_names, widths)):
+            if width == 0:
+                continue
+            data.append(pymc_model[f"{name}_exogenous_data"])
+            coefficients = pt.set_subtensor(
+                coefficients[row, offset : offset + width], pymc_model[f"beta_{name}"]
+            )
+            offset += width
+
+        return pt.concatenate(data, axis=1), coefficients
 
     def make_symbolic_graph(self) -> None:
         # Initialize the matrices

--- a/pymc_extras/statespace/models/VARMAX.py
+++ b/pymc_extras/statespace/models/VARMAX.py
@@ -418,9 +418,9 @@ class BayesianVARMAX(PyMCStateSpace):
             OBSERVED_LIKELIHOOD_NAME,
             transition[:k_endog, : k_endog * self.p],
             state_cov,
+            data,
             exog=exog,
             exog_coefficients=exog_coefficients,
-            steps=data.shape[0],
             observed=data,
             dims=dims,
         )

--- a/tests/statespace/core/test_statespace.py
+++ b/tests/statespace/core/test_statespace.py
@@ -13,6 +13,7 @@ from pytensor.scan.op import Scan
 
 from pymc_extras.statespace import BayesianETS, BayesianSARIMAX, BayesianVARMAX
 from pymc_extras.statespace.core.statespace import FILTER_FACTORY, PyMCStateSpace
+from pymc_extras.statespace.filters.distributions import KalmanFilterRV
 from pymc_extras.statespace.models import structural as st
 from pymc_extras.statespace.models.DFM import BayesianDynamicFactor
 from pymc_extras.statespace.utils.constants import JITTER_DEFAULT, MISSING_FILL
@@ -501,3 +502,14 @@ def test_post_estimation_leaves_template_matrices_alone(
 
     assert all(x is y for x, y in zip(before, after, strict=True))
     assert not set(pymc_mod.basic_RVs).intersection(ancestors(after))
+
+
+def test_a_plain_model_is_filtered():
+    mod = make_statespace_mod(k_endog=1, k_states=2, k_posdef=1, filter_type="standard")
+
+    with pm.Model() as pymc_model:
+        pm.Flat("x0", shape=(2,))
+        pm.Flat("P0", shape=(2, 2))
+        mod.build_statespace_graph(np.zeros((10, 1)))
+
+    assert isinstance(pymc_model["obs"].owner.op, KalmanFilterRV)

--- a/tests/statespace/filters/test_distributions.py
+++ b/tests/statespace/filters/test_distributions.py
@@ -5,6 +5,8 @@ import pytensor.tensor as pt
 import pytest
 
 from numpy.testing import assert_allclose
+from pytensor.tensor.linalg import solve_discrete_lyapunov
+from scipy.linalg import solve_discrete_lyapunov as sp_solve_discrete_lyapunov
 from scipy.stats import multivariate_normal
 
 from pymc_extras.statespace import structural
@@ -12,6 +14,7 @@ from pymc_extras.statespace.filters.distributions import (
     LinearGaussianStateSpace,
     SequenceMvNormal,
     SimulationSmoother,
+    StationaryVAR,
     _forward_simulate_latent_and_obs,
     _LinearGaussianStateSpace,
 )
@@ -611,3 +614,160 @@ def test_simulation_smoother_against_statsmodels(rng):
     cov_sm = np.cov(sm_samples.reshape(n_draws, -1).T)
     assert_allclose(cov_ours, cov_sm, atol=0.05)
     assert_allclose(ours.mean(0), sm_samples.mean(0), atol=0.1)
+
+
+def _var_parameters(rng, k_endog, order, k_exog):
+    """Draw a stationary ``A``, a ``B``, and a positive-definite ``Q``.
+
+    ``A`` is shrunk by a fixed factor rather than by ``target / spectral_radius``: scaling ``A``
+    by ``c`` does not scale the companion eigenvalues by ``c`` once ``order > 1``, so the
+    proportional step converges to the target from above without ever crossing it.
+    """
+    A = rng.normal(scale=0.4, size=(k_endog, k_endog * order))
+    companion = np.zeros((k_endog * order, k_endog * order))
+    if order > 1:
+        companion[k_endog:, : k_endog * (order - 1)] = np.eye(k_endog * (order - 1))
+
+    while True:
+        companion[:k_endog] = A
+        if np.abs(np.linalg.eigvals(companion)).max() < 0.9:
+            break
+        A *= 0.9
+
+    factor = rng.normal(size=(k_endog, k_endog))
+    Q = factor @ factor.T + k_endog * np.eye(k_endog)
+
+    return A.astype(floatX), rng.normal(size=(k_endog, k_exog)).astype(floatX), Q.astype(floatX)
+
+
+def _var_logp_pair(k_endog, order, k_exog, n_timesteps=80):
+    """The distribution's log-density and a Kalman filter over the same model.
+
+    The reference is assembled from concatenations rather than from the distribution's own
+    companion-form helper: a shared constructor would let both sides be wrong together.
+    """
+    rng = np.random.default_rng(sum(map(ord, f"statvar{k_endog}{order}{k_exog}")))
+    A_true, B_true, Q_true = _var_parameters(rng, k_endog, order, k_exog)
+    exog = rng.normal(size=(n_timesteps, k_exog)).astype(floatX)
+
+    endog = np.zeros((n_timesteps, k_endog))
+    noise = rng.multivariate_normal(np.zeros(k_endog), Q_true, size=n_timesteps)
+    for t in range(n_timesteps):
+        lags = [endog[t - lag] if t >= lag else np.zeros(k_endog) for lag in range(1, order + 1)]
+        endog[t] = A_true @ np.concatenate(lags) + B_true @ exog[t] + noise[t]
+    endog = endog.astype(floatX)
+
+    A = pt.tensor("A", dtype=floatX, shape=(k_endog, k_endog * order))
+    B = pt.tensor("B", dtype=floatX, shape=(k_endog, k_exog))
+    Q = pt.tensor("Q", dtype=floatX, shape=(k_endog, k_endog))
+    k_states = k_endog * order
+
+    fast = pm.logp(
+        StationaryVAR.dist(A, Q, exog=pt.as_tensor_variable(exog), exog_coefficients=B),
+        pt.as_tensor_variable(endog),
+    )
+
+    if order > 1:
+        shift = pt.concatenate(
+            [pt.eye(k_states - k_endog), pt.zeros((k_states - k_endog, k_endog))], axis=1
+        )
+        T_mat = pt.concatenate([A, shift], axis=0)
+    else:
+        T_mat = A
+    Z_mat = pt.concatenate([pt.eye(k_endog), pt.zeros((k_endog, k_states - k_endog))], axis=1)
+    R_mat = pt.concatenate([pt.eye(k_endog), pt.zeros((k_states - k_endog, k_endog))], axis=0)
+
+    *_, ll = StandardFilter(time_varying_names=["obs_intercept"], cov_jitter=0.0).build_graph(
+        pt.specify_shape(pt.as_tensor_variable(endog), (n_timesteps, k_endog)),
+        pt.zeros((k_states,)),
+        solve_discrete_lyapunov(T_mat, pt.linalg.matrix_dot(R_mat, Q, R_mat.T), method="bilinear"),
+        pt.zeros((k_states,)),
+        pt.as_tensor_variable(exog) @ B.T,
+        T_mat,
+        Z_mat,
+        R_mat,
+        pt.zeros((k_endog, k_endog)),
+        Q,
+    )
+
+    return fast, ll.sum(), [A, B, Q]
+
+
+@pytest.mark.parametrize(
+    "k_endog, order, k_exog",
+    [(1, 1, 0), (1, 3, 2), (2, 2, 0), (3, 2, 2)],
+    ids=["k1_p1_m0", "k1_p3_m2", "k2_p2_m0", "k3_p2_m2"],
+)
+def test_stationary_var_matches_kalman_filter(k_endog, order, k_exog):
+    rng = np.random.default_rng(sum(map(ord, f"draws{k_endog}{order}{k_exog}")))
+    fast, kalman, inputs = _var_logp_pair(k_endog, order, k_exog)
+    fn = pytensor.function(
+        inputs,
+        [fast, kalman, *pt.grad(fast, inputs), *pt.grad(kalman, inputs)],
+        on_unused_input="ignore",
+    )
+
+    for _ in range(3):
+        found_logp, expected_logp, dA, dB, dQ, edA, edB, edQ = fn(
+            *_var_parameters(rng, k_endog, order, k_exog)
+        )
+        assert_allclose(found_logp, expected_logp, atol=ATOL, rtol=RTOL)
+        assert_allclose(dA, edA, atol=ATOL, rtol=RTOL)
+        assert_allclose(dB, edB, atol=ATOL, rtol=RTOL)
+        # Only the symmetric part of a gradient wrt a symmetric matrix is meaningful.
+        assert_allclose(dQ + dQ.T, edQ + edQ.T, atol=ATOL, rtol=RTOL)
+
+
+def test_stationary_var_signature():
+    A = pt.tensor("A", dtype=floatX, shape=(2, 6))
+    Q = pt.tensor("Q", dtype=floatX, shape=(2, 2))
+
+    dist = StationaryVAR.dist(A, Q, steps=100)
+
+    assert dist.type.shape == (100, 2)
+    assert dist.owner.op.extended_signature == "(k,l),(k,m),(k,k),(t,m),[rng]->[rng],(t,k)"
+    assert dist.owner.op.ndim_supp == 2
+
+
+def test_stationary_var_draws_have_the_stationary_covariance():
+    rng = np.random.default_rng(90210)
+    A, _, Q = _var_parameters(rng, 2, 2, 0)
+    draw = pm.draw(StationaryVAR.dist(A, Q, steps=40000), random_seed=17)
+
+    companion = np.zeros((4, 4))
+    companion[:2] = A
+    companion[2:, :2] = np.eye(2)
+    noise = np.zeros((4, 4))
+    noise[:2, :2] = Q
+
+    expected = sp_solve_discrete_lyapunov(companion, noise)[:2, :2]
+    assert_allclose(np.cov(draw, rowvar=False), expected, rtol=0.05, atol=0.3)
+
+
+def test_stationary_var_logp_follows_the_observed_data():
+    rng = np.random.default_rng(511)
+    A, _, Q = _var_parameters(rng, 2, 2, 0)
+
+    with pm.Model() as model:
+        pm.Data("data", rng.normal(size=(30, 2)).astype(floatX))
+        StationaryVAR("obs", A, Q, steps=30, observed=model["data"])
+        before = model.compile_logp()({})
+        pm.set_data({"data": rng.normal(size=(30, 2)).astype(floatX)})
+
+        assert not np.isclose(before, model.compile_logp()({}))
+
+
+@pytest.mark.parametrize(
+    "kwargs, message",
+    [
+        ({"exog": np.zeros((10, 2))}, "both or neither"),
+        ({"steps": None}, "needs steps"),
+        ({"steps": 10}, "known statically"),
+    ],
+    ids=["exog_without_coefficients", "no_steps", "unshaped_coefficients"],
+)
+def test_stationary_var_rejects_inconsistent_arguments(kwargs, message):
+    A = pt.matrix("A") if message.startswith("known") else np.eye(2)
+
+    with pytest.raises(ValueError, match=message):
+        StationaryVAR.dist(A, np.eye(2), **kwargs)

--- a/tests/statespace/filters/test_distributions.py
+++ b/tests/statespace/filters/test_distributions.py
@@ -4,7 +4,7 @@ import pytensor
 import pytensor.tensor as pt
 import pytest
 
-from numpy.testing import assert_allclose
+from numpy.testing import assert_allclose, assert_array_less
 from pytensor.tensor.linalg import solve_discrete_lyapunov
 from scipy.linalg import solve_discrete_lyapunov as sp_solve_discrete_lyapunov
 from scipy.stats import multivariate_normal
@@ -17,6 +17,7 @@ from pymc_extras.statespace.filters.distributions import (
     StationaryVAR,
     _forward_simulate_latent_and_obs,
     _LinearGaussianStateSpace,
+    _predictive_moments,
 )
 from pymc_extras.statespace.filters.kalman_filter import StandardFilter
 from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
@@ -640,6 +641,35 @@ def _var_parameters(rng, k_endog, order, k_exog):
     return A.astype(floatX), rng.normal(size=(k_endog, k_exog)).astype(floatX), Q.astype(floatX)
 
 
+def _reference_filter(coefficients, state_cov, endog, exog, exog_coefficients):
+    """A Kalman filter over the companion form, built independently of the distribution."""
+    n_timesteps, k_endog = endog.shape
+    k_states = coefficients.type.shape[1]
+
+    transition = pt.concatenate(
+        [coefficients, pt.pad(pt.eye(k_states - k_endog), [(0, 0), (0, k_endog)])], axis=0
+    )
+    design = pt.concatenate([pt.eye(k_endog), pt.zeros((k_endog, k_states - k_endog))], axis=1)
+    selection = pt.concatenate([pt.eye(k_endog), pt.zeros((k_states - k_endog, k_endog))], axis=0)
+
+    return StandardFilter(time_varying_names=["obs_intercept"], cov_jitter=0.0).build_graph(
+        pt.specify_shape(pt.as_tensor_variable(endog), (n_timesteps, k_endog)),
+        pt.zeros((k_states,)),
+        solve_discrete_lyapunov(
+            transition,
+            pt.linalg.matrix_dot(selection, state_cov, selection.T),
+            method="bilinear",
+        ),
+        pt.zeros((k_states,)),
+        pt.as_tensor_variable(exog) @ exog_coefficients.T,
+        transition,
+        design,
+        selection,
+        pt.zeros((k_endog, k_endog)),
+        state_cov,
+    )
+
+
 def _var_logp_pair(k_endog, order, k_exog, n_timesteps=80):
     """The distribution's log-density and a Kalman filter over the same model.
 
@@ -663,32 +693,17 @@ def _var_logp_pair(k_endog, order, k_exog, n_timesteps=80):
     k_states = k_endog * order
 
     fast = pm.logp(
-        StationaryVAR.dist(A, Q, exog=pt.as_tensor_variable(exog), exog_coefficients=B),
+        StationaryVAR.dist(
+            A,
+            Q,
+            pt.as_tensor_variable(endog),
+            exog=pt.as_tensor_variable(exog),
+            exog_coefficients=B,
+        ),
         pt.as_tensor_variable(endog),
     )
 
-    if order > 1:
-        shift = pt.concatenate(
-            [pt.eye(k_states - k_endog), pt.zeros((k_states - k_endog, k_endog))], axis=1
-        )
-        T_mat = pt.concatenate([A, shift], axis=0)
-    else:
-        T_mat = A
-    Z_mat = pt.concatenate([pt.eye(k_endog), pt.zeros((k_endog, k_states - k_endog))], axis=1)
-    R_mat = pt.concatenate([pt.eye(k_endog), pt.zeros((k_states - k_endog, k_endog))], axis=0)
-
-    *_, ll = StandardFilter(time_varying_names=["obs_intercept"], cov_jitter=0.0).build_graph(
-        pt.specify_shape(pt.as_tensor_variable(endog), (n_timesteps, k_endog)),
-        pt.zeros((k_states,)),
-        solve_discrete_lyapunov(T_mat, pt.linalg.matrix_dot(R_mat, Q, R_mat.T), method="bilinear"),
-        pt.zeros((k_states,)),
-        pt.as_tensor_variable(exog) @ B.T,
-        T_mat,
-        Z_mat,
-        R_mat,
-        pt.zeros((k_endog, k_endog)),
-        Q,
-    )
+    *_, ll = _reference_filter(A, Q, endog, exog, B)
 
     return fast, ll.sum(), [A, B, Q]
 
@@ -721,27 +736,87 @@ def test_stationary_var_matches_kalman_filter(k_endog, order, k_exog):
 def test_stationary_var_signature():
     A = pt.tensor("A", dtype=floatX, shape=(2, 6))
     Q = pt.tensor("Q", dtype=floatX, shape=(2, 2))
+    endog = pt.tensor("endog", dtype=floatX, shape=(100, 2))
 
-    dist = StationaryVAR.dist(A, Q, steps=100)
+    dist = StationaryVAR.dist(A, Q, endog)
 
     assert dist.type.shape == (100, 2)
-    assert dist.owner.op.extended_signature == "(k,l),(k,m),(k,k),(t,m),[rng]->[rng],(t,k)"
+    assert dist.owner.op.extended_signature == "(k,l),(k,m),(k,k),(t,m),(t,k),[rng]->[rng],(t,k)"
     assert dist.owner.op.ndim_supp == 2
 
 
-def test_stationary_var_draws_have_the_stationary_covariance():
-    rng = np.random.default_rng(90210)
-    A, _, Q = _var_parameters(rng, 2, 2, 0)
-    draw = pm.draw(StationaryVAR.dist(A, Q, steps=40000), random_seed=17)
+def test_stationary_var_predictive_moments_match_the_filter(rng):
+    """
+    Draws come from the one-step-ahead predictive distributions, which are the filter's.
 
-    companion = np.zeros((4, 4))
-    companion[:2] = A
-    companion[2:, :2] = np.eye(2)
-    noise = np.zeros((4, 4))
-    noise[:2, :2] = Q
+    The first ``order`` rows are the ones worth checking. Their moments come from the Cholesky
+    factor of the stationary covariance rather than from the regression.
+    """
+    k_endog, order, n_timesteps = 2, 2, 40
+    coefficients, _, state_cov = _var_parameters(rng, k_endog, order, 0)
+    endog = rng.normal(size=(n_timesteps, k_endog)).astype(floatX)
 
-    expected = sp_solve_discrete_lyapunov(companion, noise)[:2, :2]
-    assert_allclose(np.cov(draw, rowvar=False), expected, rtol=0.05, atol=0.3)
+    means, covariances = _predictive_moments(
+        pt.as_tensor_variable(coefficients),
+        pt.zeros((k_endog, 0)),
+        pt.as_tensor_variable(state_cov),
+        pt.zeros((n_timesteps, 0)),
+        pt.as_tensor_variable(endog),
+        order=order,
+        k_endog=k_endog,
+    )
+    _, _, filter_means, _, _, filter_covariances, _ = _reference_filter(
+        pt.as_tensor_variable(coefficients),
+        pt.as_tensor_variable(state_cov),
+        endog,
+        np.zeros((n_timesteps, 0), dtype=floatX),
+        pt.zeros((k_endog, 0)),
+    )
+
+    found_means, found_covariances, expected_means, expected_covariances = pytensor.function(
+        [], [means, covariances, filter_means, filter_covariances]
+    )()
+
+    assert_allclose(found_means, expected_means, atol=ATOL, rtol=RTOL)
+    assert_allclose(found_covariances, expected_covariances, atol=ATOL, rtol=RTOL)
+
+
+def test_stationary_var_draws_come_from_the_predictive_moments(rng):
+    """
+    The sampling path uses the same moments the density does.
+
+    ``_predictive_moments`` can be right while ``rv_op`` wires it up wrong, and a test that calls
+    the helper directly would not notice.
+    """
+    k_endog, order, n_timesteps, n_draws = 2, 2, 12, 4000
+    coefficients, _, state_cov = _var_parameters(rng, k_endog, order, 0)
+    endog = rng.normal(size=(n_timesteps, k_endog)).astype(floatX)
+
+    draws = pm.draw(
+        StationaryVAR.dist(coefficients, state_cov, endog), draws=n_draws, random_seed=13
+    )
+    means, covariances = (
+        x.eval()
+        for x in _predictive_moments(
+            pt.as_tensor_variable(coefficients),
+            pt.zeros((k_endog, 0)),
+            pt.as_tensor_variable(state_cov),
+            pt.zeros((n_timesteps, 0)),
+            pt.as_tensor_variable(endog),
+            order=order,
+            k_endog=k_endog,
+        )
+    )
+
+    assert draws.shape == (n_draws, n_timesteps, k_endog)
+
+    standard_error = np.sqrt(np.diagonal(covariances, axis1=1, axis2=2) / n_draws)
+    assert_array_less(np.abs(draws.mean(0) - means), 5 * standard_error)
+
+    # Per timestep, not pooled. The first ``order`` rows are the only ones whose covariance
+    # differs from the innovation covariance, so pooling hides an error confined to them.
+    empirical = np.stack([np.cov(draws[:, t], rowvar=False) for t in range(n_timesteps)])
+    assert_allclose(empirical, covariances, atol=0.1 * np.abs(covariances).max())
 
 
 def test_stationary_var_logp_follows_the_observed_data():
@@ -750,7 +825,7 @@ def test_stationary_var_logp_follows_the_observed_data():
 
     with pm.Model() as model:
         pm.Data("data", rng.normal(size=(30, 2)).astype(floatX))
-        StationaryVAR("obs", A, Q, steps=30, observed=model["data"])
+        StationaryVAR("obs", A, Q, model["data"], observed=model["data"])
         before = model.compile_logp()({})
         pm.set_data({"data": rng.normal(size=(30, 2)).astype(floatX)})
 
@@ -758,16 +833,13 @@ def test_stationary_var_logp_follows_the_observed_data():
 
 
 @pytest.mark.parametrize(
-    "kwargs, message",
+    "coefficients, kwargs, message",
     [
-        ({"exog": np.zeros((10, 2))}, "both or neither"),
-        ({"steps": None}, "needs steps"),
-        ({"steps": 10}, "known statically"),
+        (np.eye(2), {"exog": np.zeros((10, 2))}, "both or neither"),
+        (pt.matrix("A"), {}, "known statically"),
     ],
-    ids=["exog_without_coefficients", "no_steps", "unshaped_coefficients"],
+    ids=["exog_without_coefficients", "unshaped_coefficients"],
 )
-def test_stationary_var_rejects_inconsistent_arguments(kwargs, message):
-    A = pt.matrix("A") if message.startswith("known") else np.eye(2)
-
+def test_stationary_var_rejects_inconsistent_arguments(coefficients, kwargs, message):
     with pytest.raises(ValueError, match=message):
-        StationaryVAR.dist(A, np.eye(2), **kwargs)
+        StationaryVAR.dist(coefficients, np.eye(2), np.zeros((10, 2)), **kwargs)

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -545,9 +545,9 @@ def test_sarimax_workflow(mock_sample):
         "interpretable",
     ],
 )
-def test_likelihood_dispatch(kwargs, expected_op, rng):
+def test_likelihood_dispatch(kwargs, expected_op):
     mod = BayesianSARIMAX(verbose=False, **kwargs)
-    pymc_model = build_model_with_flat_priors(mod, rng.normal(size=(40, 1)).astype(floatX))
+    pymc_model = build_model_with_flat_priors(mod, np.zeros((40, 1), dtype=floatX))
 
     assert isinstance(pymc_model["obs"].owner.op, expected_op)
 
@@ -572,8 +572,9 @@ def test_closed_form_likelihood_matches_the_kalman_filter(kwargs, params, rng):
     mod = BayesianSARIMAX(verbose=False, **kwargs)
     data = rng.normal(size=(60, 1)).astype(floatX)
 
-    built, kalman = compare_likelihood_to_filter(mod, params, data)
+    pymc_model, built, kalman = compare_likelihood_to_filter(mod, params, data)
 
+    assert isinstance(pymc_model["obs"].owner.op, StationaryVARRV)
     assert_allclose(built, kalman, atol=1e-8)
 
 
@@ -591,12 +592,11 @@ def test_missing_data_falls_back_to_the_filter(rng):
     data = rng.normal(size=(60, 1)).astype(floatX)
     data[20:23] = np.nan
 
-    pymc_model = build_model_with_flat_priors(mod, data)
-    assert isinstance(pymc_model["obs"].owner.op, KalmanFilterRV)
-
-    built, kalman = compare_likelihood_to_filter(
+    pymc_model, built, kalman = compare_likelihood_to_filter(
         mod, {"ar_params": [0.5, -0.2], "sigma_state": 1.3}, data
     )
+
+    assert isinstance(pymc_model["obs"].owner.op, KalmanFilterRV)
     assert_allclose(built, kalman, atol=1e-8)
 
 

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -598,3 +598,18 @@ def test_missing_data_falls_back_to_the_filter(rng):
         mod, {"ar_params": [0.5, -0.2], "sigma_state": 1.3}, data
     )
     assert_allclose(built, kalman, atol=1e-8)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Provided data contains missing values:pymc.exceptions.ImputationWarning"
+)
+def test_rebuilding_with_missing_data_raises(rng):
+    """Re-entry repoints the graph without rebuilding, so it cannot change which likelihood runs."""
+    mod = BayesianSARIMAX(order=(2, 0, 0), verbose=False)
+    gappy = rng.normal(size=(60, 1)).astype(floatX)
+    gappy[20:23] = np.nan
+
+    pymc_model = build_model_with_flat_priors(mod, rng.normal(size=(60, 1)).astype(floatX))
+
+    with pymc_model, pytest.raises(ValueError, match="cannot marginalize"):
+        mod.build_statespace_graph(gappy)

--- a/tests/statespace/models/test_SARIMAX.py
+++ b/tests/statespace/models/test_SARIMAX.py
@@ -13,6 +13,7 @@ from pymc.testing import mock_sample_setup_and_teardown
 
 from pymc_extras.statespace import BayesianSARIMAX
 from pymc_extras.statespace.core.fit_recovery import exog_from_idata
+from pymc_extras.statespace.filters.distributions import KalmanFilterRV, StationaryVARRV
 from pymc_extras.statespace.models.utilities import (
     make_harvey_state_names,
     make_SARIMA_transition_matrix,
@@ -25,6 +26,8 @@ from tests.statespace.shared_fixtures import (  # pylint: disable=unused-import
     rng,
 )
 from tests.statespace.test_utilities import (
+    build_model_with_flat_priors,
+    compare_likelihood_to_filter,
     load_nile_test_data,
     make_stationary_params,
     simulate_from_numpy_model,
@@ -517,3 +520,81 @@ def test_sarimax_workflow(mock_sample):
     irf = ss_mod.impulse_response_function(idata, n_steps=10, random_seed=42)
     assert "irf" in irf
     assert np.isfinite(irf.irf.values).all()
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_op",
+    [
+        ({"order": (2, 0, 0)}, StationaryVARRV),
+        ({"order": (1, 0, 0), "seasonal_order": (1, 0, 0, 4)}, StationaryVARRV),
+        ({"order": (2, 0, 1)}, KalmanFilterRV),
+        ({"order": (2, 0, 0), "seasonal_order": (0, 0, 1, 4)}, KalmanFilterRV),
+        ({"order": (2, 0, 0), "measurement_error": True}, KalmanFilterRV),
+        ({"order": (2, 0, 0), "stationary_initialization": False}, KalmanFilterRV),
+        ({"order": (0, 0, 0)}, KalmanFilterRV),
+        ({"order": (2, 0, 0), "state_structure": "interpretable"}, KalmanFilterRV),
+    ],
+    ids=[
+        "ar",
+        "seasonal_ar",
+        "ma",
+        "seasonal_ma",
+        "measurement_error",
+        "no_stationary_init",
+        "no_ar",
+        "interpretable",
+    ],
+)
+def test_likelihood_dispatch(kwargs, expected_op, rng):
+    mod = BayesianSARIMAX(verbose=False, **kwargs)
+    pymc_model = build_model_with_flat_priors(mod, rng.normal(size=(40, 1)).astype(floatX))
+
+    assert isinstance(pymc_model["obs"].owner.op, expected_op)
+
+
+@pytest.mark.parametrize(
+    "kwargs, params",
+    [
+        ({"order": (2, 0, 0)}, {"ar_params": [0.5, -0.2], "sigma_state": 1.3}),
+        (
+            {"order": (1, 0, 0), "seasonal_order": (1, 0, 0, 4)},
+            {"ar_params": [0.4], "seasonal_ar_params": [0.5], "sigma_state": 0.8},
+        ),
+    ],
+    ids=["ar2", "seasonal"],
+)
+def test_closed_form_likelihood_matches_the_kalman_filter(kwargs, params, rng):
+    """
+    The filter takes the stationary covariance of the Harvey state, whose entries are partial
+    sums rather than lags, while the closed form takes it of the lag stack. Agreeing here is
+    what says those describe the same distribution over the observations.
+    """
+    mod = BayesianSARIMAX(verbose=False, **kwargs)
+    data = rng.normal(size=(60, 1)).astype(floatX)
+
+    built, kalman = compare_likelihood_to_filter(mod, params, data)
+
+    assert_allclose(built, kalman, atol=1e-8)
+
+
+@pytest.mark.filterwarnings(
+    "ignore:Provided data contains missing values:pymc.exceptions.ImputationWarning"
+)
+def test_missing_data_falls_back_to_the_filter(rng):
+    """
+    Only the filter marginalizes missing observations.
+
+    The closed form would score the fill sentinel as if it were an observation, which is finite,
+    smooth, and wrong by seven orders of magnitude.
+    """
+    mod = BayesianSARIMAX(order=(2, 0, 0), verbose=False)
+    data = rng.normal(size=(60, 1)).astype(floatX)
+    data[20:23] = np.nan
+
+    pymc_model = build_model_with_flat_priors(mod, data)
+    assert isinstance(pymc_model["obs"].owner.op, KalmanFilterRV)
+
+    built, kalman = compare_likelihood_to_filter(
+        mod, {"ar_params": [0.5, -0.2], "sigma_state": 1.3}, data
+    )
+    assert_allclose(built, kalman, atol=1e-8)

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -787,6 +787,22 @@ class TestVARMAXWithExogenous:
     "kwargs, expected_op",
     [
         ({"order": (2, 0), "stationary_initialization": True}, StationaryVARRV),
+        (
+            {
+                "order": (2, 0),
+                "stationary_initialization": True,
+                "exog_state_names": ["x1", "x2"],
+            },
+            StationaryVARRV,
+        ),
+        (
+            {
+                "order": (2, 0),
+                "stationary_initialization": True,
+                "exog_state_names": {"a": ["x1", "x2"], "b": ["x3"]},
+            },
+            StationaryVARRV,
+        ),
         ({"order": (2, 1), "stationary_initialization": True}, KalmanFilterRV),
         (
             {"order": (2, 0), "stationary_initialization": True, "measurement_error": True},
@@ -795,11 +811,25 @@ class TestVARMAXWithExogenous:
         ({"order": (2, 0)}, KalmanFilterRV),
         ({"order": (0, 1), "stationary_initialization": True}, KalmanFilterRV),
     ],
-    ids=["ar", "ma", "measurement_error", "no_stationary_init", "no_ar"],
+    ids=[
+        "ar",
+        "ar_shared_exog",
+        "ar_per_series_exog",
+        "ma",
+        "measurement_error",
+        "no_stationary_init",
+        "no_ar",
+    ],
 )
 def test_likelihood_dispatch(kwargs, expected_op, rng):
     mod = BayesianVARMAX(endog_names=["a", "b"], verbose=False, **kwargs)
-    pymc_model = build_model_with_flat_priors(mod, rng.normal(size=(40, 2)).astype(floatX))
+    data_dict = {
+        name: rng.normal(size=(40, mod.data_info[name]["shape"][-1])).astype(floatX)
+        for name in mod.data_names
+    }
+    pymc_model = build_model_with_flat_priors(
+        mod, np.zeros((40, 2), dtype=floatX), data_dict or None
+    )
 
     assert isinstance(pymc_model["obs"].owner.op, expected_op)
 
@@ -832,6 +862,7 @@ def test_closed_form_likelihood_matches_the_kalman_filter(exog_state_names, rng)
         if name.startswith("beta"):
             params[name] = rng.normal(size=mod.param_info[name]["shape"])
 
-    built, kalman = compare_likelihood_to_filter(mod, params, data, data_dict or None)
+    pymc_model, built, kalman = compare_likelihood_to_filter(mod, params, data, data_dict or None)
 
+    assert isinstance(pymc_model["obs"].owner.op, StationaryVARRV)
     assert_allclose(built, kalman, atol=1e-8)

--- a/tests/statespace/models/test_VARMAX.py
+++ b/tests/statespace/models/test_VARMAX.py
@@ -14,9 +14,14 @@ from pymc.testing import mock_sample_setup_and_teardown
 
 from pymc_extras.statespace import BayesianVARMAX
 from pymc_extras.statespace.core.irf import DEFAULT_IRF_STEPS
+from pymc_extras.statespace.filters.distributions import KalmanFilterRV, StationaryVARRV
 from pymc_extras.statespace.utils.constants import SHORT_NAME_TO_LONG
 from tests.statespace.shared_fixtures import (  # pylint: disable=unused-import
     rng,
+)
+from tests.statespace.test_utilities import (
+    build_model_with_flat_priors,
+    compare_likelihood_to_filter,
 )
 
 mock_sample = pytest.fixture(scope="function")(mock_sample_setup_and_teardown)
@@ -776,3 +781,57 @@ class TestVARMAXWithExogenous:
 
         assert np.isfinite(forecast.forecast_latent.values).all()
         assert np.isfinite(forecast.forecast_observed.values).all()
+
+
+@pytest.mark.parametrize(
+    "kwargs, expected_op",
+    [
+        ({"order": (2, 0), "stationary_initialization": True}, StationaryVARRV),
+        ({"order": (2, 1), "stationary_initialization": True}, KalmanFilterRV),
+        (
+            {"order": (2, 0), "stationary_initialization": True, "measurement_error": True},
+            KalmanFilterRV,
+        ),
+        ({"order": (2, 0)}, KalmanFilterRV),
+        ({"order": (0, 1), "stationary_initialization": True}, KalmanFilterRV),
+    ],
+    ids=["ar", "ma", "measurement_error", "no_stationary_init", "no_ar"],
+)
+def test_likelihood_dispatch(kwargs, expected_op, rng):
+    mod = BayesianVARMAX(endog_names=["a", "b"], verbose=False, **kwargs)
+    pymc_model = build_model_with_flat_priors(mod, rng.normal(size=(40, 2)).astype(floatX))
+
+    assert isinstance(pymc_model["obs"].owner.op, expected_op)
+
+
+@pytest.mark.parametrize(
+    "exog_state_names",
+    [None, ["x1", "x2"], {"a": ["x1", "x2"], "b": ["x3"]}, {"a": ["x1"]}],
+    ids=["no_exog", "shared", "per_series", "one_series_only"],
+)
+def test_closed_form_likelihood_matches_the_kalman_filter(exog_state_names, rng):
+    """
+    The dict form joins per-series regressions into the observation intercept; the closed form
+    writes the same thing as one product against a block coefficient matrix.
+    """
+    mod = BayesianVARMAX(
+        order=(2, 0),
+        endog_names=["a", "b"],
+        exog_state_names=exog_state_names,
+        stationary_initialization=True,
+        verbose=False,
+    )
+    data = rng.normal(size=(60, 2)).astype(floatX)
+
+    params = {"ar_params": rng.normal(size=(2, 2, 2)) * 0.2, "state_cov": np.eye(2)}
+    data_dict = {
+        name: rng.normal(size=(60, mod.data_info[name]["shape"][-1])).astype(floatX)
+        for name in mod.data_names
+    }
+    for name in mod.param_names:
+        if name.startswith("beta"):
+            params[name] = rng.normal(size=mod.param_info[name]["shape"])
+
+    built, kalman = compare_likelihood_to_filter(mod, params, data, data_dict or None)
+
+    assert_allclose(built, kalman, atol=1e-8)

--- a/tests/statespace/test_utilities.py
+++ b/tests/statespace/test_utilities.py
@@ -289,7 +289,11 @@ def build_model_with_flat_priors(mod, data, data_dict=None):
 
 
 def compare_likelihood_to_filter(mod, param_dict, data, data_dict=None):
-    """Return the log-density a model builds and its Kalman filter's, at the same values."""
+    """Return the built model, the log-density it builds, and its filter's, at the same values.
+
+    The model comes back so a caller can assert which likelihood was dispatched. Without that the
+    comparison passes vacuously whenever the model falls back, because both sides are the filter.
+    """
     pymc_model = build_model_with_flat_priors(mod, data, data_dict)
     point = {name: np.asarray(param_dict[name], dtype=floatX) for name in mod.param_info}
     built = pymc_model.compile_logp()(point)
@@ -304,7 +308,7 @@ def compare_likelihood_to_filter(mod, param_dict, data, data_dict=None):
         *[pt.as_tensor_variable(m) for m in (x0, P0, c, d, T, Z, R, H, Q)],
     )
 
-    return built, ll.sum().eval()
+    return pymc_model, built, ll.sum().eval()
 
 
 def simulate_from_numpy_model(mod, rng, param_dict, data_dict=None, steps=100):

--- a/tests/statespace/test_utilities.py
+++ b/tests/statespace/test_utilities.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import numpy as np
 import pandas as pd
+import pymc as pm
 import pytensor
 import pytensor.tensor as pt
 import statsmodels.api as sm
@@ -19,6 +20,7 @@ from pytensor.graph.replace import graph_replace
 from pytensor.graph.traversal import explicit_graph_inputs
 
 from pymc_extras.statespace.core.statespace import PyMCStateSpace
+from pymc_extras.statespace.filters import StandardFilter
 from pymc_extras.statespace.filters.kalman_smoother import KalmanSmoother
 from pymc_extras.statespace.utils.constants import (
     MATRIX_NAMES,
@@ -272,6 +274,37 @@ def unpack_symbolic_matrices_with_params(
     x0, P0, c, d, T, Z, R, H, Q = f_matrices(**param_dict, **data_dict)
 
     return x0, P0, c, d, T, Z, R, H, Q
+
+
+def build_model_with_flat_priors(mod, data, data_dict=None):
+    """Build ``mod`` into a model whose parameters are flat, so its logp is the likelihood."""
+    with pm.Model() as pymc_model:
+        for name, value in (data_dict or {}).items():
+            pm.Data(name, value)
+        for name, info in mod.param_info.items():
+            pm.Flat(name, shape=info["shape"])
+        mod.build_statespace_graph(data)
+
+    return pymc_model
+
+
+def compare_likelihood_to_filter(mod, param_dict, data, data_dict=None):
+    """Return the log-density a model builds and its Kalman filter's, at the same values."""
+    pymc_model = build_model_with_flat_priors(mod, data, data_dict)
+    point = {name: np.asarray(param_dict[name], dtype=floatX) for name in mod.param_info}
+    built = pymc_model.compile_logp()(point)
+
+    x0, P0, c, d, T, Z, R, H, Q = unpack_symbolic_matrices_with_params(
+        mod, param_dict, steps=len(data), data_dict=data_dict
+    )
+    *_, ll = StandardFilter(
+        time_varying_names=mod.ssm.time_varying_names, cov_jitter=0.0
+    ).build_graph(
+        pt.specify_shape(pt.as_tensor_variable(data), data.shape),
+        *[pt.as_tensor_variable(m) for m in (x0, P0, c, d, T, Z, R, H, Q)],
+    )
+
+    return built, ll.sum().eval()
 
 
 def simulate_from_numpy_model(mod, rng, param_dict, data_dict=None, steps=100):


### PR DESCRIPTION
`BayesianVARMAX` and `BayesianSARIMAX` now evaluate their observation likelihood in closed form when the model allows it, instead of running a Kalman filter. A stationary VAR with no measurement error and no moving-average terms has a banded joint precision matrix, so its density collapses onto cross-products of the data against its own lags. It returns the same number the filter does. It also doesn't work if there is missing data.

`PyMCStateSpace.make_likelihood` is the new hook, and its base implementation is the Kalman filter that `build_statespace_graph` used to register inline. A model with a closed form overrides it and calls `super()` for the configurations it doesn't cover. `StationaryVAR` in `filters/distributions.py` is a PyMC distribution.

Here are benchmarks. It's good to do it this way where possible. The ones that don't specify T set `T=1000`.

```
-------------------------------------------------------- benchmark: 10 tests -----------------------------------------------
Name (time in us)                                Min                 Median                StdDev            Rounds  Speedup
----------------------------------------------------------------------------------------------------------------------------
test_likelihood[T=1000-grad-closed]          46.7499 (2.30)         51.4790 (2.36)         8.8174 (1.09)         18     206x
test_likelihood[T=1000-grad-filter]      10,068.0001 (495.16)   10,580.6874 (484.62)     305.0970 (37.58)        14
test_likelihood[T=200-grad-closed]           46.0000 (2.26)         47.7710 (2.19)        13.5600 (1.67)         12      45x
test_likelihood[T=200-grad-filter]        1,966.3749 (96.71)     2,134.2500 (97.75)      127.7059 (15.73)         5
test_likelihood[T=5000-grad-closed]          47.0830 (2.32)         49.8750 (2.28)         8.1184 (1.0)          15   1,036x
test_likelihood[T=5000-grad-filter]      51,075.2500 (>1000.0)  51,657.1670 (>1000.0)    602.1856 (74.18)         5
test_likelihood[k=1,p=2-grad-closed]         20.3330 (1.0)          21.8330 (1.0)         10.1648 (1.25)         15     204x
test_likelihood[k=1,p=2-grad-filter]      4,192.5840 (206.20)    4,445.2290 (203.60)     181.9588 (22.41)        14
test_likelihood[k=5,p=4-grad-closed]        275.8340 (13.57)       286.8751 (13.14)       13.0780 (1.61)         16     100x
test_likelihood[k=5,p=4-grad-filter]     26,723.9170 (>1000.0)  28,655.4999 (>1000.0)  5,426.6118 (668.44)        5
----------------------------------------------------------------------------------------------------------------------------
```

~~Posterior-predictive draws of `obs` change meaning on the closed-form path. The filter draws from data-conditioned one-step-ahead predictives and `StationaryVAR` draws an unconditional realization of the process. Densities are identical and `forecast`, `sample_conditional_posterior` and `sample_unconditional_posterior` all rebuild through `_build_dummy_graph`, so only a direct `pm.sample_posterior_predictive` on `obs` sees the difference. That's not the blessed path so I'm not stressing it, but it sucks. It could potentially be fixed by changing `rv_op`. I'm not sure yet.~~

I fixed this so everything is consistent.